### PR TITLE
Possibly a typo in the class name

### DIFF
--- a/kivymd/uix/imagelist.py
+++ b/kivymd/uix/imagelist.py
@@ -73,7 +73,7 @@ SmartTileWithLabel
     from kivy.lang import Builder
 
     KV = '''
-    <MyTile@SmartTileWithStar>
+    <MyTile@SmartTileWithLabel>
         size_hint_y: None
         height: "240dp"
 


### PR DESCRIPTION
Doc example for `SmartTileWithLabel` was using `SmartTileWithStar`. Fixed that. The example is working as expected.