### PR TITLE
fix: initialization of multiple MDTabs

### DIFF
--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -888,6 +888,7 @@ class MDTabs(ThemableBehavior, AnchorLayout):
         # You can add only subclass of MDTabsBase.
         if len(self.children) >= 2:
             try:
+                widget.tab_label.group = str(self)
                 widget.tab_label.callback = self.callback
                 widget.tab_label.tab_bar = self.tab_bar
                 widget.tab_label.text_color_normal = self.text_color_normal


### PR DESCRIPTION
This gives every MDTabs a unique string as a group for the ToggleButtonBehavior.
This fixes the issue that the default tab is not selected correctly if multiple instances of MDTabs exist in the same app.

### Description of Changes
I faced an issue when multiple MDTabs where in the same app (e.g. on different screens): On the start of the app, the default tabs were not selected correctly. I therefore gave every label a group that is unique to the MDTabs instance and now the problem is resolved.