### PR TITLE
Fix ThreeLineRightIconList*i*tem typo

### DIFF
--- a/kivymd/list.py
+++ b/kivymd/list.py
@@ -542,7 +542,7 @@ class TwoLineRightIconListItem(OneLineRightIconListItem):
         self.height = dp(72)
 
 
-class ThreeLineRightIconListitem(ContainerSupport, ThreeLineListItem):
+class ThreeLineRightIconListItem(ContainerSupport, ThreeLineListItem):
     # dp(40) = dp(16) + dp(24):
     _txt_right_pad = NumericProperty(dp(40) + m_res.HORIZ_MARGINS)
 


### PR DESCRIPTION
PR is still actual and works, tested on latest master.

Backporting [from gitlab](https://gitlab.com/kivymd/KivyMD/merge_requests/49)