### PR TITLE
MDDropdownMenu: remove use_icon_item kwarg

### DIFF
--- a/kivymd/uix/datatables.py
+++ b/kivymd/uix/datatables.py
@@ -960,7 +960,6 @@ class MDDataTable(BaseDialog):
         pagination_menu = MDDropdownMenu(
             caller=self.pagination.ids.drop_item,
             items=menu_items,
-            use_icon_item=False,
             position=self.pagination_menu_pos,
             max_height=self.pagination_menu_height,
             callback=self.table_data.set_number_displayed_lines,


### PR DESCRIPTION
The `use_icon_item` property was removed in commit c968caa.

### Description of Changes
Fixes TypeError caused by passing invalid argument to
`EventDispatcher.__init__` when creating an MDDropdownMenu.