### PR TITLE
menu with MDToolbar (CustomToolbar) improvement

### DIFF
--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -459,11 +459,14 @@ Menu with MDToolbar
         height: self.theme_cls.standard_increment
         padding: "5dp"
         spacing: "12dp"
+        md_bg_color: app.theme_cls.primary_color
 
         MDIconButton:
             id: button_1
             icon: "menu"
             pos_hint: {"center_y": .5}
+            theme_text_color: "Custom"
+            text_color: root.specific_text_color
             on_release: app.menu_1.open()
 
         MDLabel:
@@ -473,6 +476,8 @@ Menu with MDToolbar
             width: self.texture_size[0]
             text_size: None, None
             font_style: 'H6'
+            theme_text_color: "Custom"
+            text_color: root.specific_text_color
 
         Widget:
 
@@ -480,8 +485,9 @@ Menu with MDToolbar
             id: button_2
             icon: "dots-vertical"
             pos_hint: {"center_y": .5}
+            theme_text_color: "Custom"
+            text_color: root.specific_text_color
             on_release: app.menu_2.open()
-
 
     Screen:
 
@@ -495,9 +501,7 @@ Menu with MDToolbar
     class CustomToolbar(
         ThemableBehavior, RectangularElevationBehavior, MDBoxLayout,
     ):
-        def __init__(self, **kwargs):
-            super().__init__(**kwargs)
-            self.md_bg_color = self.theme_cls.primary_color
+        pass
 
 
     class Test(MDApp):
@@ -698,12 +702,13 @@ Builder.load_string(
         opacity: md_menu.opacity
 
         canvas:
+            Clear
             Color:
                 rgba: root.background_color if root.background_color else root.theme_cls.bg_dark
             RoundedRectangle:
                 size: self.size
                 pos: self.pos
-                radius: [7,]
+                radius: [root.radius,]
 
         MDMenu:
             id: md_menu
@@ -876,6 +881,14 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
 
     :attr:`position` is a :class:`~kivy.properties.OptionProperty`
     and defaults to `'auto'`.
+    """
+
+    radius = NumericProperty(7)
+    """
+    Menu radius.
+
+    :attr:`radius` is a :class:`~kivy.properties.NumericProperty`
+    and defaults to `'7'`.
     """
 
     _start_coords = []

--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -459,7 +459,7 @@ Menu with MDToolbar
         height: self.theme_cls.standard_increment
         padding: "5dp"
         spacing: "12dp"
-        md_bg_color: app.theme_cls.primary_color
+        md_bg_color: self.theme_cls.primary_color
 
         MDIconButton:
             id: button_1


### PR DESCRIPTION
### Description
when use [custom mdtoolbar](https://kivymd.readthedocs.io/en/latest/components/menu/index.html#menu-with-mdtoolbar) for dropdownmenu the labels and icon colours are in black always (see the below screenshots)
but in original kivymd's mdtoolbar changes textcolor of labels (and icons) according to theme_cls.primary_palette


### Screenshots
in all theme (primary_palette) mdlabels and mdicons in black in color
![bad1](https://user-images.githubusercontent.com/63696279/93712300-9b62ac00-fb72-11ea-9d15-6d2763758319.png)        ![bad2](https://user-images.githubusercontent.com/63696279/93712304-ab7a8b80-fb72-11ea-911e-7feca359e842.png)

according to the current theme (primary_palatte) mdlabels and mdicons changes colors to specific_text_color 
![gud1](https://user-images.githubusercontent.com/63696279/93712308-ae757c00-fb72-11ea-8fd3-e25e1dbbf571.png)        ![gud2](https://user-images.githubusercontent.com/63696279/93712309-b0d7d600-fb72-11ea-8b2e-83cacf70b11a.png)

