### PR TITLE
Resizable width for MDDialog

### DIFF
--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -518,6 +518,7 @@ class MDDialog(BaseDialog):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        Window.bind(on_resize=self.update_width)
 
         self.md_bg_color = (
             self.theme_cls.bg_dark if not self.md_bg_color else self.md_bg_color
@@ -556,6 +557,15 @@ class MDDialog(BaseDialog):
 
         if update_height:
             Clock.schedule_once(self.update_height)
+
+    def update_width(self, *args):
+        self.width = max(
+            self.height + dp(48),
+            min(
+                dp(560) if DEVICE_TYPE == "desktop" else dp(280),
+                Window.width - dp(48),
+            ),
+        )
 
     def update_height(self, *_):
         self._spacer_top = self.content_cls.height + dp(24)


### PR DESCRIPTION
As pointed out in #583, the width of `MDDialog` now resizes with the window.
For the resized width I've arbitrarily given left and right magin of `dp(24)` so that it doesn't look so close and compact with the device width. Also, I've restricted the dialog width to go beyond a certain limit.

Here's how it looks when resized:
![Screenshot from 2020-10-15 23-42-23](https://user-images.githubusercontent.com/37111736/96170647-7aa72f80-0f41-11eb-8e78-8d57e09ea946.png)
