### PR TITLE
change textfield animation that turns hint_text black and other modifications

### DIFF
--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -906,14 +906,15 @@ class MDTextField(ThemableBehavior, TextInput):
             )
             _fill_color = self.fill_color
             _fill_color[3] = self.fill_color[3] - 0.1
-            Animation(
-                _line_blank_space_right_point=self._line_blank_space_right_point,
-                _line_blank_space_left_point=self._hint_lbl.x - dp(5),
-                _current_hint_text_color=self.line_color_focus,
-                fill_color=_fill_color,
-                duration=0.2,
-                t="out_quad",
-            ).start(self)
+            if not self._get_has_error():
+                Animation(
+                    _line_blank_space_right_point=self._line_blank_space_right_point,
+                    _line_blank_space_left_point=self._hint_lbl.x - dp(5),
+                    _current_hint_text_color=self.line_color_focus,
+                    fill_color=_fill_color,
+                    duration=0.2,
+                    t="out_quad",
+                ).start(self)
             self.has_had_text = True
             Animation.cancel_all(
                 self, "_line_width", "_hint_y", "_hint_lbl_font_size"
@@ -939,9 +940,10 @@ class MDTextField(ThemableBehavior, TextInput):
                     self._anim_current_error_color(disabled_hint_text_color)
             else:
                 self._anim_current_right_lbl_color(disabled_hint_text_color)
-                Animation(duration=0.2, color=self.line_color_focus).start(
-                    self._hint_lbl
-                )
+                Animation(
+                    duration=0.2,
+                    _current_hint_text_color=self.line_color_focus
+                ).start(self)
                 if self.helper_text_mode == "on_error":
                     self._anim_current_error_color((0, 0, 0, 0))
                 if self.helper_text_mode in ("persistent", "on_focus"):

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -940,10 +940,9 @@ class MDTextField(ThemableBehavior, TextInput):
                     self._anim_current_error_color(disabled_hint_text_color)
             else:
                 self._anim_current_right_lbl_color(disabled_hint_text_color)
-                Animation(
-                    duration=0.2,
-                    _current_hint_text_color=self.line_color_focus
-                ).start(self)
+                Animation(duration=0.2, _current_hint_text_color=self.line_color_focus).start(
+                    self
+                )
                 if self.helper_text_mode == "on_error":
                     self._anim_current_error_color((0, 0, 0, 0))
                 if self.helper_text_mode in ("persistent", "on_focus"):

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -940,9 +940,9 @@ class MDTextField(ThemableBehavior, TextInput):
                     self._anim_current_error_color(disabled_hint_text_color)
             else:
                 self._anim_current_right_lbl_color(disabled_hint_text_color)
-                Animation(duration=0.2, _current_hint_text_color=self.line_color_focus).start(
-                    self
-                )
+                Animation(
+                    duration=0.2, _current_hint_text_color=self.line_color_focus
+                ).start(self)
                 if self.helper_text_mode == "on_error":
                     self._anim_current_error_color((0, 0, 0, 0))
                 if self.helper_text_mode in ("persistent", "on_focus"):


### PR DESCRIPTION
### Description of Changes

1. Fixed #448 issue 1.
 The animation on textfield textfield.py line 942
`                Animation(duration=0.2, color=self.line_color_focus).start(
                    self._hint_lbl
                )`
should change hint_text's color, but in reality, it adds self.line_color_focus on hint text's previous color, acting like a filter. This behavior makes hint text's color turning into a darker color.
I've changed the animation to a propper way that really changes the colors:
`Animation(
                    duration=0.2,
                    _current_hint_text_color=self.line_color_focus
                ).start(self)`

2. Changed the way that textfield acts when detects an error. 
When you get focus on a textfield and it's on error, the usual behavior is to turn hint_text's color to `line_color_focus`, overriding error_color. I've changed this adding an if statement on textfield.py line 909 to preserve error_color until widget's error is fixed.

### Screenshots

Before: 
![image](https://user-images.githubusercontent.com/29078746/93001893-56020700-f500-11ea-9d2a-9d9f996e07d7.png)

After:
![image](https://user-images.githubusercontent.com/29078746/93001911-78942000-f500-11ea-9f5f-eb30930955c9.png)

