### PR TITLE
MDAccordionListItem improvements.

### DIFF
--- a/kivymd/accordionlistitem.py
+++ b/kivymd/accordionlistitem.py
@@ -210,6 +210,7 @@ class MDAccordionListItem(BoxLayout):
     content = ObjectProperty()
     icon = StringProperty()
     title = StringProperty()
+    canAnim = True
 
     def check_open_box(self, instance):
         press_current_item = False
@@ -241,12 +242,15 @@ class MDAccordionListItem(BoxLayout):
         Animation(height=dp(68), d=.1, t='in_cubic').start(box)
 
     def anim_resize_open_item(self, *args):
-        self.content.name_item = self.title
-        anim = Animation(height=self.content.height + dp(70),
-                         d=.2, t='in_cubic')
-        anim.bind(on_complete=self.add_content)
-        anim.start(self)
+        if self.canAnim:
+            self.canAnim = False
+            self.content.name_item = self.title
+            anim = Animation(height=self.content.height + dp(70),
+                             d=.2, t='in_cubic')
+            anim.bind(on_complete=self.add_content)
+            anim.start(self)
 
     def add_content(self, *args):
+        self.canAnim = True
         if self.content:
             self.ids.box_item.add_widget(self.content)

--- a/kivymd/accordionlistitem.py
+++ b/kivymd/accordionlistitem.py
@@ -178,11 +178,11 @@ Builder.load_string('''
     size_hint_y: None
     height: dp(68)
 
-    BoxLayout:
+    StackLayout:
         id: box_item
         size_hint_y: None
         height: root.height
-        orientation: 'vertical'
+        orientation: 'lr-tb'
 
         AccordionListItem:
             id: item_anim


### PR DESCRIPTION
1. When you click on accordionlistitem with unfinished animation, it throw exception. Here is the fix.
2. Changed `BoxLayout` to `StackLayout` for more smooth animation.
But, unfortunately, the second commit causes a new bug, a solution for which I haven't found yet. The bug is that the title starts shaking when you click on the widget.