### PR TITLE
Fix MagicBehavior stop animations

### DIFF
--- a/kivymd/uix/behaviors/magic_behavior.py
+++ b/kivymd/uix/behaviors/magic_behavior.py
@@ -123,7 +123,6 @@ class MagicBehavior:
     def grow(self):
         """Grow effect animation."""
 
-        Animation.stop_all(self)
         (
             Animation(scale_x=1.2, scale_y=1.2, t="out_quad", d=0.03)
             + Animation(scale_x=1, scale_y=1, t="out_elastic", d=0.4)
@@ -132,7 +131,6 @@ class MagicBehavior:
     def shake(self):
         """Shake effect animation."""
 
-        Animation.stop_all(self)
         (
             Animation(translate_x=50, t="out_quad", d=0.02)
             + Animation(translate_x=0, t="out_elastic", d=0.5)
@@ -141,7 +139,6 @@ class MagicBehavior:
     def wobble(self):
         """Wobble effect animation."""
 
-        Animation.stop_all(self)
         (
             (
                 Animation(scale_y=0.7, t="out_quad", d=0.03)
@@ -156,7 +153,6 @@ class MagicBehavior:
     def twist(self):
         """Twist effect animation."""
 
-        Animation.stop_all(self)
         (
             Animation(rotate=25, t="out_quad", d=0.05)
             + Animation(rotate=0, t="out_elastic", d=0.5)
@@ -165,8 +161,11 @@ class MagicBehavior:
     def shrink(self):
         """Shrink effect animation."""
 
-        Animation.stop_all(self)
         Animation(scale_x=0.95, scale_y=0.95, t="out_quad", d=0.1).start(self)
+
+    def on_touch_up(self, *args):
+        Animation.stop_all(self)
+        return super().on_touch_up(*args)
 
 
 Factory.register("MagicBehavior", cls=MagicBehavior)


### PR DESCRIPTION
### Description of Changes
Issue: Button colors does not get back to normal when using MagicBehavior.

### Screenshots

![ezgif com-video-to-gif(3)](https://user-images.githubusercontent.com/55235027/97080619-924d7a80-1609-11eb-9750-4c8afb448481.gif)
