### PR TITLE
No newline if multiline False in MDTextField

### DIFF
--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -405,8 +405,8 @@ With right icon
 
 __all__ = ("MDTextField", "MDTextFieldRect", "MDTextFieldRound")
 
-import sys
 import re
+import sys
 
 from kivy.animation import Animation
 from kivy.lang import Builder

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -406,6 +406,7 @@ With right icon
 __all__ = ("MDTextField", "MDTextFieldRect", "MDTextFieldRound")
 
 import sys
+import re
 
 from kivy.animation import Animation
 from kivy.lang import Builder
@@ -991,6 +992,7 @@ class MDTextField(ThemableBehavior, TextInput):
                 Animation(_line_width=0, duration=0.2, t="out_quad").start(self)
 
     def on_text(self, instance, text):
+        self.text = re.sub("\n", " ", text) if not self.multiline else text
         if len(text) > 0:
             self.has_had_text = True
         if self.max_text_length is not None:


### PR DESCRIPTION
Fixed bug pointed out in #585 
For a single-line textfield, if a pasted text contains a newline character, it should be replaced with a space.