### PR TITLE
Md label font style options fork

### DIFF
--- a/kivymd/uix/label.py
+++ b/kivymd/uix/label.py
@@ -213,7 +213,6 @@ from kivy.properties import (
     AliasProperty,
     BooleanProperty,
     ListProperty,
-    ObjectProperty,
     OptionProperty,
     StringProperty,
 )
@@ -248,15 +247,15 @@ Builder.load_string(
 
 
 class MDLabel(ThemableBehavior, Label):
-    font_style = ObjectProperty("Body1")
+    font_style = StringProperty("Body1")
     """
     Label font style.
 
-    Available options are: `'H1'`, `'H2'`, `'H3'`, `'H4'`, `'H5'`, `'H6'`,
+    Available vanilla font_style are: `'H1'`, `'H2'`, `'H3'`, `'H4'`, `'H5'`, `'H6'`,
     `'Subtitle1'`, `'Subtitle2'`, `'Body1'`, `'Body2'`, `'Button'`,
     `'Caption'`, `'Overline'`, `'Icon'`.
 
-    :attr:`font_style` is an :class:`~kivy.properties.ObjectProperty`
+    :attr:`font_style` is an :class:`~kivy.properties.StringProperty`
     and defaults to `'Body1'`.
     """
 

--- a/kivymd/uix/label.py
+++ b/kivymd/uix/label.py
@@ -322,19 +322,17 @@ class MDLabel(ThemableBehavior, Label):
 
         Clock.schedule_once(self.check_font_styles)
 
-    def check_font_styles(self, dt):
+    def check_font_styles(self, *dt):
         if self.font_style not in list(self.theme_cls.font_styles.keys()):
             raise ValueError(
-                "MDLabel.font_style is set to an invalid option '{}'. "
-                "Must be one of: {}".format(
-                    self.font_style, list(self.theme_cls.font_styles)
-                )
+                f"MDLabel.font_style is set to an invalid option '{self.font_style}'."
+                f"Must be one of: {list(self.theme_cls.font_styles)}"
             )
         else:
             return True
 
     def update_font_style(self, *args):
-        if self.check_font_styles("") is True:
+        if self.check_font_styles() is True:
             font_info = self.theme_cls.font_styles[self.font_style]
             self.font_name = font_info[0]
             self.font_size = sp(font_info[1])

--- a/kivymd/uix/label.py
+++ b/kivymd/uix/label.py
@@ -206,6 +206,7 @@ The :class:`~MDIcon` class is inherited from
 
 __all__ = ("MDLabel", "MDIcon")
 
+from kivy.clock import Clock
 from kivy.lang import Builder
 from kivy.metrics import sp
 from kivy.properties import (
@@ -311,7 +312,7 @@ class MDLabel(ThemableBehavior, Label):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.check_font_styles()
+
         self.bind(
             font_style=self.update_font_style,
             can_capitalize=self.update_font_style,
@@ -320,7 +321,9 @@ class MDLabel(ThemableBehavior, Label):
         self.update_font_style()
         self.on_opposite_colors(None, self.opposite_colors)
 
-    def check_font_styles(self):
+        Clock.schedule_once(self.check_font_styles)
+
+    def check_font_styles(self, dt):
         if self.font_style not in list(self.theme_cls.font_styles.keys()):
             raise ValueError(
                 "MDLabel.font_style is set to an invalid option '{}'. "
@@ -328,15 +331,19 @@ class MDLabel(ThemableBehavior, Label):
                     self.font_style, list(self.theme_cls.font_styles)
                 )
             )
+        else:
+            return True
 
     def update_font_style(self, *args):
-        font_info = self.theme_cls.font_styles[self.font_style]
-        self.font_name = font_info[0]
-        self.font_size = sp(font_info[1])
-        if font_info[2] and self.can_capitalize:
-            self._capitalizing = True
-        else:
-            self._capitalizing = False
+        if self.check_font_styles("") is True:
+            font_info = self.theme_cls.font_styles[self.font_style]
+            self.font_name = font_info[0]
+            self.font_size = sp(font_info[1])
+            if font_info[2] and self.can_capitalize:
+                self._capitalizing = True
+            else:
+                self._capitalizing = False
+
         # TODO: Add letter spacing change
         # self.letter_spacing = font_info[3]
 

--- a/kivymd/uix/label.py
+++ b/kivymd/uix/label.py
@@ -255,7 +255,7 @@ class MDLabel(ThemableBehavior, Label):
     `'Subtitle1'`, `'Subtitle2'`, `'Body1'`, `'Body2'`, `'Button'`,
     `'Caption'`, `'Overline'`, `'Icon'`.
 
-    :attr:`font_style` is an :class:`~kivy.properties.OptionProperty`
+    :attr:`font_style` is an :class:`~kivy.properties.ObjectProperty`
     and defaults to `'Body1'`.
     """
 

--- a/kivymd/uix/label.py
+++ b/kivymd/uix/label.py
@@ -213,11 +213,10 @@ from kivy.properties import (
     BooleanProperty,
     ListProperty,
     OptionProperty,
+    ObjectProperty,
     StringProperty,
 )
 from kivy.uix.label import Label
-
-from kivymd.font_definitions import theme_font_styles
 from kivymd.theming import ThemableBehavior
 from kivymd.theming_dynamic_text import get_contrast_text_color
 
@@ -247,7 +246,7 @@ Builder.load_string(
 
 
 class MDLabel(ThemableBehavior, Label):
-    font_style = OptionProperty("Body1", options=theme_font_styles)
+    font_style = ObjectProperty("Body1")
     """
     Label font style.
 
@@ -311,6 +310,7 @@ class MDLabel(ThemableBehavior, Label):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.check_font_styles()
         self.bind(
             font_style=self.update_font_style,
             can_capitalize=self.update_font_style,
@@ -318,6 +318,11 @@ class MDLabel(ThemableBehavior, Label):
         self.on_theme_text_color(None, self.theme_text_color)
         self.update_font_style()
         self.on_opposite_colors(None, self.opposite_colors)
+
+    def check_font_styles(self):
+        if self.font_style not in list(self.theme_cls.font_styles.keys()):
+            raise ValueError("MDLabel.font_style is set to an invalid option '{}'. "
+                             "Must be one of: {}".format( self.font_style, list(self.theme_cls.font_styles)))
 
     def update_font_style(self, *args):
         font_info = self.theme_cls.font_styles[self.font_style]

--- a/kivymd/uix/label.py
+++ b/kivymd/uix/label.py
@@ -212,11 +212,12 @@ from kivy.properties import (
     AliasProperty,
     BooleanProperty,
     ListProperty,
-    OptionProperty,
     ObjectProperty,
+    OptionProperty,
     StringProperty,
 )
 from kivy.uix.label import Label
+
 from kivymd.theming import ThemableBehavior
 from kivymd.theming_dynamic_text import get_contrast_text_color
 
@@ -321,8 +322,12 @@ class MDLabel(ThemableBehavior, Label):
 
     def check_font_styles(self):
         if self.font_style not in list(self.theme_cls.font_styles.keys()):
-            raise ValueError("MDLabel.font_style is set to an invalid option '{}'. "
-                             "Must be one of: {}".format( self.font_style, list(self.theme_cls.font_styles)))
+            raise ValueError(
+                "MDLabel.font_style is set to an invalid option '{}'. "
+                "Must be one of: {}".format(
+                    self.font_style, list(self.theme_cls.font_styles)
+                )
+            )
 
     def update_font_style(self, *args):
         font_info = self.theme_cls.font_styles[self.font_style]


### PR DESCRIPTION
Fixes #515 : Bug where MDLabel.font_style does not update

### Description of Changes
Changed `OptionProperty` to `ObjectProperty`
Added `check_font_style()` to replace the validation function of `OptionProperty`
Code in question:

`font_style = ObjectProperty("Body1")` changed to `font_style = ObjectProperty("Body1")`
```:attr:`font_style` is an :class:`~kivy.properties.OptionProperty``` changed to ```:attr:`font_style` is an :class:`~kivy.properties.OptionProperty` ```
List of options is not changed as it is still applicable (they are in `self.theme_cls.font_style.keys()`)

Added:

- `self.check_font_styles() to .__init__()`

- ```def check_font_styles(self):
          if self.font_style not in list(self.theme_cls.font_styles.keys()):
              raise ValueError(
                  "MDLabel.font_style is set to an invalid option '{}'. "
                  "Must be one of: {}".format(
                      self.font_style, list(self.theme_cls.font_styles)
                  )
              )
```
@ArtemSBulgakov @HeaTTheatR 
