### PR TITLE
 fix NameError: name 'Factory' is not defined on line 97.

### DIFF
--- a/demos/kitchen_sink/main.py
+++ b/demos/kitchen_sink/main.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 from kivy.core.window import Window
+from kivy.factory import Factory
 from kivy.lang import Builder
 from kivy.loader import Loader
 from libs.baseclass.dialog_change_theme import (


### PR DESCRIPTION
Fix name error on line 97 because when you are using eval, some libraries are not imported.

I think pycharm removes unused import on optimize imports, and it won't care if you are using `eval()`.

### Description of Changes
* add an import

