### PR TITLE
Fixed rectangle intersecting hint text in MDTextField

### DIFF
--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -1129,8 +1129,7 @@ class MDTextField(ThemableBehavior, TextInput):
         if not self._better_texture_size:
             self._better_texture_size = self._hint_lbl.texture_size[0]
         return (
-            self._better_texture_size
-            - self._better_texture_size / 100 * dp(18)
+            self._better_texture_size - self._better_texture_size / 100 * dp(18)
             if DEVICE_TYPE == "desktop"
             else dp(10)
         )

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -847,6 +847,7 @@ class MDTextField(ThemableBehavior, TextInput):
             accent_color=self._update_accent_color,
         )
         self.has_had_text = False
+        self._better_texture_size = None
 
     def set_objects_labels(self):
         """Creates labels objects for the parameters
@@ -1125,9 +1126,11 @@ class MDTextField(ThemableBehavior, TextInput):
 
     def _get_line_blank_space_right_point(self):
         # https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/_line_blank_space_right_point.png
+        if not self._better_texture_size:
+            self._better_texture_size = self._hint_lbl.texture_size[0]
         return (
-            self._hint_lbl.texture_size[0]
-            - self._hint_lbl.texture_size[0] / 100 * dp(18)
+            self._better_texture_size
+            - self._better_texture_size / 100 * dp(18)
             if DEVICE_TYPE == "desktop"
             else dp(10)
         )


### PR DESCRIPTION
A possible fix for #582. 
It seems to me that the same texture is returning a different `texture_size[0]` for when the textfield is empty and when it's not.
We are sure of one thing is that when it's focused while empty, it returns a better texture size and hence creates no overlapping for empty textfield. So, a possible fix is that get the better texture size and use it when focused while having some text.

No more overlapping:
 
![Screenshot from 2020-10-16 01-21-53](https://user-images.githubusercontent.com/37111736/96181147-2c019180-0f51-11eb-9d17-41ecc295f4da.png)
