### PR TITLE
Fixed custom content height, when using adaptive_height

### DIFF
--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -64,6 +64,7 @@ Usage
 
 __all__ = ("MDDialog",)
 
+from kivy.clock import Clock
 from kivy.core.window import Window
 from kivy.lang import Builder
 from kivy.metrics import dp
@@ -81,7 +82,6 @@ from kivymd.theming import ThemableBehavior
 from kivymd.uix.button import BaseButton
 from kivymd.uix.card import MDSeparator
 from kivymd.uix.list import BaseListItem
-from kivy.clock import Clock
 
 Builder.load_string(
     """
@@ -544,7 +544,7 @@ class MDDialog(BaseDialog):
 
         if update_height:
             Clock.schedule_once(self.update_height)
-    
+
     def update_height(self, *_):
         self._spacer_top = self.content_cls.height + dp(24)
 

--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -81,6 +81,7 @@ from kivymd.theming import ThemableBehavior
 from kivymd.uix.button import BaseButton
 from kivymd.uix.card import MDSeparator
 from kivymd.uix.list import BaseListItem
+from kivy.clock import Clock
 
 Builder.load_string(
     """
@@ -525,6 +526,7 @@ class MDDialog(BaseDialog):
         else:
             self.create_buttons()
 
+        update_height = False
         if self.type in ("simple", "confirmation"):
             if self.type == "confirmation":
                 self.ids.spacer_top_box.add_widget(MDSeparator())
@@ -535,10 +537,16 @@ class MDDialog(BaseDialog):
                 self.ids.container.remove_widget(self.ids.scroll)
                 self.ids.container.remove_widget(self.ids.text)
                 self.ids.spacer_top_box.add_widget(self.content_cls)
-                self._spacer_top = self.content_cls.height + dp(24)
                 self.ids.spacer_top_box.padding = (0, "24dp", "16dp", 0)
+                update_height = True
         if self.type == "alert":
             self.ids.scroll.bar_width = 0
+
+        if update_height:
+            Clock.schedule_once(self.update_height)
+    
+    def update_height(self, *_):
+        self._spacer_top = self.content_cls.height + dp(24)
 
     def on_open(self):
         # TODO: Add scrolling text.


### PR DESCRIPTION
### Description of Changes
MDDialog content height now works with adaptive_height widgets.

This was fixed / added by setting the height after the \_\_init\_\_ method
has finished.

```python
if update_height:
        Clock.schedule_once(self.update_height)
...
def update_height(self, *_):
        self._spacer_top = self.content_cls.height + dp(24)
```


