### PR TITLE
Declare encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import re
 from distutils.core import setup
 


### PR DESCRIPTION
Fixing:

```
  File "./setup.py", line 19                                                                                                                           
SyntaxError: Non-ASCII character '\xc3' in file ./setup.py on line 19, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details 
```