### PR TITLE
fix: laggy scrolling with ScrollView inside MDTabs

### DIFF
--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -397,6 +397,7 @@ Builder.load_string(
         MDTabsCarousel:
             id: carousel
             lock_swiping: root.lock_swiping
+            ignore_perpendicular_swipes: True
             anim_move_duration: root.anim_duration
             on_index: root.on_carousel_index(*args)
             on__offset: tab_bar.android_animation(*args)


### PR DESCRIPTION
### Description of Changes
The option "ignore_perpendicular_swipes" improves the scrolling behavior of a ScrollView(up-down-scolling) is inside a Tab. The left-right-swiping for change of tabs is not effected by this change.