### PR TITLE
Add Theming Colors screen to Kitchen Sink demo

### DIFF
--- a/demos/kitchen_sink/libs/baseclass/theming_colors.py
+++ b/demos/kitchen_sink/libs/baseclass/theming_colors.py
@@ -1,0 +1,55 @@
+from kivy.properties import BooleanProperty, ColorProperty, StringProperty
+from kivy.uix.screenmanager import Screen
+from kivy.utils import rgba
+
+from kivymd.color_definitions import colors as _colors
+from kivymd.color_definitions import text_colors
+from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.tab import MDTabsBase
+
+
+class KitchenSinkThemingColors(Screen):
+    def on_enter(self):
+        for color in _colors.keys():
+            tab_widget = KitchenSinkThemeTab(text=str(color))
+            self.ids.tabs_manager.add_widget(tab_widget)
+
+    def on_tab_switch(
+        self,
+        instance_tab_manager,
+        instance_android_tabs,
+        instance_tab_label,
+        tab_label_text,
+    ):
+        if not instance_android_tabs.colors_loaded:
+            for hue in _colors[tab_label_text]:
+                color = _colors[tab_label_text][hue]
+                if tab_label_text == "Light":
+                    text_color = (0, 0, 0, 1)
+                elif tab_label_text == "Dark":
+                    text_color = (1, 1, 1, 1)
+                else:
+                    text_color = text_colors[tab_label_text][hue]
+                color_widget = {
+                    "rgba_color": rgba(color),
+                    "hex_color": color,
+                    "hue_color": hue,
+                    "text_color": text_color,
+                }
+                instance_android_tabs.rv.data.append(color_widget)
+            instance_android_tabs.colors_loaded = True
+
+
+class KitchenSinkColorWidget(MDBoxLayout):
+    rgba_color = ColorProperty()
+    text_color = ColorProperty()
+    hex_color = StringProperty()
+    hue_color = StringProperty()
+
+
+class KitchenSinkThemeTab(MDBoxLayout, MDTabsBase):
+    colors_loaded = BooleanProperty(False)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.orientation = "vertical"

--- a/demos/kitchen_sink/libs/kv/theming_colors.kv
+++ b/demos/kitchen_sink/libs/kv/theming_colors.kv
@@ -1,0 +1,47 @@
+<KitchenSinkThemingColors>:
+    name: 'theming colors'
+    tabs_manager: tabs_manager
+
+    BoxLayout:
+        orientation: "vertical"
+
+        Toolbar:
+            id: toolbar
+
+        MDTabs:
+            id: tabs_manager
+            tab_indicator_anim: True
+            background_color: self.theme_cls.primary_color
+            on_tab_switch: root.on_tab_switch(*args)
+
+
+<KitchenSinkColorWidget>:
+    padding: dp(15)
+    md_bg_color: root.rgba_color
+
+    KitchenSinkColorLabel:
+        text: root.hue_color
+        halign: 'left'
+        text_color: root.text_color
+
+    KitchenSinkColorLabel:
+        text: '#' + root.hex_color
+        halign: 'right'
+        text_color: root.text_color
+
+
+<KitchenSinkColorLabel@MDLabel>
+    pos_hint: {'center_y': .3}
+    theme_text_color: 'Custom'
+
+<KitchenSinkThemeTab>:
+    rv: rv
+    RecycleView:
+        id: rv
+        viewclass: "KitchenSinkColorWidget"
+
+        RecycleBoxLayout:
+            orientation: 'vertical'
+            size_hint_y: None
+            height: self.minimum_height
+            default_size_hint: 1, None

--- a/demos/kitchen_sink/screens_data.json
+++ b/demos/kitchen_sink/screens_data.json
@@ -79,6 +79,14 @@
       'object': 0,
       'icon': 'refresh'
   },
+  'Theming Colors': {
+    'kv_string': 'theming_colors',
+    'Import': 'from libs.baseclass.theming_colors import KitchenSinkThemingColors',
+    'Factory': 'KitchenSinkThemingColors()',
+    'name_screen': 'theming colors',
+    'object': 0,
+    'icon': 'format-color-fill'
+  },
   'Button Speed Dial': {
       'kv_string': 'stack_buttons',
       'Import': 'from libs.baseclass.stack_buttons import KitchenSinkStackButtons',


### PR DESCRIPTION
### Description of Changes
added theming_colors screen in demo for show that what colors have can be use in `KivyMD`


### Screenshots
![theming](https://user-images.githubusercontent.com/63696279/98081684-91d0a180-1e9d-11eb-89cc-1aab243762e9.gif)

