### PR TITLE
Docs: fix typo in button docs

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1413,7 +1413,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
 
     right_pad = BooleanProperty(True)
     """
-    If `True`, the button will increase on the right side by 2.5 piesels
+    If `True`, the button will increase on the right side by 2.5 pixels
     if the :attr:`~hint_animation` parameter equal to `True`.
 
     .. rubric:: False


### PR DESCRIPTION
### Description of Changes
* Just fixed a minor typo that I saw while going over the documentation
