### PR TITLE
Fix Swiper on_scroll_start AttributeError

### DIFF
--- a/kivymd/uix/swiper.py
+++ b/kivymd/uix/swiper.py
@@ -506,6 +506,10 @@ class MDSwiper(ScrollView, EventDispatcher):
             self.dispatch("on_swipe_right")
 
     def on_scroll_start(self, touch, check_children=True):
+
+        if platform in ["ios", "android"]:
+            return super().on_scroll_start(touch)
+
         # on touch pad events
         if touch.button == "scrollright":
             self.swipe_left()


### PR DESCRIPTION
### Description of Changes
```python
    def on_scroll_start(self, touch, check_children=True):
        # on touch pad events
        if touch.button == "scrollright":
            self.swipe_left()
        elif touch.button == "scrollleft":
            self.swipe_right()
        return super().on_scroll_start(touch)
```

`touch.button` will cause AttributeError exception on Android. Here is the fix. 