### PR TITLE
Icon for menu

### DIFF
--- a/kivymd/icon_definitions.py
+++ b/kivymd/icon_definitions.py
@@ -22,6 +22,7 @@ LAST UPDATED: Version 4.3.95
 __all__ = ("md_icons",)
 
 md_icons = {
+    "null-icon": "",
     "ab-testing": "\U000F001C",
     "access-point": "\uF002",
     "access-point-network": "\uF003",

--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -56,7 +56,8 @@ Builder.load_string(
         id: item_icon
         icon: root.icon if root.icon else 'null-icon'
         size_hint_x: None
-        width: self.texture_size[0] if root.icon else 0
+        # width: (self.texture_size[0] ) if root.icon else 0
+        width: self.font_size * 1.5 if root.icon else 0
         halign: 'left'
         
     MDLabel:

--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -52,15 +52,21 @@ Builder.load_string(
         root.parent.parent.parent.parent.dismiss()
         root.callback(root.text)
 
-    Label:
+    MDIcon:
+        id: item_icon
+        icon: root.icon if root.icon else 'null-icon'
+        size_hint_x: None
+        width: self.texture_size[0] if root.icon else 0
+        halign: 'left'
+        
+    MDLabel:
         id: item_text
         text: root.text
         markup: True
         font_size: '14sp'
-        size_hint_x: None
-        width: self.texture_size[0]
+        size_hint_x: 1
+        size_hint_y: 1
         halign: 'left'
-
 
 <MDMenu>
     size_hint: None, None
@@ -115,6 +121,7 @@ Builder.load_string(
 
 class MDMenuItem(RecycleDataViewBehavior, ButtonBehavior, BoxLayout):
     text = StringProperty()
+    icon = StringProperty('')
 
 
 class MDMenu(RecycleView):

--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -45,8 +45,9 @@ Builder.load_string(
 
 <MDMenuItem>
     size_hint: None, None
-    height: dp(48)
-    padding: dp(16), 0
+    height: dp(48)  # Spec
+    spacing: dp(20) if root.icon else 0  # Spec
+    padding: dp(16), 0  # Spec
     # Horrible, but hey it works.
     on_release:
         root.parent.parent.parent.parent.dismiss()
@@ -56,17 +57,14 @@ Builder.load_string(
         id: item_icon
         icon: root.icon if root.icon else 'null-icon'
         size_hint_x: None
-        # width: (self.texture_size[0] ) if root.icon else 0
-        width: self.font_size * 1.5 if root.icon else 0
-        halign: 'left'
-        
+        width: self.texture_size[0] if root.icon else 0
+        valign: 'middle'
+        halign: 'center'
+
     MDLabel:
         id: item_text
         text: root.text
         markup: True
-        font_size: '14sp'
-        size_hint_x: 1
-        size_hint_y: 1
         halign: 'left'
 
 <MDMenu>
@@ -122,7 +120,7 @@ Builder.load_string(
 
 class MDMenuItem(RecycleDataViewBehavior, ButtonBehavior, BoxLayout):
     text = StringProperty()
-    icon = StringProperty('')
+    icon = StringProperty("")
 
 
 class MDMenu(RecycleView):


### PR DESCRIPTION
### Description of Changes

- Add an icon property to MDMenuItem.
- Use MDLabel instead of Label, so the font color is correctly set by KivyMD's palette

### Examples

Using of the `icon` property

```python
       menu_items = [
            dict(
                viewclass='MDMenuItem',
                icon='file-document',
                text=self.text_show_properties,
                callback=lambda *a:self.show_props()
            ),
            dict(
                viewclass='MDMenuItem',
                icon='share-variant',
                text=self.text_share,
                callback=lambda *a: self.on_share()
            )
        ]

        context_menu = MDDropdownMenu(
            items=menu_items,
            max_height=dp(260), width_mult=4)

        context_menu.open(self)
```


