### PR TITLE
Revert "Fix #605"

### DIFF
--- a/kivymd/uix/behaviors/ripplebehavior.py
+++ b/kivymd/uix/behaviors/ripplebehavior.py
@@ -201,7 +201,6 @@ class CommonRipple(object):
     _finishing_ripple = BooleanProperty(False)
     _fading_out = BooleanProperty(False)
     _no_ripple_effect = BooleanProperty(False)
-    _canvas_after_loaded = False
 
     def lay_canvas_instructions(self):
         raise NotImplementedError
@@ -248,6 +247,7 @@ class CommonRipple(object):
         self._doing_ripple = False
         self._finishing_ripple = False
         self._fading_out = False
+        self.canvas.after.clear()
 
     def on_touch_down(self, touch):
         if touch.is_mouse_scrolling:
@@ -316,10 +316,6 @@ class RectangularRippleBehavior(CommonRipple):
     def lay_canvas_instructions(self):
         if self._no_ripple_effect:
             return
-
-        if self._canvas_after_loaded:
-            return
-
         with self.canvas.after:
             StencilPush()
             Rectangle(pos=self.pos, size=self.size)
@@ -336,7 +332,6 @@ class RectangularRippleBehavior(CommonRipple):
             Rectangle(pos=self.pos, size=self.size)
             StencilPop()
         self.bind(ripple_color=self._set_color, _ripple_rad=self._set_ellipse)
-        self._canvas_after_loaded = True
 
     def _set_ellipse(self, instance, value):
         super()._set_ellipse(instance, value)
@@ -360,10 +355,6 @@ class CircularRippleBehavior(CommonRipple):
     def lay_canvas_instructions(self):
         if self._no_ripple_effect:
             return
-
-        if self._canvas_after_loaded:
-            return
-
         with self.canvas.after:
             StencilPush()
             self.stencil = Ellipse(
@@ -391,7 +382,6 @@ class CircularRippleBehavior(CommonRipple):
             self.bind(
                 ripple_color=self._set_color, _ripple_rad=self._set_ellipse
             )
-        self._canvas_after_loaded = True
 
     def _set_ellipse(self, instance, value):
         super()._set_ellipse(instance, value)


### PR DESCRIPTION
This reverts commit 7db49dcae5a32511bc3603f1be6d1a4ceee72e38.

### Description of Changes
After more investigations i noticed this fix breaks some other parts of the ripplebehavior. Not clearing canvas.after will make issues when trying to resize the screen. Reverting this commit is better idea until i find a proper fix. 