### PR TITLE
change: suggestion for colors

### DIFF
--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -338,7 +338,10 @@ from kivy.utils import boundary
 from kivymd import fonts_path
 from kivymd.icon_definitions import md_icons
 from kivymd.theming import ThemableBehavior
-from kivymd.uix.behaviors import RectangularElevationBehavior
+from kivymd.uix.behaviors import (
+    RectangularElevationBehavior,
+    SpecificBackgroundColorBehavior,
+)
 from kivymd.uix.boxlayout import MDBoxLayout
 
 Builder.load_string(
@@ -390,7 +393,17 @@ Builder.load_string(
     carousel: carousel
     tab_bar: tab_bar
     anchor_y: 'top'
-
+    background_palette: "Primary" 
+    text_color_normal: (\
+    self.specific_secondary_text_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.primary_color\
+    )
+    text_color_active: (\
+    self.specific_text_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.primary_dark\
+    )
+    background_color: self.theme_cls.primary_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.bg_dark
+    color_indicator: (\
+    self.theme_cls.accent_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.primary_dark\
+    )
     MDTabsMain:
         padding: 0, tab_bar.height, 0, 0
 
@@ -734,7 +747,7 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
             self.update_indicator(x_step, w_step)
 
 
-class MDTabs(ThemableBehavior, AnchorLayout):
+class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     You can use this class to create your own tabbed panel..
 

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -394,16 +394,9 @@ Builder.load_string(
     tab_bar: tab_bar
     anchor_y: 'top'
     background_palette: "Primary"
-    text_color_normal: (\
-    self.specific_secondary_text_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.primary_color\
-    )
-    text_color_active: (\
-    self.specific_text_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.primary_dark\
-    )
-    background_color: self.theme_cls.primary_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.bg_dark
-    color_indicator: (\
-    self.theme_cls.accent_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.primary_dark\
-    )
+    text_color_normal: self.specific_secondary_text_color
+    text_color_active: self.specific_text_color
+
     MDTabsMain:
         padding: 0, tab_bar.height, 0, 0
 

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -393,7 +393,7 @@ Builder.load_string(
     carousel: carousel
     tab_bar: tab_bar
     anchor_y: 'top'
-    background_palette: "Primary" 
+    background_palette: "Primary"
     text_color_normal: (\
     self.specific_secondary_text_color if self.theme_cls.theme_style == "Dark" else self.theme_cls.primary_color\
     )


### PR DESCRIPTION
Here is a suggestion for a little color-change for the tabs:

### Description of Changes
#### Light
text_color_normal is in the primary_color on light grey background . The active element is primary_dark with indicator in the same color.

#### Dark
Background is the primary_color. text_color_active and text_color_normal are chosen by help of the SpecificBackgroundColorBehavior.


Theme picker with my changes:
![tabs-theming](https://user-images.githubusercontent.com/31960422/86489344-60678e00-bd64-11ea-859e-c367f4e245ad.gif)
Theme picker from readthedocs:
![theme-picker-old](https://raw.githubusercontent.com/HeaTTheatR/KivyMD-data/master/gallery/kivymddoc/MDThemePicker.gif)