### PR TITLE
More flexible close on click navigation drawer

### DIFF
--- a/kivymd/uix/navigationdrawer.py
+++ b/kivymd/uix/navigationdrawer.py
@@ -623,8 +623,9 @@ class MDNavigationDrawer(MDCard):
                 self.set_state("open", animation=True)
         elif self.status == "opened":
             if (
-                self.close_on_click
-                and not self.collide_point(touch.ox, touch.oy)
+                    self.close_on_click
+                    and self.get_dist_from_side(touch.ox) > self.width
+                    and not self.collide_point(touch.ox, touch.oy)
             ):
                 self.set_state("close", animation=True)
         elif self.status == "closed":

--- a/kivymd/uix/navigationdrawer.py
+++ b/kivymd/uix/navigationdrawer.py
@@ -623,9 +623,9 @@ class MDNavigationDrawer(MDCard):
                 self.set_state("open", animation=True)
         elif self.status == "opened":
             if (
-                    self.close_on_click
-                    and self.get_dist_from_side(touch.ox) > self.width
-                    and not self.collide_point(touch.ox, touch.oy)
+                self.close_on_click
+                and self.get_dist_from_side(touch.ox) > self.width
+                and not self.collide_point(touch.ox, touch.oy)
             ):
                 self.set_state("close", animation=True)
         elif self.status == "closed":

--- a/kivymd/uix/navigationdrawer.py
+++ b/kivymd/uix/navigationdrawer.py
@@ -624,7 +624,7 @@ class MDNavigationDrawer(MDCard):
         elif self.status == "opened":
             if (
                 self.close_on_click
-                and self.get_dist_from_side(touch.ox) > self.width
+                and not self.collide_point(touch.ox, touch.oy)
             ):
                 self.set_state("close", animation=True)
         elif self.status == "closed":

--- a/kivymd/uix/navigationdrawer.py
+++ b/kivymd/uix/navigationdrawer.py
@@ -624,7 +624,6 @@ class MDNavigationDrawer(MDCard):
         elif self.status == "opened":
             if (
                 self.close_on_click
-                and self.get_dist_from_side(touch.ox) > self.width
                 and not self.collide_point(touch.ox, touch.oy)
             ):
                 self.set_state("close", animation=True)


### PR DESCRIPTION
### Description of Changes

* Currently, only the x coordinate is checked against width in determining on click closing
* For more flexibility in allowing this widget to be used with less then the entire height, it could instead check for any outside click.

### Screenshots

New behaviour:

![nav](https://user-images.githubusercontent.com/48946947/82581018-37ae7f00-9b90-11ea-8699-b8422858b195.gif)

Old behaviour: does not close when clicking below the pane.