### PR TITLE
BUGFIX - selectioncontrol.py - MDCheckbox

### DIFF
--- a/kivymd/uix/selectioncontrol.py
+++ b/kivymd/uix/selectioncontrol.py
@@ -360,6 +360,8 @@ class MDCheckbox(CircularRippleBehavior, ToggleButtonBehavior, MDIcon):
             self.check_anim_in.cancel(self)
             self.check_anim_out.start(self)
             self.update_icon()
+            if self.group:
+                self._release_group(self)
             self.active = True
         else:
             self.check_anim_in.cancel(self)


### PR DESCRIPTION
When MDCheckbox.active is externally setted to a value True|False and is
part of a group, the group should deactivate in favor of the button
wich has MDCheckbox.active setted to True.

When the button is pressed, the ToggleButtonBehavior does the chekup
internally, but when we set the attribute MDCheckbox.active from outside
the class, the ToggleButtonBehavior._release_group is not called.

This is fixed by adding the following code to the on_state event of
MDCheckbox, inside of `if self.state == "down"`

```python
    if self.state == "down":
        [...]
        if self.group:
            self._release_group(self)
        [...]
```

### Description of Changes
* Bugfix for the MDCheckbox.active set from outside the class.


