### PR TITLE
Stack Floating Buttons: Label background color fix

### DIFF
--- a/kivymd/uix/stackfloatingbutton.py
+++ b/kivymd/uix/stackfloatingbutton.py
@@ -74,6 +74,7 @@ from kivy.properties import (
     ListProperty,
 )
 from kivy.metrics import dp
+from kivy.app import App
 
 from kivymd.uix.card import MDCard
 
@@ -149,6 +150,10 @@ Builder.load_string(
 class MDFloatingLabel(MDCard):
     text = StringProperty()
     text_color = ListProperty([0, 0, 0, 1])
+
+    def on_md_bg_color(self, instance, value):
+        app = App.get_running_app()
+        self.md_bg_color = app.theme_cls.primary_color    
 
 
 class MDStackFloatingButtons(FloatLayout):


### PR DESCRIPTION
Fix for an issue where the md_bg_color of floating labels for Stack Floating Buttons are not consistent when theme_style is toggled between 'Dark' and 'Light'.
