### PR TITLE
Allowing to change the color of the bottom toolbar

### DIFF
--- a/kivymd/uix/toolbar.py
+++ b/kivymd/uix/toolbar.py
@@ -298,7 +298,7 @@ Builder.load_string(
                 if root.type == "bottom" else (0, 0)
             radius: (root.round, 0, 0, 0) if root.mode == "center" else (0, root.round, 0, 0)
         Color:
-            rgba: 1, 1, 1, 1
+            rgba: root.theme_cls.bg_normal
         Ellipse:
             pos:
                 (self.center[0] - root.action_button.width / 2 - dp(6), self.center[1] - root._shift * 2) \

--- a/kivymd/uix/toolbar.py
+++ b/kivymd/uix/toolbar.py
@@ -267,7 +267,7 @@ Builder.load_string(
 
     canvas:
         Color:
-            rgba: root.theme_cls.primary_color
+            rgba: root._bottom_md_bg_color
         RoundedRectangle:
             pos:
                 self.pos \
@@ -393,6 +393,12 @@ class MDToolbar(
     and defaults to `[0, 0, 0, 0]`.
     """
 
+    _bottom_md_bg_color = ListProperty([0, 0, 0, 0])
+    """Color of the bottom toolbar
+
+    This is not meant to be used directly, set md_bg_color instead
+    """
+
     anchor_title = StringProperty("left")
 
     mode = OptionProperty(
@@ -480,8 +486,9 @@ class MDToolbar(
         pass
 
     def on_md_bg_color(self, instance, value):
-        if type == "bottom":
+        if self.type == "bottom":
             self.md_bg_color = [0, 0, 0, 0]
+            self._bottom_md_bg_color = value
 
     def on_left_action_items(self, instance, value):
         self.update_action_bar(self.ids["left_actions"], value)


### PR DESCRIPTION
### Description of Changes

* Fixing an issue with on_md_bg_color, the comparison was made with type instead of self.type

* Allowing to change the color of a Toolbar that has the bottom type. Originally it was hardcoded to primary_color, I added an internal property called _bottom_md_bg_color which is set instead of the md_bg_color when the type is bottom.

* Fixing the identation on the bar always being drawn in white, switching to use the actual bg color