### PR TITLE
Fixed Menu height bug occuring after window resize

### DIFF
--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -970,6 +970,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
 
         # Set the target_height of the menu depending on the size of
         # each MDMenuItem or MDMenuItemIcon
+        self.target_height = 0
         for item in self.menu.ids.box.children:
             self.target_height += item.height
 
@@ -1125,7 +1126,6 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
         self.menu.width = 0
         self.menu.height = 0
         self.menu.opacity = 0
-        self.target_height = 0
 
     def dismiss(self):
         self.on_dismiss()


### PR DESCRIPTION
### Description of Changes
Replacing bugfix in commit 6d9b448  with a new fix.
Proposed change fixes menu height growth both when
reopening the menu and resizing the window.

Former bugfix only resolves the former issue.


