### PR TITLE
Update chip.py 

### DIFF
--- a/kivymd/uix/chip.py
+++ b/kivymd/uix/chip.py
@@ -153,6 +153,7 @@ Builder.load_string(
             text: root.label
             size_hint_x: None
             width: self.texture_size[0]
+            color: root.text_color
 
     MDIconButton:
         id: icon
@@ -187,7 +188,14 @@ class MDChip(BoxLayout, ThemableBehavior):
     :attr:`color` is an :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
+    
+    text_color = ListProperty()
+    """Chip's text color in ``rgba`` format.
 
+    :attr:`color` is an :class:`~kivy.properties.ListProperty`
+    and defaults to `[]`.
+    """
+    
     check = BooleanProperty(False)
     """
     If True, a checkmark is added to the left when touch to the chip.

--- a/kivymd/uix/chip.py
+++ b/kivymd/uix/chip.py
@@ -153,7 +153,7 @@ Builder.load_string(
             text: root.label
             size_hint_x: None
             width: self.texture_size[0]
-            color: root.text_color
+            color: root.text_color if root.text_color else (root.theme_cls.text_color)
 
     MDIconButton:
         id: icon


### PR DESCRIPTION
### Description of Changes
Added option to change the color of the chip's text

### Example
```
        MDChip:
            label: 'test'
            text_color: 1, 0, 0, 1
            icon: ''
            color: 1, 0, 0, .4
```
### Screenshots


![image](https://user-images.githubusercontent.com/45745548/83061968-819ed580-a066-11ea-9cd0-638685f199e8.png)
