### PR TITLE
Backdrop movement reference update

### DIFF
--- a/kivymd/uix/backdrop.py
+++ b/kivymd/uix/backdrop.py
@@ -124,7 +124,6 @@ __all__ = (
 from kivy.animation import Animation
 from kivy.clock import Clock
 from kivy.lang import Builder
-from kivy.metrics import dp
 from kivy.properties import (
     BooleanProperty,
     ListProperty,
@@ -331,7 +330,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
         if open_up_to:
             y = open_up_to
         else:
-            y = dp(120) - self.height
+            y = self.ids.header_button.height - self.ids._front_layer.height
         Animation(y=y, d=0.2, t="out_quad").start(self.ids._front_layer)
         self._front_layer_open = True
         self.dispatch("on_open")

--- a/kivymd/uix/backdrop.py
+++ b/kivymd/uix/backdrop.py
@@ -328,7 +328,15 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
             self.close()
             return
         if open_up_to:
-            y = open_up_to
+            # added open_up_to check
+            if open_up_to < (
+                self.ids.header_button.height - self.ids._front_layer.height
+            ):
+                y = self.ids.header_button.height - self.ids._front_layer.height
+            elif open_up_to > 0:
+                y = 0
+            else:
+                y = open_up_to
         else:
             y = self.ids.header_button.height - self.ids._front_layer.height
         Animation(y=y, d=0.2, t="out_quad").start(self.ids._front_layer)

--- a/kivymd/uix/backdrop.py
+++ b/kivymd/uix/backdrop.py
@@ -327,8 +327,8 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
         if self._front_layer_open:
             self.close()
             return
+
         if open_up_to:
-            # added open_up_to check
             if open_up_to < (
                 self.ids.header_button.height - self.ids._front_layer.height
             ):
@@ -339,6 +339,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
                 y = open_up_to
         else:
             y = self.ids.header_button.height - self.ids._front_layer.height
+
         Animation(y=y, d=0.2, t="out_quad").start(self.ids._front_layer)
         self._front_layer_open = True
         self.dispatch("on_open")


### PR DESCRIPTION
### Description of Changes
- Added open_up_to check so the user can't cause not intended backdrop transitions
- Changes default open reference to use header_button and front_layer height

The above mention changes fix the problem of when you open the backdrop all the way you get part of whatever is put in the front layer. What is shown should just the the space where the header goes. Also this stops the user from being able to set the open_up_to direction to be to far below the screen or above 0 reference which shows the background, both are undesirable behaviors.

Implementation was tests with header property = True & False
