### PR TITLE
Filemanager : enable multi select option for files

### DIFF
--- a/demos/kitchen_sink/libs/baseclass/filemanager.py
+++ b/demos/kitchen_sink/libs/baseclass/filemanager.py
@@ -1,5 +1,16 @@
 from kivy.uix.screenmanager import Screen
 
+from kivymd.uix.boxlayout import MDBoxLayout
+
+
+class FileManagerTypeDialog(MDBoxLayout):
+    """ Choose file manager type and selection type """
+
+    allow_multiple_selection = False
+
+    def set_selection_type(self, checkbox, value):
+        self.allow_multiple_selection = value
+
 
 class KitchenSinkFileManager(Screen):
     manager_open = False
@@ -21,19 +32,25 @@ class KitchenSinkFileManager(Screen):
                     preview=preview,
                 )
             self.file_manager.preview = preview
+            self.file_manager.multiselect = (
+                manager_type_dialog.allow_multiple_selection
+            )
             self.file_manager.show(MDApp.get_running_app().user_data_dir)
             self.manager_open = True
 
+        manager_type_dialog = FileManagerTypeDialog()
+
         MDDialog(
             title="Kitchen Sink",
+            type="custom",
             size_hint=(0.8, 0.4),
-            text="Open manager with 'list' or 'previous' mode?",
+            content_cls=manager_type_dialog,
             buttons=[
                 MDFlatButton(
                     text="List", on_release=lambda x: open_file_manager("List")
                 ),
                 MDFlatButton(
-                    text="Previous",
+                    text="Preview",
                     on_release=lambda x: open_file_manager("Preview"),
                 ),
             ],
@@ -50,7 +67,10 @@ class KitchenSinkFileManager(Screen):
         from kivymd.toast import toast
 
         self.exit_manager()
-        toast(path)
+        if type(path) == str:
+            toast(path)
+        else:
+            toast(",".join(path))
 
     def exit_manager(self, *args):
         """Called when the user reaches the root of the directory tree."""

--- a/demos/kitchen_sink/libs/kv/file_manager.kv
+++ b/demos/kitchen_sink/libs/kv/file_manager.kv
@@ -12,3 +12,17 @@
         opposite_colors: True
         pos_hint: {'center_x': .5, 'center_y': .5}
         on_release: root.file_manager_open()
+
+<FileManagerTypeDialog>:
+    orientation: 'vertical'
+    adaptive_height: True
+    MDLabel:
+        text: "Open manager with 'list' or 'preview' mode?"
+    MDBoxLayout:
+        orientation: 'horizontal'
+        adaptive_height: True
+        MDCheckbox:
+            on_active: root.set_selection_type(*args)
+            size_hint_x: None
+        MDLabel:
+            text: "Allow Multiple Selection ?"

--- a/kivymd/tools/release/git_commands.py
+++ b/kivymd/tools/release/git_commands.py
@@ -69,11 +69,7 @@ def git_tag(name: str):
 def git_push(branches_to_push: list, ask: bool = True, push: bool = False):
     """Push all changes."""
     if ask:
-        push = input("Do you want to push changes? (y)") in (
-            "",
-            "y",
-            "yes",
-        )
+        push = input("Do you want to push changes? (y)") in ("", "y", "yes",)
 
     cmd = ["git", "push", "--tags", "origin", "master", *branches_to_push]
     if push:

--- a/kivymd/tools/release/make_release.py
+++ b/kivymd/tools/release/make_release.py
@@ -157,22 +157,14 @@ def move_changelog(
 
 
 def create_unreleased_changelog(
-    index_file,
-    unreleased_file,
-    version,
-    ask: bool = True,
-    test: bool = False,
+    index_file, unreleased_file, version, ask: bool = True, test: bool = False,
 ):
     """Create unreleased.rst by template."""
     # Check if unreleased file exists
     if os.path.exists(unreleased_file):
         if ask and input(
             f'Do you want to rewrite "{unreleased_file}"? (y)'
-        ) not in (
-            "",
-            "y",
-            "yes",
-        ):
+        ) not in ("", "y", "yes",):
             exit(0)
     # Generate unreleased changelog
     changelog = f"""Unreleased
@@ -285,10 +277,7 @@ def main():
     # branches_to_push.append("stable")
 
     create_unreleased_changelog(
-        changelog_index_file,
-        changelog_unreleased_file,
-        version,
-        test=test,
+        changelog_index_file, changelog_unreleased_file, version, test=test,
     )
     update_init_py(next_version, is_release=False, test=test)
     git_commit(f"KivyMD {next_version}")

--- a/kivymd/uix/filemanager.py
+++ b/kivymd/uix/filemanager.py
@@ -395,7 +395,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     multiselect = BooleanProperty(False)
     """
     Determines whether the user is able to select multiple files or not.
-    
+
     :attr:`multiselect` is a :class:`~kivy.properties.BooleanProperty` and defaults to
     False.
     """
@@ -403,7 +403,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     selection = ListProperty([])
     """
     Contains the list of files that are currently selected.
-    
+
     :attr:`selection` is a read-only :class:`~kivy.properties.ListProperty` and
     defaults to [].
     """
@@ -649,7 +649,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     def select_directory_on_press_button(self, *args):
         """Called when a click on a floating button."""
 
-        if self.multiselect:
+        if len(self.selection) > 0:
             self.select_path(self.selection)
         else:
             self.select_path(self.current_path)

--- a/kivymd/uix/progressbar.py
+++ b/kivymd/uix/progressbar.py
@@ -288,9 +288,7 @@ class MDProgressBar(ThemableBehavior, ProgressBar):
         )
         self.running_anim.bind(on_complete=self.catching_up)
         self.catching_anim = Animation(
-            opacity=0,
-            t=self.catching_transition,
-            d=self.catching_duration,
+            opacity=0, t=self.catching_transition, d=self.catching_duration,
         )
         self.catching_anim.bind(on_complete=self.running_away)
 


### PR DESCRIPTION
### Description of Changes
* add multi-select support for files only
* update kitchen sink example to have a custom MDDIalog and to have an option to choose for 'multiselect'
* fix a typo ( rename 'previous' in kitchen_sink as 'preview' )

### Screenshots
![Updated MDDialog in kitchen_sink](https://user-images.githubusercontent.com/46491838/93078478-27bf2b80-f6a8-11ea-8a2e-40fadae39b8a.png)
![Darker shade shows selected files](https://user-images.githubusercontent.com/46491838/93078488-2d1c7600-f6a8-11ea-8457-e8e5272a97ad.png)
