### PR TITLE
text_validate_unfocus should be True by default.

### DIFF
--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -433,6 +433,7 @@ Builder.load_string(
             font_size: sp(root.font_size)
             allow_copy: root.allow_copy
             text_validate_unfocus: root.text_validate_unfocus
+            focus: root.focus
             on_focus: root._on_focus(self)
             on_text:
                 root.text = self.text
@@ -1026,9 +1027,9 @@ class MDTextFieldRound(ThemableBehavior, BoxLayout):
     """
 
     focus = BooleanProperty()
-    """Whether or not the widget is focused"""
+    """get/set the widget's focus"""
 
-    text_validate_unfocus = BooleanProperty(False)
+    text_validate_unfocus = BooleanProperty(True)
     """ Whether on_text_validate() should unfocus the field"""
 
     radius = NumericProperty(dp(25))


### PR DESCRIPTION
Changed default value for `text_validate_unfocus` to True which means `on_text_validate()` should unfocus the widget by default.

Also the field's `focus` was not accessible thus added a few bits for that.