### PR TITLE
Fix Docs

### DIFF
--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -708,7 +708,7 @@ class ThemeManager(EventDispatcher):
     def _set_ripple_color(self, value):
         self._ripple_color = value
 
-    _ripple_color = ColorProperty(get_color_from_hex(colors["Gray"]["400"]))
+    _ripple_color = ColorProperty(colors["Gray"]["400"])
     """Private value."""
 
     ripple_color = AliasProperty(

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -731,7 +731,7 @@ class ThemeManager(EventDispatcher):
     """
     Device orientation.
 
-    :attr:`device_orientation` is an :class:`~kivy.properties.StringProperty`.
+    :attr:`device_orientation` is a :class:`~kivy.properties.StringProperty`.
     """
 
     def _get_standard_increment(self):
@@ -848,7 +848,7 @@ class ThemeManager(EventDispatcher):
 
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/font-styles.png
 
-    :attr:`font_styles` is an :class:`~kivy.properties.DictProperty`.
+    :attr:`font_styles` is a :class:`~kivy.properties.DictProperty`.
     """
 
     def __init__(self, **kwargs):
@@ -874,7 +874,7 @@ class ThemableBehavior(EventDispatcher):
     """
     ``True`` if device is ``iOS``.
 
-    :attr:`device_ios` is an :class:`~kivy.properties.BooleanProperty`.
+    :attr:`device_ios` is a :class:`~kivy.properties.BooleanProperty`.
     """
 
     opposite_colors = BooleanProperty(False)

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -727,7 +727,7 @@ class ThemeManager(EventDispatcher):
         elif window_size[1] >= window_size[0]:
             self.device_orientation = "portrait"
 
-    device_orientation = StringProperty("")
+    device_orientation = StringProperty()
     """
     Device orientation.
 

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -40,7 +40,6 @@ from kivy.utils import get_color_from_hex
 
 from kivymd import images_path
 from kivymd.color_definitions import colors, hue, palette
-from kivymd.font_definitions import theme_font_styles  # NOQA: F401
 from kivymd.material_resources import DEVICE_IOS, DEVICE_TYPE
 
 

--- a/kivymd/toast/kivytoast/kivytoast.py
+++ b/kivymd/toast/kivytoast/kivytoast.py
@@ -72,7 +72,7 @@ class Toast(BaseDialog):
     """
     The amount of time (in seconds) that the toast is visible on the screen.
 
-    :attr:`duration` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`duration` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `2.5`.
     """
 

--- a/kivymd/uix/backdrop.py
+++ b/kivymd/uix/backdrop.py
@@ -218,7 +218,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     """
     Padding for contents of the front layer.
 
-    :attr:`padding` is an :class:`~kivy.properties.ListProperty`
+    :attr:`padding` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[0, 0, 0, 0]`.
     """
 
@@ -228,7 +228,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     in back layer. For more information, see the :class:`kivymd.uix.toolbar.MDToolbar` module
     and :attr:`left_action_items` parameter.
 
-    :attr:`left_action_items` is an :class:`~kivy.properties.ListProperty`
+    :attr:`left_action_items` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -236,7 +236,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     """
     Works the same way as :attr:`left_action_items`.
 
-    :attr:`right_action_items` is an :class:`~kivy.properties.ListProperty`
+    :attr:`right_action_items` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -244,7 +244,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     """
     See the :class:`kivymd.uix.toolbar.MDToolbar.title` parameter.
 
-    :attr:`title` is an :class:`~kivy.properties.StringProperty`
+    :attr:`title` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -252,7 +252,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     """
     Background color of back layer.
 
-    :attr:`back_layer_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`back_layer_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -260,7 +260,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     """
     Background color of front layer.
 
-    :attr:`front_layer_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`front_layer_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -269,7 +269,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     The value of the rounding radius of the upper left corner
     of the front layer.
 
-    :attr:`radius_left` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`radius_left` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `16dp`.
     """
 
@@ -278,7 +278,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     The value of the rounding radius of the upper right corner
     of the front layer.
 
-    :attr:`radius_right` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`radius_right` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `16dp`.
     """
 
@@ -286,7 +286,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     """
     Whether to use a header above the contents of the front layer.
 
-    :attr:`header` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`header` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -294,7 +294,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     """
     Text of header.
 
-    :attr:`header_text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`header_text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'Header'`.
     """
 
@@ -303,7 +303,7 @@ class MDBackdrop(ThemableBehavior, FloatLayout):
     The name of the icon that will be installed on the toolbar
     on the left when opening the front layer.
 
-    :attr:`close_icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`close_icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'close'`.
     """
 

--- a/kivymd/uix/banner.py
+++ b/kivymd/uix/banner.py
@@ -264,7 +264,7 @@ class MDBanner(MDCard):
     """
     Indent the banner at the top of the screen.
 
-    :attr:`vertical_pad` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`vertical_pad` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `dp(68)`.
     """
 
@@ -272,14 +272,14 @@ class MDBanner(MDCard):
     """
     The name of the animation transition.
 
-    :attr:`opening_transition` is an :class:`~kivy.properties.StringProperty`
+    :attr:`opening_transition` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'in_quad'`.
     """
 
     icon = StringProperty("data/logo/kivy-icon-128.png")
     """Icon banner.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'data/logo/kivy-icon-128.png'`.
     """
 
@@ -297,7 +297,7 @@ class MDBanner(MDCard):
     Must contain no more than three lines for a
     `'one-line'`, `'two-line'` and `'three-line'` banner, respectively.
 
-    :attr:`text` is an :class:`~kivy.properties.ListProperty`
+    :attr:`text` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -308,14 +308,14 @@ class MDBanner(MDCard):
     where `'name_action'` is a string that corresponds to an action name and
     ``callback`` is the function called on a touch release event.
 
-    :attr:`left_action` is an :class:`~kivy.properties.ListProperty`
+    :attr:`left_action` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
     right_action = ListProperty()
     """Works the same way as :attr:`left_action`.
 
-    :attr:`right_action` is an :class:`~kivy.properties.ListProperty`
+    :attr:`right_action` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 

--- a/kivymd/uix/behaviors/backgroundcolor_behavior.py
+++ b/kivymd/uix/behaviors/backgroundcolor_behavior.py
@@ -41,28 +41,28 @@ class BackgroundColorBehavior(Widget):
     r = BoundedNumericProperty(1.0, min=0.0, max=1.0)
     """The value of ``red`` in the ``rgba`` palette.
 
-    :attr:`r` is an :class:`~kivy.properties.BoundedNumericProperty`
+    :attr:`r` is a :class:`~kivy.properties.BoundedNumericProperty`
     and defaults to `1.0`.
     """
 
     g = BoundedNumericProperty(1.0, min=0.0, max=1.0)
     """The value of ``green`` in the ``rgba`` palette.
 
-    :attr:`g` is an :class:`~kivy.properties.BoundedNumericProperty`
+    :attr:`g` is a :class:`~kivy.properties.BoundedNumericProperty`
     and defaults to `1.0`.
     """
 
     b = BoundedNumericProperty(1.0, min=0.0, max=1.0)
     """The value of ``blue`` in the ``rgba`` palette.
 
-    :attr:`b` is an :class:`~kivy.properties.BoundedNumericProperty`
+    :attr:`b` is a :class:`~kivy.properties.BoundedNumericProperty`
     and defaults to `1.0`.
     """
 
     a = BoundedNumericProperty(0.0, min=0.0, max=1.0)
     """The value of ``alpha channel`` in the ``rgba`` palette.
 
-    :attr:`a` is an :class:`~kivy.properties.BoundedNumericProperty`
+    :attr:`a` is a :class:`~kivy.properties.BoundedNumericProperty`
     and defaults to `0.0`.
     """
 
@@ -76,7 +76,7 @@ class BackgroundColorBehavior(Widget):
             md_bg_color: app.theme_cls.primary_color
             radius: [25, 0, 0, 0]
 
-    :attr:`radius` is an :class:`~kivy.properties.ListProperty`
+    :attr:`radius` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[0, 0, 0, 0]`.
     """
 
@@ -103,7 +103,7 @@ class BackgroundColorBehavior(Widget):
         <MyWidget@BackgroundColorBehavior>
             md_bg_color: 0, 1, 1, 1
 
-    :attr:`md_bg_color` is an :class:`~kivy.properties.ReferenceListProperty`
+    :attr:`md_bg_color` is a :class:`~kivy.properties.ReferenceListProperty`
     and defaults to :attr:`r`, :attr:`g`, :attr:`b`, :attr:`a`.
     """
 
@@ -126,12 +126,12 @@ class SpecificBackgroundColorBehavior(BackgroundColorBehavior):
     """
 
     specific_text_color = ColorProperty([0, 0, 0, 0.87])
-    """:attr:`specific_text_color` is an :class:`~kivy.properties.ColorProperty`
+    """:attr:`specific_text_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `[0, 0, 0, 0.87]`.
     """
 
     specific_secondary_text_color = ColorProperty([0, 0, 0, 0.87])
-    """:attr:`specific_secondary_text_color`is an :class:`~kivy.properties.ColorProperty`
+    """:attr:`specific_secondary_text_color`is a :class:`~kivy.properties.ColorProperty`
     and defaults to `[0, 0, 0, 0.87]`.
     """
 

--- a/kivymd/uix/behaviors/elevation.py
+++ b/kivymd/uix/behaviors/elevation.py
@@ -178,7 +178,7 @@ class CommonElevationBehavior(object):
     """
     Elevation value.
 
-    :attr:`elevation` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`elevation` is a :class:`~kivy.properties.NumericProperty`
     and defaults to 1.
     """
 

--- a/kivymd/uix/behaviors/hover_behavior.py
+++ b/kivymd/uix/behaviors/hover_behavior.py
@@ -95,7 +95,7 @@ class HoverBehavior(object):
     """
     `True`, if the mouse cursor is within the borders of the widget.
 
-    :attr:`hovered` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`hovered` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 

--- a/kivymd/uix/behaviors/ripple_behavior.py
+++ b/kivymd/uix/behaviors/ripple_behavior.py
@@ -253,9 +253,7 @@ class CommonRipple(object):
 
     def on_touch_down(self, touch):
         super().on_touch_down(touch)
-        if touch.is_mouse_scrolling:
-            return False
-        if not self.collide_point(touch.x, touch.y):
+        if touch.is_mouse_scrolling or not self.collide_point(touch.x, touch.y):
             return False
 
         if not self.disabled:

--- a/kivymd/uix/behaviors/ripple_behavior.py
+++ b/kivymd/uix/behaviors/ripple_behavior.py
@@ -123,7 +123,7 @@ class CommonRipple(object):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/ripple-rad-default.gif
        :align: center
 
-    :attr:`ripple_rad_default` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_rad_default` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `1`.
     """
 
@@ -131,7 +131,7 @@ class CommonRipple(object):
     """
     Ripple color in ``rgba`` format.
 
-    :attr:`ripple_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`ripple_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -139,7 +139,7 @@ class CommonRipple(object):
     """
     Alpha channel values for ripple effect.
 
-    :attr:`ripple_alpha` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_alpha` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.5`.
     """
 
@@ -150,7 +150,7 @@ class CommonRipple(object):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/ripple-scale-1.gif
        :align: center
 
-    :attr:`ripple_scale` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_scale` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `None`.
     """
 
@@ -158,7 +158,7 @@ class CommonRipple(object):
     """
     Ripple duration when touching to widget.
 
-    :attr:`ripple_duration_in_fast` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_duration_in_fast` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.3`.
     """
 
@@ -166,7 +166,7 @@ class CommonRipple(object):
     """
     Ripple duration when long touching to widget.
 
-    :attr:`ripple_duration_in_slow` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_duration_in_slow` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `2`.
     """
 
@@ -177,7 +177,7 @@ class CommonRipple(object):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/ripple-duration-out.gif
        :align: center
 
-    :attr:`ripple_duration_out` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_duration_out` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.3`.
     """
 
@@ -185,7 +185,7 @@ class CommonRipple(object):
     """
     Type of animation for ripple in effect.
 
-    :attr:`ripple_func_in` is an :class:`~kivy.properties.StringProperty`
+    :attr:`ripple_func_in` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'out_quad'`.
     """
 
@@ -193,7 +193,7 @@ class CommonRipple(object):
     """
     Type of animation for ripple out effect.
 
-    :attr:`ripple_func_in` is an :class:`~kivy.properties.StringProperty`
+    :attr:`ripple_func_in` is anaclass:`~kivy.properties.StringProperty`
     and defaults to `'ripple_func_out'`.
     """
 
@@ -309,7 +309,7 @@ class RectangularRippleBehavior(CommonRipple):
     """
     See :class:`~CommonRipple.ripple_scale`.
 
-    :attr:`ripple_scale` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_scale` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `2.75`.
     """
 
@@ -354,7 +354,7 @@ class CircularRippleBehavior(CommonRipple):
     """
     See :class:`~CommonRipple.ripple_scale`.
 
-    :attr:`ripple_scale` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_scale` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `1`.
     """
 

--- a/kivymd/uix/behaviors/touch_behavior.py
+++ b/kivymd/uix/behaviors/touch_behavior.py
@@ -62,7 +62,7 @@ class TouchBehavior:
     """
     Time for a long touch.
 
-    :attr:`duration_long_touch` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`duration_long_touch` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.4`.
     """
 

--- a/kivymd/uix/bottomnavigation.py
+++ b/kivymd/uix/bottomnavigation.py
@@ -309,19 +309,19 @@ class MDBottomNavigationHeader(BaseFlatButton, BasePressedButton):
     panel_color = ListProperty([1, 1, 1, 0])
     """Panel color of bottom navigation.
 
-    :attr:`panel_color` is an :class:`~kivy.properties.ListProperty`
+    :attr:`panel_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[1, 1, 1, 0]`.
     """
 
     tab = ObjectProperty()
     """
-    :attr:`tab` is an :class:`~MDBottomNavigationItem`
+    :attr:`tab` is a :class:`~MDBottomNavigationItem`
     and defaults to `None`.
     """
 
     panel = ObjectProperty()
     """
-    :attr:`panel` is an :class:`~MDBottomNavigation`
+    :attr:`panel` is a :class:`~MDBottomNavigation`
     and defaults to `None`.
     """
 
@@ -329,7 +329,7 @@ class MDBottomNavigationHeader(BaseFlatButton, BasePressedButton):
 
     text = StringProperty()
     """
-    :attr:`text` is an :class:`~MDTab.text`
+    :attr:`text` is a :class:`~MDTab.text`
     and defaults to `''`.
     """
 
@@ -337,7 +337,7 @@ class MDBottomNavigationHeader(BaseFlatButton, BasePressedButton):
     """
     Text color of the label when it is not selected.
 
-    :attr:`text_color_normal` is an :class:`~kivy.properties.ListProperty`
+    :attr:`text_color_normal` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[1, 1, 1, 1]`.
     """
 
@@ -345,7 +345,7 @@ class MDBottomNavigationHeader(BaseFlatButton, BasePressedButton):
     """
     Text color of the label when it is selected.
 
-    :attr:`text_color_active` is an :class:`~kivy.properties.ListProperty`
+    :attr:`text_color_active` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[1, 1, 1, 1]`.
     """
 
@@ -406,14 +406,14 @@ class MDTab(Screen, ThemableBehavior):
     text = StringProperty()
     """Tab header text.
 
-    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
     icon = StringProperty("checkbox-blank-circle")
     """Tab header icon.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'checkbox-blank-circle'`.
     """
 
@@ -456,7 +456,7 @@ class MDTab(Screen, ThemableBehavior):
 class MDBottomNavigationItem(MDTab):
     header = ObjectProperty()
     """
-    :attr:`header` is an :class:`~MDBottomNavigationHeader`
+    :attr:`header` is a :class:`~MDBottomNavigationHeader`
     and defaults to `None`.
     """
 
@@ -493,19 +493,19 @@ class TabbedPanelBase(
     current = StringProperty(None)
     """Current tab name.
 
-    :attr:`current` is an :class:`~kivy.properties.StringProperty`
+    :attr:`current` is a :class:`~kivy.properties.StringProperty`
     and defaults to `None`.
     """
 
     previous_tab = ObjectProperty()
     """
-    :attr:`previous_tab` is an :class:`~MDTab` and defaults to `None`.
+    :attr:`previous_tab` is a :class:`~MDTab` and defaults to `None`.
     """
 
     panel_color = ListProperty()
     """Panel color of bottom navigation.
 
-    :attr:`panel_color` is an :class:`~kivy.properties.ListProperty`
+    :attr:`panel_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -518,13 +518,13 @@ class MDBottomNavigation(TabbedPanelBase):
 
     first_widget = ObjectProperty()
     """
-    :attr:`first_widget` is an :class:`~MDBottomNavigationItem`
+    :attr:`first_widget` is a :class:`~MDBottomNavigationItem`
     and defaults to `None`.
     """
 
     tab_header = ObjectProperty()
     """
-    :attr:`tab_header` is an :class:`~MDBottomNavigationHeader`
+    :attr:`tab_header` is a :class:`~MDBottomNavigationHeader`
     and defaults to `None`.
     """
 
@@ -532,7 +532,7 @@ class MDBottomNavigation(TabbedPanelBase):
     """
     Text color of the label when it is not selected.
 
-    :attr:`text_color_normal` is an :class:`~kivy.properties.ListProperty`
+    :attr:`text_color_normal` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[1, 1, 1, 1]`.
     """
 
@@ -540,7 +540,7 @@ class MDBottomNavigation(TabbedPanelBase):
     """
     Text color of the label when it is selected.
 
-    :attr:`text_color_active` is an :class:`~kivy.properties.ListProperty`
+    :attr:`text_color_active` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[1, 1, 1, 1]`.
     """
 

--- a/kivymd/uix/bottomsheet.py
+++ b/kivymd/uix/bottomsheet.py
@@ -327,7 +327,7 @@ class MDBottomSheet(ThemableBehavior, ModalView):
     """
     The duration of the bottom sheet dialog opening animation.
 
-    :attr:`duration_opening` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`duration_opening` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.15`.
     """
 
@@ -335,7 +335,7 @@ class MDBottomSheet(ThemableBehavior, ModalView):
     """
     The duration of the bottom sheet dialog closing animation.
 
-    :attr:`duration_closing` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`duration_closing` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.15`.
     """
 
@@ -343,7 +343,7 @@ class MDBottomSheet(ThemableBehavior, ModalView):
     """
     The value of the rounding of the corners of the dialog.
 
-    :attr:`radius` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`radius` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `25`.
     """
 
@@ -374,7 +374,7 @@ class MDBottomSheet(ThemableBehavior, ModalView):
     """
     Whether to use animation for opening and closing of the bottomsheet or not.
 
-    :attr:`animation` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`animation` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -382,7 +382,7 @@ class MDBottomSheet(ThemableBehavior, ModalView):
     """
     Dialog background color in ``rgba`` format.
 
-    :attr:`bg_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`bg_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `[]`.
     """
 
@@ -390,7 +390,7 @@ class MDBottomSheet(ThemableBehavior, ModalView):
     """
     Background transparency value when opening a dialog.
 
-    :attr:`value_transparent` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`value_transparent` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `[0, 0, 0, 0.8]`.
     """
 
@@ -534,7 +534,7 @@ class GridBottomSheetItem(ButtonBehavior, BoxLayout):
     Icon path if you use a local image or icon name
     if you use icon names from a file ``kivymd/icon_definitions.py``.
 
-    :attr:`source` is an :class:`~kivy.properties.StringProperty`
+    :attr:`source` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -542,7 +542,7 @@ class GridBottomSheetItem(ButtonBehavior, BoxLayout):
     """
     Item text.
 
-    :attr:`caption` is an :class:`~kivy.properties.StringProperty`
+    :attr:`caption` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -550,7 +550,7 @@ class GridBottomSheetItem(ButtonBehavior, BoxLayout):
     """
     Icon size.
 
-    :attr:`caption` is an :class:`~kivy.properties.StringProperty`
+    :attr:`caption` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'24sp'`.
     """
 

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -212,7 +212,7 @@ MDRectangleFlatIconButton
 .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/md-rectangle-flat-icon-button.png
     :align: center
 
-Button parameters :class:`~MDRectangleFlatButton` are the same as
+Button parameters :class:`~MDRectangleFlatIconButton` are the same as
 button :class:`~MDRectangleFlatButton`:
 
 .. code-block:: kv
@@ -727,7 +727,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     """
     Button text.
 
-    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `' '`.
     """
 
@@ -754,7 +754,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     """
     Button text color in (r, g, b, a) format.
 
-    :attr:`text_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`text_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -762,7 +762,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     """
     Button text font name.
 
-    :attr:`font_name` is an :class:`~kivy.properties.StringProperty`
+    :attr:`font_name` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -770,7 +770,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     """
     Button text font size.
 
-    :attr:`font_size` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`font_size` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `14sp`.
     """
 
@@ -778,7 +778,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     """
     Custom font size for :class:`~MDIconButton`.
 
-    :attr:`user_font_size` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`user_font_size` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0`.
     """
 
@@ -790,7 +790,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     `'H6'`, `'Subtitle1'`, `'Subtitle2'`, `'Body1'`, `'Body2'`, `'Button'`,
     `'Caption'`, `'Overline'`, `'Icon'`.
 
-    :attr:`font_style` is an :class:`~kivy.properties.StringProperty`
+    :attr:`font_style` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'Body1'`.
     """
 
@@ -798,7 +798,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     """
     Button background color.
 
-    :attr:`md_bg_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`md_bg_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `[1.0, 1.0, 1.0, 0]`.
     """
 
@@ -806,7 +806,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     """
     Disabled button text color.
 
-    :attr:`md_bg_color_disabled` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`md_bg_color_disabled` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1050,7 +1050,7 @@ class BaseRectangleFlatButton(BaseFlatButton, BaseElevationButton):
     """
     Line width for button border.
 
-    :attr:`line_width` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`line_width` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `1`.
     """
 
@@ -1058,7 +1058,7 @@ class BaseRectangleFlatButton(BaseFlatButton, BaseElevationButton):
     """
     Line color for button border.
 
-    :attr:`line_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`line_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1086,7 +1086,7 @@ class MDRectangleFlatIconButton(BaseRectangleFlatButton):
     """
     Button icon.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'android'`.
     """
 
@@ -1094,7 +1094,7 @@ class MDRectangleFlatIconButton(BaseRectangleFlatButton):
     """
     Button icon color.
 
-    :attr:`icon_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`icon_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1118,7 +1118,7 @@ class MDRoundFlatButton(MDFlatButton):
     """
     Line width for button border.
 
-    :attr:`line_width` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`line_width` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `1`.
     """
 
@@ -1126,7 +1126,7 @@ class MDRoundFlatButton(MDFlatButton):
     """
     Line color for button border.
 
-    :attr:`line_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`line_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1164,7 +1164,7 @@ class MDRoundFlatIconButton(MDRoundFlatButton):
     """
     Button icon.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'android'`.
     """
 
@@ -1172,7 +1172,7 @@ class MDRoundFlatIconButton(MDRoundFlatButton):
     """
     Button icon color.
 
-    :attr:`icon_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`icon_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1243,7 +1243,7 @@ class MDIconButton(BaseRoundButton, BasePressedButton):
     """
     Button icon.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'checkbox-blank-circle'`.
     """
 
@@ -1274,7 +1274,7 @@ class MDFloatingActionButton(
     """
     Button icon.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'android'`.
     """
 
@@ -1300,7 +1300,7 @@ class MDTextButton(ButtonBehavior, MDLabel):
     """
     Button color in (r, g, b, a) format.
 
-    :attr:`color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1308,7 +1308,7 @@ class MDTextButton(ButtonBehavior, MDLabel):
     """
     Button color disabled in (r, g, b, a) format.
 
-    :attr:`color_disabled` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`color_disabled` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1380,9 +1380,9 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
     """
     :Events:
         :attr:`on_open`
-            Called when a stack is opened.
+            Called when stack is opened.
         :attr:`on_close`
-            Called when a stack is closed.
+            Called when stack is closed.
     """
 
     icon = StringProperty("plus")
@@ -1397,7 +1397,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
     """
     Stack anchor. Available options are: `'right'`.
 
-    :attr:`anchor` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`anchor` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'right'`.
     """
 
@@ -1416,7 +1416,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
             print(instance.icon)
 
 
-    :attr:`callback` is a :class:`~kivy.properties.ObjectProperty`
+    :attr:`callback` is an :class:`~kivy.properties.ObjectProperty`
     and defaults to `None`.
     """
 
@@ -1435,7 +1435,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
     .. code-block:: python
 
         {
-            'name-icon': 'Text label',
+            'icon-name': 'Text label',
             ...,
             ...,
         }
@@ -1542,7 +1542,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
     Indicates whether the stack is closed or open.
     Available options are: `'close'`, `'open'`.
 
-    :attr:`state` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`state` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'close'`.
     """
 

--- a/kivymd/uix/card.py
+++ b/kivymd/uix/card.py
@@ -655,7 +655,7 @@ class MDCard(
     """
     Elevation value.
 
-    :attr:`elevation` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`elevation` is a :class:`~kivy.properties.NumericProperty`
     and defaults to 1.
     """
 
@@ -731,7 +731,7 @@ class MDCardSwipe(RelativeLayout):
     """
     Anchoring screen edge for card. Available options are: `'left'`, `'right'`.
 
-    :attr:`anchor` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`anchor` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `left`.
     """
 
@@ -757,7 +757,7 @@ class MDCardSwipe(RelativeLayout):
     Detailed state. Sets before :attr:`state`. Bind to :attr:`state` instead
     of :attr:`status`. Available options are: `'closed'`,  `'opened'`.
 
-    :attr:`status` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`status` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'closed'`.
     """
 
@@ -786,7 +786,7 @@ class MDCardSwipe(RelativeLayout):
     a set position :attr:`~max_opened_x`. Available options are:
     `'auto'`, `'hand'`.
 
-    :attr:`type_swipe` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`type_swipe` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `auto`.
     """
 

--- a/kivymd/uix/chip.py
+++ b/kivymd/uix/chip.py
@@ -177,7 +177,7 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
     """
     Chip text.
 
-    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -185,7 +185,7 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
     """
     Chip icon.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'checkbox-blank-circle'`.
     """
 
@@ -193,7 +193,7 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
     """
     Chip color in ``rgba`` format.
 
-    :attr:`color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -201,7 +201,7 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
     """
     Chip's text color in ``rgba`` format.
 
-    :attr:`text_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`text_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -209,7 +209,7 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
     """
     Chip's icon color in ``rgba`` format.
 
-    :attr:`icon_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`icon_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -217,7 +217,7 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
     """
     If True, a checkmark is added to the left when touch to the chip.
 
-    :attr:`check` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`check` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -229,7 +229,7 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
     """
     Corner radius values.
 
-    :attr:`radius` is an :class:`~kivy.properties.ListProperty`
+    :attr:`radius` is a :class:`~kivy.properties.ListProperty`
     and defaults to `'[dp(12),]'`.
     """
 
@@ -237,7 +237,7 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
     """
     The color of the chip that is currently selected in ``rgba`` format.
 
-    :attr:`selected_chip_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`selected_chip_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 

--- a/kivymd/uix/datatables.py
+++ b/kivymd/uix/datatables.py
@@ -1038,7 +1038,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-column-data.png
         :align: center
 
-    :attr:`column_data` is an :class:`~kivy.properties.ListProperty`
+    :attr:`column_data` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
 
     .. note::
@@ -1159,7 +1159,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-row-data.png
         :align: center
 
-    :attr:`row_data` is an :class:`~kivy.properties.ListProperty`
+    :attr:`row_data` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -1170,7 +1170,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
     If the table data is showing an already sorted data then this can be used
     to indicate upon which column the data is sorted.
 
-    :attr:`sorted_on` is an :class:`~kivy.properties.StringProperty`
+    :attr:`sorted_on` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -1190,7 +1190,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-check.gif
         :align: center
 
-    :attr:`check` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`check` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -1234,7 +1234,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-use-pagination.png
         :align: center
 
-    :attr:`use_pagination` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`use_pagination` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -1242,7 +1242,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
     """
     Table elevation.
 
-    :attr:`elevation` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`elevation` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `8`.
     """
 
@@ -1253,7 +1253,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-use-pagination.gif
         :align: center
 
-    :attr:`rows_num` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`rows_num` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `10`.
     """
 
@@ -1290,7 +1290,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-menu-height-240.png
         :align: center
 
-    :attr:`pagination_menu_height` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`pagination_menu_height` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `'140dp'`.
     """
 

--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -195,7 +195,7 @@ class BaseDialog(ThemableBehavior, ModalView):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-radius.png
         :align: center
 
-    :attr:`radius` is an :class:`~kivy.properties.ListProperty`
+    :attr:`radius` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[7, 7, 7, 7]`.
     """
 
@@ -225,7 +225,7 @@ class MDDialog(BaseDialog):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-title.png
         :align: center
 
-    :attr:`title` is an :class:`~kivy.properties.StringProperty`
+    :attr:`title` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -251,7 +251,7 @@ class MDDialog(BaseDialog):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-text.png
         :align: center
 
-    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -272,7 +272,7 @@ class MDDialog(BaseDialog):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-buttons.png
         :align: center
 
-    :attr:`buttons` is an :class:`~kivy.properties.ListProperty`
+    :attr:`buttons` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -421,7 +421,7 @@ class MDDialog(BaseDialog):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-confirmation.png
         :align: center
 
-    :attr:`items` is an :class:`~kivy.properties.ListProperty`
+    :attr:`items` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -429,7 +429,7 @@ class MDDialog(BaseDialog):
     """
     Dialog offset from device width.
 
-    :attr:`width_offset` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`width_offset` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `dp(48)`.
     """
 
@@ -521,7 +521,7 @@ class MDDialog(BaseDialog):
     """
     Background color in the format (r, g, b, a).
 
-    :attr:`md_bg_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`md_bg_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 

--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -181,7 +181,11 @@ Builder.load_string(
 
 
 class BaseDialog(ThemableBehavior, ModalView):
-    radius = ListProperty([7, 7, 7, 7])
+    radius = ListProperty(
+        [
+            dp(7),
+        ]
+    )
     """
     Dialog corners rounding value.
 
@@ -196,7 +200,7 @@ class BaseDialog(ThemableBehavior, ModalView):
         :align: center
 
     :attr:`radius` is a :class:`~kivy.properties.ListProperty`
-    and defaults to `[7, 7, 7, 7]`.
+    and defaults to `[dp(7),]`.
     """
 
     _scale_x = NumericProperty(1)

--- a/kivymd/uix/expansionpanel.py
+++ b/kivymd/uix/expansionpanel.py
@@ -224,7 +224,7 @@ class MDExpansionPanel(RelativeLayout):
     Icon Should be either be a path to an image or
     a logo name in :class:`~kivymd.icon_definitions.md_icons`
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -267,7 +267,7 @@ class MDExpansionPanel(RelativeLayout):
     :class:`~MDExpansionPanelOneLine`, :class:`~MDExpansionPanelTwoLine` or
     :class:`~MDExpansionPanelThreeLine`.
 
-    :attr:`panel_cls` is a :class:`~kivy.properties.ObjectProperty`
+    :attr:`panel_cls` is an :class:`~kivy.properties.ObjectProperty`
     and defaults to `None`.
     """
 

--- a/kivymd/uix/filemanager.py
+++ b/kivymd/uix/filemanager.py
@@ -142,7 +142,8 @@ from kivymd.uix.floatlayout import MDFloatLayout
 from kivymd.uix.list import BaseListItem, ContainerSupport
 from kivymd.utils.fitimage import FitImage
 
-ACTIVITY_MANAGER = """
+Builder.load_string(
+    """
 #:import os os
 
 
@@ -260,6 +261,7 @@ ACTIVITY_MANAGER = """
         y: root.y + root.height / 2 - self.height / 2
         size: dp(48), dp(48)
 """
+)
 
 
 class BodyManagerWithPreview(MDBoxLayout):
@@ -664,6 +666,3 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
         else:
             if self.selector == "folder" or self.selector == "any":
                 self.select_path(self.current_path)
-
-
-Builder.load_string(ACTIVITY_MANAGER)

--- a/kivymd/uix/filemanager.py
+++ b/kivymd/uix/filemanager.py
@@ -292,7 +292,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     """
     The icon that will be used on the directory selection button.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `check`.
     """
 
@@ -300,7 +300,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     """
     The icon that will be used for folder icons when using ``preview = True``.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `check`.
     """
 
@@ -326,7 +326,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     For example, `['.py', '.kv']` - will filter out all files,
     except python scripts and Kv Language.
 
-    :attr:`ext` is an :class:`~kivy.properties.ListProperty`
+    :attr:`ext` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -344,7 +344,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     """
     Current directory.
 
-    :attr:`current_path` is an :class:`~kivy.properties.StringProperty`
+    :attr:`current_path` is a :class:`~kivy.properties.StringProperty`
     and defaults to `/`.
     """
 
@@ -352,7 +352,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     """
     Show access to files and directories.
 
-    :attr:`use_access` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`use_access` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -360,7 +360,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     """
     Shows only image previews.
 
-    :attr:`preview` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`preview` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -368,7 +368,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     """
     Shows hidden files.
 
-    :attr:`show_hidden_files` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`show_hidden_files` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -388,7 +388,7 @@ class MDFileManager(ThemableBehavior, MDFloatLayout):
     """
     Sort by descending.
 
-    :attr:`sort_by_desc` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`sort_by_desc` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 

--- a/kivymd/uix/imagelist.py
+++ b/kivymd/uix/imagelist.py
@@ -220,7 +220,7 @@ class SmartTile(
     Determines wether the information box acts as a header or footer to the
     image. Available are options: `'footer'`, `'header'`.
 
-    :attr:`box_position` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`box_position` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'footer'`.
     """
 
@@ -229,7 +229,7 @@ class SmartTile(
     Number of lines in the `header/footer`. As per `Material Design specs`,
     only 1 and 2 are valid values. Available are options: ``1``, ``2``.
 
-    :attr:`lines` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`lines` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `1`.
     """
 

--- a/kivymd/uix/label.py
+++ b/kivymd/uix/label.py
@@ -256,7 +256,7 @@ class MDLabel(ThemableBehavior, Label, MDAdaptiveWidget):
     `'Subtitle1'`, `'Subtitle2'`, `'Body1'`, `'Body2'`, `'Button'`,
     `'Caption'`, `'Overline'`, `'Icon'`.
 
-    :attr:`font_style` is an :class:`~kivy.properties.StringProperty`
+    :attr:`font_style` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'Body1'`.
     """
 
@@ -300,7 +300,7 @@ class MDLabel(ThemableBehavior, Label, MDAdaptiveWidget):
     text_color = ColorProperty(None)
     """Label text color in ``rgba`` format.
 
-    :attr:`text_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`text_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -385,7 +385,7 @@ class MDIcon(MDLabel):
     """
     Label icon name.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'android'`.
     """
 
@@ -393,6 +393,6 @@ class MDIcon(MDLabel):
     """
     Path to icon.
 
-    :attr:`source` is an :class:`~kivy.properties.StringProperty`
+    :attr:`source` is a :class:`~kivy.properties.StringProperty`
     and defaults to `None`.
     """

--- a/kivymd/uix/list.py
+++ b/kivymd/uix/list.py
@@ -751,7 +751,7 @@ class BaseListItem(
     Divider mode. Available options are: `'Full'`, `'Inset'`
     and default to `'Full'`.
 
-    :attr:`divider` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`divider` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'Full'`.
     """
 

--- a/kivymd/uix/menu.py
+++ b/kivymd/uix/menu.py
@@ -847,7 +847,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
     Where the menu will grow vertically to when opening. Set to None to let
     the widget pick for you. Available options are: `'up'`, `'down'`.
 
-    :attr:`ver_growth` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`ver_growth` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `None`.
     """
 
@@ -856,7 +856,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
     Where the menu will grow horizontally to when opening. Set to None to let
     the widget pick for you. Available options are: `'left'`, `'right'`.
 
-    :attr:`hor_growth` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`hor_growth` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `None`.
     """
 
@@ -889,7 +889,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
     """
     The widget object that caller the menu window.
 
-    :attr:`caller` is a :class:`~kivy.properties.ObjectProperty`
+    :attr:`caller` is an :class:`~kivy.properties.ObjectProperty`
     and defaults to `None`.
     """
 
@@ -898,7 +898,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
     Menu window position relative to parent element.
     Available options are: `'auto'`, `'center'`, `'bottom'`.
 
-    :attr:`position` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`position` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'auto'`.
     """
 

--- a/kivymd/uix/navigationdrawer.py
+++ b/kivymd/uix/navigationdrawer.py
@@ -422,7 +422,7 @@ class MDNavigationDrawer(MDCard):
     :attr:`close_on_click` and :attr:`enable_swiping` to prevent closing
     drawer for standard type.
 
-    :attr:`type` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`type` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `modal`.
     """
 
@@ -431,7 +431,7 @@ class MDNavigationDrawer(MDCard):
     Anchoring screen edge for drawer. Set it to `'right'` for right-to-left
     languages. Available options are: `'left'`, `'right'`.
 
-    :attr:`anchor` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`anchor` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `left`.
     """
 
@@ -449,7 +449,7 @@ class MDNavigationDrawer(MDCard):
     Indicates if panel closed or opened. Sets after :attr:`status` change.
     Available options are: `'close'`, `'open'`.
 
-    :attr:`state` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`state` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'close'`.
     """
 
@@ -470,7 +470,7 @@ class MDNavigationDrawer(MDCard):
     `'opening_with_swipe'`, `'opening_with_animation'`, `'opened'`,
     `'closing_with_swipe'`, `'closing_with_animation'`.
 
-    :attr:`status` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`status` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'closed'`.
     """
 

--- a/kivymd/uix/navigationrail.py
+++ b/kivymd/uix/navigationrail.py
@@ -244,7 +244,7 @@ class BaseNavigationRailFloatingButton(MDFloatingActionButton):
     """
     The text will be placed to the left of the button icon..
 
-    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -270,7 +270,7 @@ class NavigationRailTitle(MDBoxLayout):
     """
     Icon item.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'blank'`.
     """
 
@@ -278,7 +278,7 @@ class NavigationRailTitle(MDBoxLayout):
     """
     Text title.
 
-    :attr:`title` is an :class:`~kivy.properties.StringProperty`
+    :attr:`title` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'Rail'`.
     """
 
@@ -294,7 +294,7 @@ class MDNavigationRailItem(
     """
     Icon item.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'checkbox-blank'`.
     """
 
@@ -302,7 +302,7 @@ class MDNavigationRailItem(
     """
     Text item.
 
-    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -391,7 +391,7 @@ class MDNavigationRail(MDCard):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/navigation-rail-hover-behavior.gif
         :align: center
 
-    :attr:`use_hover_behavior` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`use_hover_behavior` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -503,7 +503,7 @@ class MDNavigationRail(MDCard):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/navigation-rail-use-title.gif
         :align: center
 
-    :attr:`use_title` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`use_title` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -511,7 +511,7 @@ class MDNavigationRail(MDCard):
     """
     Icon (name or path to `png` file) for :class:`~NavigationRailTitle` class.
 
-    :attr:`icon_title` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon_title` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'menu'`.
     """
 
@@ -519,7 +519,7 @@ class MDNavigationRail(MDCard):
     """
     Text title  for :class:`~NavigationRailTitle` class.
 
-    :attr:`text_title` is an :class:`~kivy.properties.StringProperty`
+    :attr:`text_title` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'Rail'`.
     """
 
@@ -537,7 +537,7 @@ class MDNavigationRail(MDCard):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/navigation-rail-use-action-button.gif
         :align: center
 
-    :attr:`use_action_button` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`use_action_button` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -545,7 +545,7 @@ class MDNavigationRail(MDCard):
     """
     Icon of :attr:`~use_action_button`.
 
-    :attr:`action_icon_button` is an :class:`~kivy.properties.StringProperty`
+    :attr:`action_icon_button` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'plus'`.
     """
 
@@ -553,7 +553,7 @@ class MDNavigationRail(MDCard):
     """
     Text of :attr:`~use_action_button`.
 
-    :attr:`action_text_button` is an :class:`~kivy.properties.StringProperty`
+    :attr:`action_text_button` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -561,7 +561,7 @@ class MDNavigationRail(MDCard):
     """
     Text of :attr:`~use_action_button`.
 
-    :attr:`action_color_button` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`action_color_button` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -569,7 +569,7 @@ class MDNavigationRail(MDCard):
     """
     Color normal of item menu.
 
-    :attr:`color_normal` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`color_normal` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -577,7 +577,7 @@ class MDNavigationRail(MDCard):
     """
     Color active of item menu.
 
-    :attr:`color_active` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`color_active` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -645,7 +645,7 @@ class MDNavigationRail(MDCard):
     """
     Closed or open rails.
 
-    :attr:`rail_state` is a :class:`~kivy.properties.OptionProperty`
+    :attr:`rail_state` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'close'`.
     """
 

--- a/kivymd/uix/picker.py
+++ b/kivymd/uix/picker.py
@@ -720,7 +720,7 @@ class MDTimePicker(
     """
     Corner radius values.
 
-    :attr:`radius` is an :class:`~kivy.properties.ListProperty`
+    :attr:`radius` is a :class:`~kivy.properties.ListProperty`
     and defaults to `'[0, 0, 0, 0]'`.
     """
 
@@ -728,7 +728,7 @@ class MDTimePicker(
     """
     24H Mode.
 
-    :attr:`military` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`military` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 

--- a/kivymd/uix/progressbar.py
+++ b/kivymd/uix/progressbar.py
@@ -185,7 +185,7 @@ class MDProgressBar(ThemableBehavior, ProgressBar):
     reversed = BooleanProperty(False)
     """Reverse the direction the progressbar moves.
 
-    :attr:`reversed` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`reversed` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -203,35 +203,35 @@ class MDProgressBar(ThemableBehavior, ProgressBar):
     """
     Progress bar color in ``rgba`` format.
 
-    :attr:`color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
     running_transition = StringProperty("in_cubic")
     """Running transition.
 
-    :attr:`running_transition` is an :class:`~kivy.properties.StringProperty`
+    :attr:`running_transition` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'in_cubic'`.
     """
 
     catching_transition = StringProperty("out_quart")
     """Catching transition.
 
-    :attr:`catching_transition` is an :class:`~kivy.properties.StringProperty`
+    :attr:`catching_transition` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'out_quart'`.
     """
 
     running_duration = NumericProperty(0.5)
     """Running duration.
 
-    :attr:`running_duration` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`running_duration` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.5`.
     """
 
     catching_duration = NumericProperty(0.8)
     """Catching duration.
 
-    :attr:`running_duration` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`running_duration` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.8`.
     """
 

--- a/kivymd/uix/slider.py
+++ b/kivymd/uix/slider.py
@@ -192,7 +192,7 @@ class MDSlider(ThemableBehavior, Slider):
     """
     If the slider is clicked.
 
-    :attr:`active` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`active` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -200,7 +200,7 @@ class MDSlider(ThemableBehavior, Slider):
     """
     If True, then the current value is displayed above the slider.
 
-    :attr:`hint` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`hint` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -208,7 +208,7 @@ class MDSlider(ThemableBehavior, Slider):
     """
     Hint rectangle color in ``rgba`` format.
 
-    :attr:`hint_bg_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`hint_bg_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -216,7 +216,7 @@ class MDSlider(ThemableBehavior, Slider):
     """
     Hint text color in ``rgba`` format.
 
-    :attr:`hint_text_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`hint_text_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -224,7 +224,7 @@ class MDSlider(ThemableBehavior, Slider):
     """
     Hint radius.
 
-    :attr:`hint_radius` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`hint_radius` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `4`.
     """
 
@@ -232,7 +232,7 @@ class MDSlider(ThemableBehavior, Slider):
     """
     Show the `'off'` ring when set to minimum value.
 
-    :attr:`show_off` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`show_off` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -240,7 +240,7 @@ class MDSlider(ThemableBehavior, Slider):
     """
     Color slider in ``rgba`` format.
 
-    :attr:`color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 

--- a/kivymd/uix/swiper.py
+++ b/kivymd/uix/swiper.py
@@ -312,7 +312,7 @@ class MDSwiper(ScrollView, EventDispatcher):
     """
     The space between each :class:`MDSwiperItem`.
 
-    :attr:`items_spacing` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`items_spacing` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `20dp`.
     """
 
@@ -320,7 +320,7 @@ class MDSwiper(ScrollView, EventDispatcher):
     """
     Duration of switching between :class:`MDSwiperItem`.
 
-    :attr:`transition_duration` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`transition_duration` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.2`.
     """
 
@@ -328,7 +328,7 @@ class MDSwiper(ScrollView, EventDispatcher):
     """
     Duration of changing the size of :class:`MDSwiperItem`.
 
-    :attr:`transition_duration` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`transition_duration` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.2`.
     """
 
@@ -336,7 +336,7 @@ class MDSwiper(ScrollView, EventDispatcher):
     """
     The type of animation used for changing the size of :class:`MDSwiperItem`.
 
-    :attr:`size_transition` is an :class:`~kivy.properties.StringProperty`
+    :attr:`size_transition` is a :class:`~kivy.properties.StringProperty`
     and defaults to `out_quad`.
     """
 
@@ -344,7 +344,7 @@ class MDSwiper(ScrollView, EventDispatcher):
     """
     The type of animation used for swiping.
 
-    :attr:`swipe_transition` is an :class:`~kivy.properties.StringProperty`
+    :attr:`swipe_transition` is a :class:`~kivy.properties.StringProperty`
     and defaults to `out_quad`.
     """
 
@@ -352,7 +352,7 @@ class MDSwiper(ScrollView, EventDispatcher):
     """
     Distance to move before swiping the :class:`MDSwiperItem`.
 
-    :attr:`swipe_distance` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`swipe_distance` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `70dp`.
     """
 
@@ -363,7 +363,7 @@ class MDSwiper(ScrollView, EventDispatcher):
     :class:`MDSwiperItem`. So by decreasing the :attr:`width_mult` the width
     of :class:`MDSwiperItem` increases and vice versa.
 
-    :attr:`width_mult` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`width_mult` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `3`.
     """
 
@@ -371,7 +371,7 @@ class MDSwiper(ScrollView, EventDispatcher):
     """
     Wheter to swipe on mouse wheel scrolling or not.
 
-    :attr:`swipe_on_scroll` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`swipe_on_scroll` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -650,7 +650,7 @@ class MDTabsBase(Widget):
     """
     It will be the label text of the tab.
 
-    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -691,7 +691,7 @@ class MDTabsCarousel(MDCarousel):
     """
     If True - disable switching tabs by swipe.
 
-    :attr:`lock_swiping` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`lock_swiping` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -959,7 +959,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Index of the default tab.
 
-    :attr:`default_tab` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`default_tab` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0`.
     """
 
@@ -967,7 +967,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Height of the tab bar.
 
-    :attr:`tab_bar_height` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`tab_bar_height` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `'48dp'`.
     """
 
@@ -975,7 +975,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Tab indicator animation. If you want use animation set it to ``True``.
 
-    :attr:`tab_indicator_anim` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`tab_indicator_anim` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -983,7 +983,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Height of the tab indicator.
 
-    :attr:`tab_indicator_height` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`tab_indicator_height` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `'2dp'`.
     """
 
@@ -1002,7 +1002,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Duration of the slide animation.
 
-    :attr:`anim_duration` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`anim_duration` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.2`.
     """
 
@@ -1012,7 +1012,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Animation threshold allow you to change the tab indicator animation effect.
 
-    :attr:`anim_threshold` is an :class:`~kivy.properties.BoundedNumericProperty`
+    :attr:`anim_threshold` is a :class:`~kivy.properties.BoundedNumericProperty`
     and defaults to `0.8`.
     """
 
@@ -1020,7 +1020,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     If False - tabs will not stretch to full screen.
 
-    :attr:`allow_stretch` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`allow_stretch` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -1028,7 +1028,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Background color of tabs in ``rgba`` format.
 
-    :attr:`background_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1036,7 +1036,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Text color of the label when it is not selected.
 
-    :attr:`text_color_normal` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`text_color_normal` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `(1, 1, 1, 1)`.
     """
 
@@ -1044,7 +1044,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Text color of the label when it is selected.
 
-    :attr:`text_color_active` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`text_color_active` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `(1, 1, 1, 1)`.
     """
 
@@ -1056,7 +1056,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
 
         `Behaviors/Elevation <https://kivymd.readthedocs.io/en/latest/behaviors/elevation/index.html>`_
 
-    :attr:`elevation` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`elevation` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0`.
     """
 
@@ -1064,7 +1064,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Color indicator in ``rgba`` format.
 
-    :attr:`indicator_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`indicator_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1072,7 +1072,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     If True - disable switching tabs by swipe.
 
-    :attr:`lock_swiping` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`lock_swiping` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -1080,7 +1080,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Font name for tab text.
 
-    :attr:`font_name` is an :class:`~kivy.properties.StringProperty`
+    :attr:`font_name` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'Roboto'`.
     """
 
@@ -1088,7 +1088,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Ripple duration when long touching to tab.
 
-    :attr:`ripple_duration` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`ripple_duration` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `2`.
     """
 
@@ -1096,7 +1096,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     """
     Whether to use the ripple effect when tapping on a tab.
 
-    :attr:`no_ripple_effect` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`no_ripple_effect` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -569,7 +569,7 @@ Builder.load_string(
             ignore_perpendicular_swipes: True
             anim_move_duration: root.anim_duration
             on_index: root.on_carousel_index(*args)
-            on__offset: tab_bar.android_animation(*args)            
+            on__offset: tab_bar.android_animation(*args)
             on_slides:
                 self.index = root.default_tab
                 root.on_carousel_index(self, 0)

--- a/kivymd/uix/taptargetview.py
+++ b/kivymd/uix/taptargetview.py
@@ -234,7 +234,6 @@ from kivy.logger import Logger
 from kivy.metrics import dp
 from kivy.properties import (
     BooleanProperty,
-    ColorProperty,
     ListProperty,
     NumericProperty,
     ObjectProperty,

--- a/kivymd/uix/taptargetview.py
+++ b/kivymd/uix/taptargetview.py
@@ -479,6 +479,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     state = OptionProperty("close", options=["close", "open"])
     """
     State of :class:`~MDTapTargetView`.
+    Available options are `'close'` `'open'`.
 
     :attr:`state` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'close'`.

--- a/kivymd/uix/taptargetview.py
+++ b/kivymd/uix/taptargetview.py
@@ -270,7 +270,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/tap-target-view-widget-outer-radius.png
         :align: center
 
-    :attr:`outer_radius` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`outer_radius` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `dp(200)`.
     """
 
@@ -288,7 +288,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/tap-target-view-widget-outer-circle-color.png
         :align: center
 
-    :attr:`outer_circle_color` is an :class:`~kivy.properties.ListProperty`
+    :attr:`outer_circle_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to ``theme_cls.primary_color``.
     """
 
@@ -296,7 +296,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Alpha value for outer circle.
 
-    :attr:`outer_circle_alpha` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`outer_circle_alpha` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `0.96`.
     """
 
@@ -307,7 +307,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/tap-target-view-widget-target-radius.png
         :align: center
 
-    :attr:`target_radius` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`target_radius` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `dp(45)`.
     """
 
@@ -325,7 +325,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/tap-target-view-widget-target-circle-color.png
         :align: center
 
-    :attr:`target_circle_color` is an :class:`~kivy.properties.ListProperty`
+    :attr:`target_circle_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[1, 1, 1]`.
     """
 
@@ -333,7 +333,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Title to be shown on the view.
 
-    :attr:`title_text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`title_text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -341,7 +341,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Text size for title.
 
-    :attr:`title_text_size` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`title_text_size` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `dp(25)`.
     """
 
@@ -349,7 +349,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Text color for title.
 
-    :attr:`title_text_color` is an :class:`~kivy.properties.ListProperty`
+    :attr:`title_text_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[1, 1, 1, 1]`.
     """
 
@@ -357,7 +357,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Whether title should be bold.
 
-    :attr:`title_text_bold` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`title_text_bold` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -365,7 +365,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Description to be shown below the title (keep it short).
 
-    :attr:`description_text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`description_text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -373,7 +373,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Text size for description text.
 
-    :attr:`description_text_size` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`description_text_size` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `dp(20)`.
     """
 
@@ -381,7 +381,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Text size for description text.
 
-    :attr:`description_text_color` is an :class:`~kivy.properties.ListProperty`
+    :attr:`description_text_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[0.9, 0.9, 0.9, 1]`.
     """
 
@@ -389,7 +389,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Whether description should be bold.
 
-    :attr:`description_text_bold` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`description_text_bold` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -397,7 +397,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Whether to show shadow.
 
-    :attr:`draw_shadow` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`draw_shadow` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -405,7 +405,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Whether clicking outside the outer circle dismisses the view.
 
-    :attr:`cancelable` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`cancelable` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -464,7 +464,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Whether clicking on outer circle stops the animation.
 
-    :attr:`stop_on_outer_touch` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`stop_on_outer_touch` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -472,7 +472,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
     """
     Whether clicking on target circle should stop the animation.
 
-    :attr:`stop_on_target_touch` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`stop_on_target_touch` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -683,7 +683,7 @@ class MDTextFieldRect(ThemableBehavior, TextInput):
     """
     If True, then text field shows animated line when on focus.
 
-    :attr:`line_anim` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`line_anim` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -731,7 +731,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Text for ``helper_text`` mode.
 
-    :attr:`helper_text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`helper_text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'This field is required'`.
     """
 
@@ -750,7 +750,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Maximum allowed value of characters in a text field.
 
-    :attr:`max_text_length` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`max_text_length` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `None`.
     """
 
@@ -758,7 +758,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Required text. If True then the text field requires text.
 
-    :attr:`required` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`required` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -785,7 +785,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Line color normal in ``rgba`` format.
 
-    :attr:`line_color_normal` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`line_color_normal` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -793,7 +793,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Line color focus in ``rgba`` format.
 
-    :attr:`line_color_focus` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`line_color_focus` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -801,7 +801,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     If True, then text field shows animated line when on focus.
 
-    :attr:`line_anim` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`line_anim` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -809,7 +809,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Error color in ``rgba`` format for ``required = True``.
 
-    :attr:`error_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`error_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -818,7 +818,7 @@ class MDTextField(ThemableBehavior, TextInput):
     The background color of the fill in rgba format when the ``mode`` parameter
     is "fill".
 
-    :attr:`fill_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`fill_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `(0, 0, 0, 0)`.
     """
 
@@ -826,7 +826,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Show active line or not.
 
-    :attr:`active_line` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`active_line` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.
     """
 
@@ -834,7 +834,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     If True, then the text field goes into ``error`` mode.
 
-    :attr:`error` is an :class:`~kivy.properties.BooleanProperty`
+    :attr:`error` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
@@ -842,7 +842,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     ``hint_text`` text color.
 
-    :attr:`current_hint_text_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`current_hint_text_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -850,7 +850,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Right icon.
 
-    :attr:`icon_right` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon_right` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -858,7 +858,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Color of right icon in ``rgba`` format.
 
-    :attr:`icon_right_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`icon_right_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `(0, 0, 0, 1)`.
     """
 
@@ -866,7 +866,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Text color in ``rgba`` format.
 
-    :attr:`text_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`text_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1276,7 +1276,7 @@ class MDTextFieldRound(ThemableBehavior, TextInput):
     """
     Left icon.
 
-    :attr:`icon_left` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon_left` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -1284,7 +1284,7 @@ class MDTextFieldRound(ThemableBehavior, TextInput):
     """
     Color of left icon in ``rgba`` format.
 
-    :attr:`icon_left_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`icon_left_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `(0, 0, 0, 1)`.
     """
 
@@ -1292,7 +1292,7 @@ class MDTextFieldRound(ThemableBehavior, TextInput):
     """
     Right icon.
 
-    :attr:`icon_right` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon_right` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -1300,7 +1300,7 @@ class MDTextFieldRound(ThemableBehavior, TextInput):
     """
     Color of right icon.
 
-    :attr:`icon_right_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`icon_right_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `(0, 0, 0, 1)`.
     """
 
@@ -1308,7 +1308,7 @@ class MDTextFieldRound(ThemableBehavior, TextInput):
     """
     Field line color.
 
-    :attr:`line_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`line_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1316,7 +1316,7 @@ class MDTextFieldRound(ThemableBehavior, TextInput):
     """
     Field color if `focus` is `False`.
 
-    :attr:`normal_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`normal_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -1324,7 +1324,7 @@ class MDTextFieldRound(ThemableBehavior, TextInput):
     """
     Field color if `focus` is `True`.
 
-    :attr:`color_active` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`color_active` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 

--- a/kivymd/uix/toolbar.py
+++ b/kivymd/uix/toolbar.py
@@ -384,7 +384,7 @@ class MDToolbar(
     """
     Elevation value.
 
-    :attr:`elevation` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`elevation` is a :class:`~kivy.properties.NumericProperty`
     and defaults to `6`.
     """
 
@@ -400,7 +400,7 @@ class MDToolbar(
     where `'icon_name'` is a string that corresponds to an icon definition and
     ``callback`` is the function called on a touch release event.
 
-    :attr:`left_action_items` is an :class:`~kivy.properties.ListProperty`
+    :attr:`left_action_items` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -409,7 +409,7 @@ class MDToolbar(
     The icons on the left of the toolbar.
     Works the same way as :attr:`left_action_items`.
 
-    :attr:`right_action_items` is an :class:`~kivy.properties.ListProperty`
+    :attr:`right_action_items` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[]`.
     """
 
@@ -417,7 +417,7 @@ class MDToolbar(
     """
     Text toolbar.
 
-    :attr:`title` is an :class:`~kivy.properties.StringProperty`
+    :attr:`title` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -446,7 +446,7 @@ class MDToolbar(
     Rounding the corners at the notch for a button.
     Onle for :class:`~MDBottomAppBar` class.
 
-    :attr:`round` is an :class:`~kivy.properties.NumericProperty`
+    :attr:`round` is a:class:`~kivy.properties.NumericProperty`
     and defaults to `'10dp'`.
     """
 
@@ -454,7 +454,7 @@ class MDToolbar(
     """
     Floating button. Onle for :class:`~MDBottomAppBar` class.
 
-    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    :attr:`icon` is a :class:`~kivy.properties.StringProperty`
     and defaults to `'android'`.
     """
 
@@ -462,7 +462,7 @@ class MDToolbar(
     """
     Color action button. Onle for :class:`~MDBottomAppBar` class.
 
-    :attr:`icon_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`icon_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `[]`.
     """
 
@@ -629,7 +629,7 @@ class MDBottomAppBar(FloatLayout):
     """
     Color toolbar.
 
-    :attr:`md_bg_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`md_bg_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `[0, 0, 0, 0]`.
     """
 

--- a/kivymd/uix/tooltip.py
+++ b/kivymd/uix/tooltip.py
@@ -139,7 +139,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior, Widget):
     """
     Tooltip background color in ``rgba`` format.
 
-    :attr:`tooltip_bg_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`tooltip_bg_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -147,7 +147,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior, Widget):
     """
     Tooltip text color in ``rgba`` format.
 
-    :attr:`tooltip_text_color` is an :class:`~kivy.properties.ColorProperty`
+    :attr:`tooltip_text_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to `None`.
     """
 
@@ -155,7 +155,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior, Widget):
     """
     Tooltip text.
 
-    :attr:`tooltip_text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`tooltip_text` is a :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -177,7 +177,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior, Widget):
     """
     Corner radius values.
 
-    :attr:`radius` is an :class:`~kivy.properties.ListProperty`
+    :attr:`radius` is a :class:`~kivy.properties.ListProperty`
     and defaults to `[dp(7),]`.
     """
 
@@ -185,7 +185,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior, Widget):
     """
     Tooltip dsiplay delay.
 
-    :attr:`tooltip_display_delay` is an :class:`~kivy.properties.BoundedNumericProperty`
+    :attr:`tooltip_display_delay` is a :class:`~kivy.properties.BoundedNumericProperty`
     and defaults to `0`, min of `0` & max of `4`. This property only works on desktop.
     """
 
@@ -193,7 +193,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior, Widget):
     """
     Y-offset of tooltip text.
 
-    :attr:`shift_y` is an :class:`~kivy.properties.StringProperty`
+    :attr:`shift_y` is a :class:`~kivy.properties.StringProperty`
     and defaults to `0`.
     """
 


### PR DESCRIPTION
### Description of Changes
* Fix typo (a and an)
* Removed `get_color_from_hex`
> When handling with `ColorProperty` we can directly give a hex color or rgba it would recognize automatically.
> ex: "FFFFFF", "#FFFFFF", (1, 1, 1, 1)

#### See files by commit to get a clear understand