### PR TITLE
Fix modalview dimming on kivy version 2.0.0

### DIFF
--- a/kivymd/toast/kivytoast/kivytoast.py
+++ b/kivymd/toast/kivytoast/kivytoast.py
@@ -82,6 +82,7 @@ class Toast(ModalView):
         self.size_hint = (None, None)
         self.pos_hint = {"center_x": 0.5, "center_y": 0.1}
         self.background_color = [0, 0, 0, 0]
+        self.overlay_color = [0, 0, 0, 0]
         self.background = f"{images_path}transparent.png"
         self.opacity = 0
         self.auto_dismiss = True


### PR DESCRIPTION
### Description of Changes
Modalview's `background_color` property has been changed to `overlay_color` in version 2.0.0

### Screenshots

toast in version 1.11.1
![ezgif com-video-to-gif(6)](https://user-images.githubusercontent.com/55235027/99724980-afbb1a80-2ac9-11eb-93f6-9f821f8d4d6d.gif)


toast in version 2.0.0.rc4
![ezgif com-video-to-gif(5)](https://user-images.githubusercontent.com/55235027/99724892-8bf7d480-2ac9-11eb-9b2d-b02e09b361f5.gif)
