### PR TITLE
Added width_offset property in MDDialog

### DIFF
--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -421,7 +421,7 @@ class MDDialog(BaseDialog):
     :attr:`items` is an :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
-    
+
     width_offset = NumericProperty(dp(48))
     """
     Dialog offset from device width.

--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -421,6 +421,14 @@ class MDDialog(BaseDialog):
     :attr:`items` is an :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
+    
+    width_offset = NumericProperty(dp(48))
+    """
+    Dialog offset from device width.
+
+    :attr:`width_offset` is an :class:`~kivy.properties.NumericProperty`
+    and defaults to `dp(48)`.
+    """
 
     type = OptionProperty(
         "alert", options=["alert", "simple", "confirmation", "custom"]
@@ -527,10 +535,10 @@ class MDDialog(BaseDialog):
 
         if self.size_hint == [1, 1] and DEVICE_TYPE == "mobile":
             self.size_hint = (None, None)
-            self.width = min(dp(280), Window.width - dp(48))
+            self.width = min(dp(280), Window.width - self.width_offset)
         elif self.size_hint == [1, 1] and DEVICE_TYPE == "desktop":
             self.size_hint = (None, None)
-            self.width = min(dp(560), Window.width - dp(48))
+            self.width = min(dp(560), Window.width - self.width_offset)
 
         if not self.title:
             self._spacer_top = 0
@@ -561,10 +569,10 @@ class MDDialog(BaseDialog):
 
     def update_width(self, *args):
         self.width = max(
-            self.height + dp(48),
+            self.height + self.width_offset,
             min(
                 dp(560) if DEVICE_TYPE == "desktop" else dp(280),
-                Window.width - dp(48),
+                Window.width - self.width_offset,
             ),
         )
 


### PR DESCRIPTION
Now user can customize the Dialog offset from the device width.
Fix for #631

### Screenshots
offset: dp(24)
![Screenshot from 2020-11-08 23-07-59](https://user-images.githubusercontent.com/37111736/98472390-d13e1b80-2218-11eb-89c7-98cbe297cc76.png)

offset: dp(48)
![Screenshot from 2020-11-08 23-08-26](https://user-images.githubusercontent.com/37111736/98472391-d307df00-2218-11eb-88e9-e1ddce8fbc2c.png)

