### PR TITLE
Updated icon and animation for selection controls

### DIFF
--- a/kivymd/uix/selectioncontrol.py
+++ b/kivymd/uix/selectioncontrol.py
@@ -256,7 +256,7 @@ class MDCheckbox(CircularRippleBehavior, ToggleButtonBehavior, MDIcon):
     representation when the checkbox is pressed.
 
     :attr:`checkbox_icon_down` is a :class:`~kivy.properties.StringProperty`
-    and defaults to `'checkbox-marked-outline'`.
+    and defaults to `'checkbox-marked'`.
     """
 
     radio_icon_normal = StringProperty("checkbox-blank-circle-outline")
@@ -274,7 +274,7 @@ class MDCheckbox(CircularRippleBehavior, ToggleButtonBehavior, MDIcon):
     the default graphical representation when the checkbox is pressed.
 
     :attr:`radio_icon_down` is a :class:`~kivy.properties.StringProperty`
-    and defaults to `'checkbox-marked-circle-outline'`.
+    and defaults to `'checkbox-marked-circle'`.
     """
 
     selected_color = ListProperty()

--- a/kivymd/uix/selectioncontrol.py
+++ b/kivymd/uix/selectioncontrol.py
@@ -250,7 +250,7 @@ class MDCheckbox(CircularRippleBehavior, ToggleButtonBehavior, MDIcon):
     and defaults to `'checkbox-blank-outline'`.
     """
 
-    checkbox_icon_down = StringProperty("checkbox-marked-outline")
+    checkbox_icon_down = StringProperty("checkbox-marked")
     """
     Background icon of the checkbox used for the default graphical
     representation when the checkbox is pressed.
@@ -268,7 +268,7 @@ class MDCheckbox(CircularRippleBehavior, ToggleButtonBehavior, MDIcon):
     and defaults to `'checkbox-blank-circle-outline'`.
     """
 
-    radio_icon_down = StringProperty("checkbox-marked-circle-outline")
+    radio_icon_down = StringProperty("checkbox-marked-circle")
     """
     Background icon (when using the ``group`` option) of the checkbox used for
     the default graphical representation when the checkbox is pressed.
@@ -365,7 +365,8 @@ class MDCheckbox(CircularRippleBehavior, ToggleButtonBehavior, MDIcon):
             self.active = True
         else:
             self.check_anim_in.cancel(self)
-            self.check_anim_out.start(self)
+            if not self.group:
+                self.check_anim_out.start(self)
             self.update_icon()
             self.active = False
 


### PR DESCRIPTION
### Description of Changes
* Updated `down` state icons for checkbox and radio buttons
* Removed unnecessary blinking animation from a radio button when it is unselected and another radio button is pressed. For radio buttons, now the blinking kind of animation is only shown when the state is changed to `down` i.e. when a button is activated and not when it is deactivated.

### Screenshots

![test_selection](https://user-images.githubusercontent.com/37111736/96544290-e54ec700-12c3-11eb-8172-0464e7064f0a.gif)

