### PR TITLE
Fix size of `MDDropdownMenu`

### DIFF
--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -667,8 +667,14 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
                 int(Window.width / m_res.STANDARD_INCREMENT)
                 * m_res.STANDARD_INCREMENT
             )
-
-        self.target_height = sum([dp(56) for i in self.items])
+            
+        # The height of each MDMenuItem or MDMenuItemIcon
+        menu_item_height = (MDMenuItemIcon().height if self.use_icon_item else
+                            MDMenuItem().height)
+        # Set the target_height of the menu depending on the size of
+        # each MDMenuItem or MDMenuItemIcon
+        self.target_height = menu_item_height * len(self.items)
+        
         # If we're over max_height...
         if 0 < self.max_height < self.target_height:
             self.target_height = self.max_height


### PR DESCRIPTION


### Description of Changes
The old code assumes that the size of each `MDMenuItem` or `MDMenuItemIcon` is `dp(56)`. This is correct for `MDMenuItemIcon`, but `MDMenuItem` has a size of `dp(48)`. This caused the menu to be bigger than expected when using `MDMenuItem`.

The new code calculates the menu's target height taking into consideration the type of item that is being used. It would be ideal if the code could check the height of each item, but it is possible for `set_menu_properties` to be called before `create_menu_items`, meaning that the items would not have been created yet.

### Screenshots

#### Before fix
![Imgur](https://i.imgur.com/sZWXjAH.png)

#### After fix
![Imgur](https://i.imgur.com/yGsJ1Rl.png)

