### PR TITLE
#754

### DIFF
--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -861,6 +861,7 @@ class ThemeManager(EventDispatcher):
         Clock.schedule_once(lambda x: self.on_theme_style(0, self.theme_style))
         self._determine_device_orientation(None, Window.size)
         Window.bind(size=self._determine_device_orientation)
+        self.colors = colors
 
 
 class ThemableBehavior(EventDispatcher):

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -32,8 +32,8 @@ However, if you do need to change the standard colors, for instance to meet bran
 guidelines, you can do this by overloading the `color_definitions.py` object.
 
 * Create a custom copy of `color_definitions.py`,
-* Change the color codes in `colors` object in your custum `color_definitions.py`
-file as required. Note that you *cannot* change the names of the colors, you can only
+* Change the color codes in the `colors` object in your custum `color_definitions.py`
+file as required. Note that you *can not* change the names of the colors, you can only
 change the values. That is say, for instance, you cannot change the name of `Blue` and
 you cannot add `NavyBlue` but you change the value of the color blue to meet your
 requirements.

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -30,6 +30,7 @@ from kivy.metrics import dp
 from kivy.properties import (
     AliasProperty,
     BooleanProperty,
+    ColorProperty,
     DictProperty,
     ObjectProperty,
     OptionProperty,

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -274,7 +274,9 @@ class ThemeManager(EventDispatcher):
     """
 
     def _get_accent_color(self):
-        return get_color_from_hex(self.colors[self.accent_palette][self.accent_hue])
+        return get_color_from_hex(
+            self.colors[self.accent_palette][self.accent_hue]
+        )
 
     accent_color = AliasProperty(
         _get_accent_color, bind=["accent_palette", "accent_hue"]

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -31,25 +31,116 @@ We do not recommend that you change this.
 However, if you do need to change the standard colors, for instance to meet branding
 guidelines, you can do this by overloading the `color_definitions.py` object.
 
-* Create a custom copy of `color_definitions.py`,
-* Change the color codes in the `colors` object in your custum `color_definitions.py`
-file as required. Note that you *can not* change the names of the colors, you can only
-change the values. That is say, for instance, you cannot change the name of `Blue` and
-you cannot add `NavyBlue` but you change the value of the color blue to meet your
-requirements.
-* Import the custom colors into your module and do something like this (where the custom
-version of `color_defintions.py` is called `custom_palette.py`):
+* Create a custom color defintion object. This should have the format of the `colors 
+<https://kivymd.readthedocs.io/en/latest/themes/color-definitions/#module-kivymd.color_definitions>`_
+object in `color_definitions.py` and contain definitions for at least the primary color, the accent
+color and the Light and Dark backgrounds. *Note* - your custom colors *must* use the names of the
+`existing colors as defined in the palette
+<https://kivymd.readthedocs.io/en/latest/themes/color-definitions/#kivymd.color_definitions.palette>`_
+You can have `Blue` but you cannot have `NavyBlue`. An example is shown in the code snippet
+below.
+
+* Add the custom theme to the MDApp as shown in the following snippet.
 
 .. code-block:: python
 
-    from custom_palette import colors
+    from kivy.lang import Builder
+from kivy.uix.floatlayout import FloatLayout
+from kivy.properties import ObjectProperty
 
-    class Example(MDApp):
-        icons = list(md_icons.keys())[15:30]
+from kivymd.app import MDApp
+from kivymd.uix.tab import MDTabsBase
+from kivymd.icon_definitions import md_icons
 
-        def __init__(self, **kwargs):
-            super(Example, self).__init__(**kwargs)
-            self.theme_cls.colors = colors
+colors = {
+    "Teal": {
+        "50": "e4f8f9",
+        "100": "bdedf0",
+        "200": "97e2e8",
+        "300": "79d5de",
+        "400": "6dcbd6",
+        "500": "6ac2cf",
+        "600": "63b2bc",
+        "700": "5b9ca3",
+        "800": "54888c",
+        "900": "486363",
+        "A100": "bdedf0",
+        "A200": "97e2e8",
+        "A400": "6dcbd6",
+        "A700": "5b9ca3",
+    },
+    "Blue": {
+        "50": "e3f3f8",
+        "100": "b9e1ee",
+        "200": "91cee3",
+        "300": "72bad6",
+        "400": "62acce",
+        "500": "589fc6",
+        "600": "5191b8",
+        "700": "487fa5",
+        "800": "426f91",
+        "900": "35506d",
+        "A100": "b9e1ee",
+        "A200": "91cee3",
+        "A400": "62acce",
+        "A700": "487fa5",
+    },
+    "Light": {
+        "StatusBar": "E0E0E0",
+        "AppBar": "F5F5F5",
+        "Background": "FAFAFA",
+        "CardsDialogs": "FFFFFF",
+        "FlatButtonDown": "cccccc",
+    },
+    "Dark": {
+        "StatusBar": "000000",
+        "AppBar": "212121",
+        "Background": "303030",
+        "CardsDialogs": "424242",
+        "FlatButtonDown": "999999",
+    }
+}
+
+
+KV = '''
+
+BoxLayout:
+    orientation: "vertical"
+    MDToolbar:
+        title: "Example Tabs"
+    MDTabs:
+        id: tabs
+
+
+<Tab>:
+
+    MDIconButton:
+        id: icon
+        icon: root.icon
+        user_font_size: "48sp"
+        pos_hint: {"center_x": .5, "center_y": .5}
+
+class Tab(FloatLayout, MDTabsBase):
+    '''Class implementing content for a tab.'''
+    icon = ObjectProperty()
+
+
+class Example(MDApp):
+    icons = list(md_icons.keys())[15:30]
+
+    def build(self):
+        self.theme_cls.colors = colors
+        self.theme_cls.primary_palette = "Blue"
+        self.theme_cls.accent_palette = "Teal"
+        return Builder.load_string(KV)
+
+    def on_start(self):
+        for name_tab in self.icons:
+            tab = Tab(text="This is " + name_tab, icon=name_tab)
+            self.root.ids.tabs.add_widget(tab)
+
+Example().run()
+```
 
 This will change the theme colors to your custom defintion. In all other respects,
 the theming stays as documented.

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -152,7 +152,7 @@ class ThemeManager(EventDispatcher):
 
     def _get_primary_color(self):
         return get_color_from_hex(
-            colors[self.primary_palette][self.primary_hue]
+            self.colors[self.primary_palette][self.primary_hue]
         )
 
     primary_color = AliasProperty(
@@ -167,7 +167,7 @@ class ThemeManager(EventDispatcher):
 
     def _get_primary_light(self):
         return get_color_from_hex(
-            colors[self.primary_palette][self.primary_light_hue]
+            self.colors[self.primary_palette][self.primary_light_hue]
         )
 
     primary_light = AliasProperty(
@@ -221,7 +221,7 @@ class ThemeManager(EventDispatcher):
 
     def _get_primary_dark(self):
         return get_color_from_hex(
-            colors[self.primary_palette][self.primary_dark_hue]
+            self.colors[self.primary_palette][self.primary_dark_hue]
         )
 
     primary_dark = AliasProperty(
@@ -275,7 +275,7 @@ class ThemeManager(EventDispatcher):
     """
 
     def _get_accent_color(self):
-        return get_color_from_hex(colors[self.accent_palette][self.accent_hue])
+        return get_color_from_hex(self.colors[self.accent_palette][self.accent_hue])
 
     accent_color = AliasProperty(
         _get_accent_color, bind=["accent_palette", "accent_hue"]
@@ -290,7 +290,7 @@ class ThemeManager(EventDispatcher):
 
     def _get_accent_light(self):
         return get_color_from_hex(
-            colors[self.accent_palette][self.accent_light_hue]
+            self.colors[self.accent_palette][self.accent_light_hue]
         )
 
     accent_light = AliasProperty(
@@ -306,7 +306,7 @@ class ThemeManager(EventDispatcher):
 
     def _get_accent_dark(self):
         return get_color_from_hex(
-            colors[self.accent_palette][self.accent_dark_hue]
+            self.colors[self.accent_palette][self.accent_dark_hue]
         )
 
     accent_dark = AliasProperty(
@@ -362,9 +362,9 @@ class ThemeManager(EventDispatcher):
     def _get_bg_darkest(self, opposite=False):
         theme_style = self._get_theme_style(opposite)
         if theme_style == "Light":
-            return get_color_from_hex(colors["Light"]["StatusBar"])
+            return get_color_from_hex(self.colors["Light"]["StatusBar"])
         elif theme_style == "Dark":
-            return get_color_from_hex(colors["Dark"]["StatusBar"])
+            return get_color_from_hex(self.colors["Dark"]["StatusBar"])
 
     bg_darkest = AliasProperty(_get_bg_darkest, bind=["theme_style"])
     """
@@ -433,9 +433,9 @@ class ThemeManager(EventDispatcher):
     def _get_bg_dark(self, opposite=False):
         theme_style = self._get_theme_style(opposite)
         if theme_style == "Light":
-            return get_color_from_hex(colors["Light"]["AppBar"])
+            return get_color_from_hex(self.colors["Light"]["AppBar"])
         elif theme_style == "Dark":
-            return get_color_from_hex(colors["Dark"]["AppBar"])
+            return get_color_from_hex(self.colors["Dark"]["AppBar"])
 
     bg_dark = AliasProperty(_get_bg_dark, bind=["theme_style"])
     """
@@ -462,9 +462,9 @@ class ThemeManager(EventDispatcher):
     def _get_bg_normal(self, opposite=False):
         theme_style = self._get_theme_style(opposite)
         if theme_style == "Light":
-            return get_color_from_hex(colors["Light"]["Background"])
+            return get_color_from_hex(self.colors["Light"]["Background"])
         elif theme_style == "Dark":
-            return get_color_from_hex(colors["Dark"]["Background"])
+            return get_color_from_hex(self.colors["Dark"]["Background"])
 
     bg_normal = AliasProperty(_get_bg_normal, bind=["theme_style"])
     """
@@ -491,9 +491,9 @@ class ThemeManager(EventDispatcher):
     def _get_bg_light(self, opposite=False):
         theme_style = self._get_theme_style(opposite)
         if theme_style == "Light":
-            return get_color_from_hex(colors["Light"]["CardsDialogs"])
+            return get_color_from_hex(self.colors["Light"]["CardsDialogs"])
         elif theme_style == "Dark":
-            return get_color_from_hex(colors["Dark"]["CardsDialogs"])
+            return get_color_from_hex(self.colors["Dark"]["CardsDialogs"])
 
     bg_light = AliasProperty(_get_bg_light, bind=["theme_style"])
     """"
@@ -690,7 +690,7 @@ class ThemeManager(EventDispatcher):
 
     # Hardcoded because muh standard
     def _get_error_color(self):
-        return get_color_from_hex(colors["Red"]["A700"])
+        return get_color_from_hex(self.colors["Red"]["A700"])
 
     error_color = AliasProperty(_get_error_color)
     """
@@ -783,7 +783,7 @@ class ThemeManager(EventDispatcher):
         if not self.set_clearcolor:
             return
         Window.clearcolor = get_color_from_hex(
-            colors[theme_style]["Background"]
+            self.colors[theme_style]["Background"]
         )
 
     # font name, size (sp), always caps, letter spacing (sp)

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -31,7 +31,7 @@ We do not recommend that you change this.
 However, if you do need to change the standard colors, for instance to meet branding
 guidelines, you can do this by overloading the `color_definitions.py` object.
 
-* Create a custom color defintion object. This should have the format of the `colors 
+* Create a custom color defintion object. This should have the format of the `colors
 <https://kivymd.readthedocs.io/en/latest/themes/color-definitions/#module-kivymd.color_definitions>`_
 object in `color_definitions.py` and contain definitions for at least the primary color, the accent
 color and the Light and Dark backgrounds. *Note* - your custom colors *must* use the names of the

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -30,7 +30,6 @@ from kivy.metrics import dp
 from kivy.properties import (
     AliasProperty,
     BooleanProperty,
-    ColorProperty,
     DictProperty,
     ObjectProperty,
     OptionProperty,
@@ -40,7 +39,6 @@ from kivy.utils import get_color_from_hex
 
 from kivymd import images_path
 from kivymd.color_definitions import colors, hue, palette
-from kivymd.font_definitions import theme_font_styles  # NOQA: F401
 from kivymd.material_resources import DEVICE_IOS, DEVICE_TYPE
 
 

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -45,101 +45,101 @@ below.
 .. code-block:: python
 
     from kivy.lang import Builder
-from kivy.uix.floatlayout import FloatLayout
-from kivy.properties import ObjectProperty
+    from kivy.uix.floatlayout import FloatLayout
+    from kivy.properties import ObjectProperty
 
-from kivymd.app import MDApp
-from kivymd.uix.tab import MDTabsBase
-from kivymd.icon_definitions import md_icons
+    from kivymd.app import MDApp
+    from kivymd.uix.tab import MDTabsBase
+    from kivymd.icon_definitions import md_icons
 
-colors = {
-    "Teal": {
-        "50": "e4f8f9",
-        "100": "bdedf0",
-        "200": "97e2e8",
-        "300": "79d5de",
-        "400": "6dcbd6",
-        "500": "6ac2cf",
-        "600": "63b2bc",
-        "700": "5b9ca3",
-        "800": "54888c",
-        "900": "486363",
-        "A100": "bdedf0",
-        "A200": "97e2e8",
-        "A400": "6dcbd6",
-        "A700": "5b9ca3",
-    },
-    "Blue": {
-        "50": "e3f3f8",
-        "100": "b9e1ee",
-        "200": "91cee3",
-        "300": "72bad6",
-        "400": "62acce",
-        "500": "589fc6",
-        "600": "5191b8",
-        "700": "487fa5",
-        "800": "426f91",
-        "900": "35506d",
-        "A100": "b9e1ee",
-        "A200": "91cee3",
-        "A400": "62acce",
-        "A700": "487fa5",
-    },
-    "Light": {
-        "StatusBar": "E0E0E0",
-        "AppBar": "F5F5F5",
-        "Background": "FAFAFA",
-        "CardsDialogs": "FFFFFF",
-        "FlatButtonDown": "cccccc",
-    },
-    "Dark": {
-        "StatusBar": "000000",
-        "AppBar": "212121",
-        "Background": "303030",
-        "CardsDialogs": "424242",
-        "FlatButtonDown": "999999",
+    colors = {
+        "Teal": {
+            "50": "e4f8f9",
+            "100": "bdedf0",
+            "200": "97e2e8",
+            "300": "79d5de",
+            "400": "6dcbd6",
+            "500": "6ac2cf",
+            "600": "63b2bc",
+            "700": "5b9ca3",
+            "800": "54888c",
+            "900": "486363",
+            "A100": "bdedf0",
+            "A200": "97e2e8",
+            "A400": "6dcbd6",
+            "A700": "5b9ca3",
+        },
+        "Blue": {
+            "50": "e3f3f8",
+            "100": "b9e1ee",
+            "200": "91cee3",
+            "300": "72bad6",
+            "400": "62acce",
+            "500": "589fc6",
+            "600": "5191b8",
+            "700": "487fa5",
+            "800": "426f91",
+            "900": "35506d",
+            "A100": "b9e1ee",
+            "A200": "91cee3",
+            "A400": "62acce",
+            "A700": "487fa5",
+        },
+        "Light": {
+            "StatusBar": "E0E0E0",
+            "AppBar": "F5F5F5",
+            "Background": "FAFAFA",
+            "CardsDialogs": "FFFFFF",
+            "FlatButtonDown": "cccccc",
+        },
+        "Dark": {
+            "StatusBar": "000000",
+            "AppBar": "212121",
+            "Background": "303030",
+            "CardsDialogs": "424242",
+            "FlatButtonDown": "999999",
+        }
     }
-}
 
 
-KV = '''
+    KV = '''
 
-BoxLayout:
-    orientation: "vertical"
-    MDToolbar:
-        title: "Example Tabs"
-    MDTabs:
-        id: tabs
-
-
-<Tab>:
-
-    MDIconButton:
-        id: icon
-        icon: root.icon
-        user_font_size: "48sp"
-        pos_hint: {"center_x": .5, "center_y": .5}
-
-class Tab(FloatLayout, MDTabsBase):
-    '''Class implementing content for a tab.'''
-    icon = ObjectProperty()
+    BoxLayout:
+        orientation: "vertical"
+        MDToolbar:
+            title: "Example Tabs"
+        MDTabs:
+            id: tabs
 
 
-class Example(MDApp):
-    icons = list(md_icons.keys())[15:30]
+    <Tab>:
 
-    def build(self):
-        self.theme_cls.colors = colors
-        self.theme_cls.primary_palette = "Blue"
-        self.theme_cls.accent_palette = "Teal"
-        return Builder.load_string(KV)
+        MDIconButton:
+            id: icon
+            icon: root.icon
+            user_font_size: "48sp"
+            pos_hint: {"center_x": .5, "center_y": .5}
 
-    def on_start(self):
-        for name_tab in self.icons:
-            tab = Tab(text="This is " + name_tab, icon=name_tab)
-            self.root.ids.tabs.add_widget(tab)
+    class Tab(FloatLayout, MDTabsBase):
+        '''Class implementing content for a tab.'''
+        icon = ObjectProperty()
 
-Example().run()
+
+    class Example(MDApp):
+        icons = list(md_icons.keys())[15:30]
+
+        def build(self):
+            self.theme_cls.colors = colors
+            self.theme_cls.primary_palette = "Blue"
+            self.theme_cls.accent_palette = "Teal"
+            return Builder.load_string(KV)
+
+        def on_start(self):
+            for name_tab in self.icons:
+                tab = Tab(text="This is " + name_tab, icon=name_tab)
+                self.root.ids.tabs.add_widget(tab)
+
+    Example().run()
 ```
 
 This will change the theme colors to your custom defintion. In all other respects,

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -19,6 +19,42 @@ Control material properties
 
 The main application class inherited from the `MDApp` class has the :attr:`theme_cls`
 attribute, with which you control the material properties of your application.
+
+Changing the theme colors
+-------------------------
+
+The standard theme_cls is designed to provide the standard themes and colors as
+defined by Material Design.
+
+We do not recommend that you change this.
+
+However, if you do need to change the standard colors, for instance to meet branding
+guidelines, you can do this by overloading the `color_definitions.py` object.
+
+* Create a custom copy of `color_definitions.py`,
+* Change the color codes in `colors` object in your custum `color_definitions.py`
+file as required. Note that you *cannot* change the names of the colors, you can only
+change the values. That is say, for instance, you cannot change the name of `Blue` and
+you cannot add `NavyBlue` but you change the value of the color blue to meet your 
+requirements.
+* Import the custom colors into your module and do something like this (where the custom 
+version of `color_defintions.py` is called `custom_palette.py`):
+
+.. code-block:: python
+
+    from custom_palette import colors
+
+    class Example(MDApp):
+        icons = list(md_icons.keys())[15:30]
+
+        def __init__(self, **kwargs):
+            super(Example, self).__init__(**kwargs)
+            self.theme_cls.colors = colors
+
+This will change the theme colors to your custom defintion. In all other respects,
+the theming stays as documented.
+
+
 """
 
 from kivy.app import App

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -35,9 +35,9 @@ guidelines, you can do this by overloading the `color_definitions.py` object.
 * Change the color codes in `colors` object in your custum `color_definitions.py`
 file as required. Note that you *cannot* change the names of the colors, you can only
 change the values. That is say, for instance, you cannot change the name of `Blue` and
-you cannot add `NavyBlue` but you change the value of the color blue to meet your 
+you cannot add `NavyBlue` but you change the value of the color blue to meet your
 requirements.
-* Import the custom colors into your module and do something like this (where the custom 
+* Import the custom colors into your module and do something like this (where the custom
 version of `color_defintions.py` is called `custom_palette.py`):
 
 .. code-block:: python

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -569,7 +569,7 @@ Builder.load_string(
             ignore_perpendicular_swipes: True
             anim_move_duration: root.anim_duration
             on_index: root.on_carousel_index(*args)
-            on__offset: tab_bar.android_animation(*args)            
+            on__offset: tab_bar.android_animation(*args)
             on_slides:
                 self.index = root.default_tab
                 root.on_carousel_index(self, 0)

--- a/kivymd/uix/taptargetview.py
+++ b/kivymd/uix/taptargetview.py
@@ -234,7 +234,6 @@ from kivy.logger import Logger
 from kivy.metrics import dp
 from kivy.properties import (
     BooleanProperty,
-    ColorProperty,
     ListProperty,
     NumericProperty,
     ObjectProperty,


### PR DESCRIPTION
### Description of Changes
Changes to allow the palette colors to be overridden as discussed in #754 

Change `colors` in `ThemeManager` to `self.colors` and default to the standard palette.

To create custom colors, create your version of `color_definitions.py` and change one of the existing color definitions (it has to be one of the existing ones because the palette color names are hard coded.


