### PR TITLE
Adding parameter to set non active button color

### DIFF
--- a/kivymd/managerswiper.py
+++ b/kivymd/managerswiper.py
@@ -232,10 +232,12 @@ class MDSwiperPagination(ThemableBehavior, BoxLayout):
     screens = ListProperty()
     items_round_paginator = []
     manager = ObjectProperty()
+    color_round_not_active = ListProperty([1, 1, 1, 1])
 
     def on_screens(self, instance, screen_names):
         for i, screen_name in enumerate(screen_names):
             item_paginator = ItemPagination(current_index=i)
+            item_paginator.color_round_not_active = self.color_round_not_active
             self.ids.box.add_widget(item_paginator)
             self.items_round_paginator.append(item_paginator)
 


### PR DESCRIPTION
When adding a swipe manager to a white background all the rectangles disappear because they are hard coded to white.  Adding a parameter to set the non active rectangles so they can be adjusted for background colors.  This allows users to set the color like this 

```
        Builder.load_string(activity)
        start_screen = MySwiperManager(util=self.util)
        self.swiper_manager = start_screen.ids.swiper_manager
        paginator = MDSwiperPagination()
        paginator.color_round_not_active = [0, 0, 0, .2] # <- Color can be set here now
        paginator.screens = self.swiper_manager.screen_names
        paginator.manager = self.swiper_manager
        self.swiper_manager.paginator = paginator
        start_screen.add_widget(paginator)

        return start_screen
```