### PR TITLE
Fixed the bug with toast

### DIFF
--- a/kivymd/toast/androidtoast/androidtoast.py
+++ b/kivymd/toast/androidtoast/androidtoast.py
@@ -17,7 +17,7 @@ from android import activity
 from android.runnable import run_on_ui_thread
 
 Toast = autoclass('android.widget.Toast')
-context = autoclass('org.renpy.android.PythonActivity').mActivity    
+context = autoclass('org.kivy.android.PythonActivity').mActivity    
 
 @run_on_ui_thread
 def toast(text, length_long=False):


### PR DESCRIPTION
org.renpy.android.PythonActivity does not work due to the error:

> W PythonActivity: Accessing org.renpy.android.PythonActivity is deprecated and will be removed in a future version. Please switch to org.kivy.android.PythonActivity.
> F art     : art/runtime/java_vm_ext.cc:410] JNI DETECTED ERROR IN APPLICATION: static jfieldID 0xb4766278 not valid for class java.lang.Class<org.renpy.android.PythonActivity>

Switching to org.kivy.android.PythonActivity works propertly.
Tested on
> API 27
> NDK r17c
> Android 8.1.0