### PR TITLE
Reset target_height on_dismiss

### DIFF
--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -1125,6 +1125,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
         self.menu.width = 0
         self.menu.height = 0
         self.menu.opacity = 0
+        self.target_height = 0
 
     def dismiss(self):
         self.on_dismiss()


### PR DESCRIPTION
### Description of Changes
Reseting the target_height on_dimiss. Fixes menu expanding in height every time
the menu gets reopened.


