### PR TITLE
MDLabel set default theme_text_color to "Primary"

### DIFF
--- a/kivymd/uix/label.py
+++ b/kivymd/uix/label.py
@@ -278,7 +278,7 @@ class MDLabel(ThemableBehavior, Label):
     """Text of the label."""
 
     theme_text_color = OptionProperty(
-        None,
+        "Primary",
         allownone=True,
         options=[
             "Primary",


### PR DESCRIPTION
### Description of Changes
Set default MDLabel theme_text_color to "Primary"
