### PR TITLE
setup.cfg: use ansi charset

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = kivymd
 description = Set of widgets for Kivy inspired by Google's Material Design
-author = Andrés Rodríguez, fork author - HeaTTheatR
+author = Andres Rodriguez, fork author - HeaTTheatR
 author_email = kivydevelopment@gmail.com
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8


### PR DESCRIPTION
This fixes an installation issue with python 3.6.9 under linux (on an ARM processor, with a jetson machine).

Sadly, it seems that pip for python 3.6.9 does not support charset other than ansi.

### Description of Changes

Removed non ansi characters in setup.cfg

Full install output without this patch:

````
kivy_venv) ➜  KivyMD git:(master) pip install .
Processing /home/tecbak/dvp/fs_ai_gui/external/KivyMD
  Installing build dependencies ... error
  ERROR: Command errored out with exit status 2:
   command: /home/tecbak/dvp/fs_ai_gui/kivy_venv/bin/python /home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-m1vqylbg/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel
       cwd: None
  Complete output (32 lines):
  Collecting setuptools>=40.8.0
    Using cached setuptools-50.3.2-py3-none-any.whl (785 kB)
  Collecting wheel
    Using cached wheel-0.35.1-py2.py3-none-any.whl (33 kB)
  Installing collected packages: setuptools, wheel
  ERROR: Exception:
  Traceback (most recent call last):
    File "/home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip/_internal/cli/base_command.py", line 228, in _main
      status = self.run(options, args)
    File "/home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip/_internal/cli/req_command.py", line 182, in wrapper
[metadata]
      return func(self, options, args)
    File "/home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip/_internal/commands/install.py", line 406, in run
      pycompile=options.compile,
    File "/home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip/_internal/req/__init__.py", line 90, in install_given_reqs
      pycompile=pycompile,
    File "/home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip/_internal/req/req_install.py", line 785, in install
      prefix=prefix,
    File "/home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip/_internal/locations.py", line 186, in get_scheme
      dist_name, user, home, root, isolated, prefix
    File "/home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip/_internal/locations.py", line 109, in distutils_scheme
      d.parse_config_files()
    File "/home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/_virtualenv.py", line 21, in parse_config_files
      result = old_parse_config_files(self, *args, **kwargs)
    File "/usr/lib/python3.6/distutils/dist.py", line 395, in parse_config_files
      parser.read(filename)
    File "/usr/lib/python3.6/configparser.py", line 697, in read
      self._read(fp, filename)
    File "/usr/lib/python3.6/configparser.py", line 1015, in _read
      for lineno, line in enumerate(fp, start=1):
    File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
      return codecs.ascii_decode(input, self.errors)[0]
  UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 113: ordinal not in range(128)
  ----------------------------------------
ERROR: Command errored out with exit status 2: /home/tecbak/dvp/fs_ai_gui/kivy_venv/bin/python /home/tecbak/dvp/fs_ai_gui/kivy_venv/lib/python3.6/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-m1vqylbg/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel Check the logs for full command output.
````

