### PR TITLE
Fixed #545 by checking against self._current_button_color

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -895,7 +895,7 @@ class BaseButton(
             self._current_text_color = value
 
     def on_md_bg_color(self, instance, value):
-        if value != self.theme_cls.primary_color:
+        if value != self._current_button_color:
             self._current_button_color = value
 
     def on_disabled(self, instance, value):


### PR DESCRIPTION
### Description of Changes
When setting a button's `md_bg_color` check against `self._current_button_color` instead of `self.theme_cls.primary_color`.

This fixes issue #545 