### PR TITLE
Added icon_right re-color to the _on_focus method of MDTextFieldRound

### DIFF
--- a/demos/kitchen_sink/libs/baseclass/textfields.py
+++ b/demos/kitchen_sink/libs/baseclass/textfields.py
@@ -16,4 +16,4 @@ class KitchenSinkTextFields(Screen):
         # and set icon of right button.
         field.password = not field.password
         field.focus = True
-        button.icon = "eye" if button.icon == "eye-off" else "eye-off"
+        button.icon = ["eye", "eye-off"][field.password]

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -194,7 +194,7 @@ class Example(MDApp):
         # and set icon of right button.
         field.password = not field.password
         field.focus = True
-        button.icon = "eye" if button.icon == "eye-off" else "eye-off"
+        button.icon = ["eye", "eye-off"][field.password]
 
 
 Example().run()
@@ -1072,6 +1072,15 @@ class MDTextFieldRound(ThemableBehavior, BoxLayout):
                     self.theme_cls.primary_color
                     if field.focus
                     else self.icon_left_color
+                )
+        except ReferenceError:
+            pass
+        try:
+            if self._instance_icon_right:
+                self._instance_icon_right.text_color = (
+                    self.theme_cls.primary_color
+                    if field.focus
+                    else self.icon_right_color
                 )
         except ReferenceError:
             pass


### PR DESCRIPTION
Just a tiny PR with the below changes.

Changes:
- Changed the default on_focus behavior in `MDTextFieldRound` to also re-color the `icon_right` (to be coherent with existing `icon_left` behavior)
- Tied the `show_password` icon evaluate to the `password` Boolean property in the kitchen_sink demo (this also enables new functionality compared to before if `icon_right: 'account-box'`, meaning it has been declared as any icon other than `eye` or `eye-off` initially, this would then correctly change the icon from its initial icon to either `eye` or `eye-off` and then its counterpart, but allows for a different icon to exist in the input field's initial state)

