### PR TITLE
Request a message update for the helper text

### DIFF
--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -948,6 +948,7 @@ class MDTextField(ThemableBehavior, TextInput):
         self.has_had_text = False
         self._better_texture_size = None
         Clock.schedule_once(self.check_text)
+        self._set_msg(self,self.helper_text)
 
     def check_text(self, interval):
         self.set_text(self, self.text)

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -948,7 +948,7 @@ class MDTextField(ThemableBehavior, TextInput):
         self.has_had_text = False
         self._better_texture_size = None
         Clock.schedule_once(self.check_text)
-        self._set_msg(self,self.helper_text)
+        self._set_msg(self, self.helper_text)
 
     def check_text(self, interval):
         self.set_text(self, self.text)


### PR DESCRIPTION
Fix #824

resume: the __init__ call didnt call the update message event because 
the inner memory was set inside the super()__init__ call.

### Description of Changes
The class request a message update inside `__init__`

### Screenshots
```py
from kivymd.app import MDApp
from kivymd.uix.screen import MDScreen
from kivymd.uix.textfield import MDTextField


class Example(MDApp):
    def build(self):
        screen = MDScreen()
        screen.add_widget(
            MDTextField(
                hint_text="hint_text",
                helper_text="helper_text",
                helper_text_mode="on_focus",
                pos_hint={"center_x": .5, "center_y": .5},
                size_hint_x=0.5,
            )
        )
        return screen


Example().run()

```
#### Before
![Captura de pantalla de 2021-02-09 18-13-42](https://user-images.githubusercontent.com/5509325/107445766-b5416300-6b02-11eb-8288-68de389efa68.png)

#### Before
![Captura de pantalla de 2021-02-09 18-13-32](https://user-images.githubusercontent.com/5509325/107445771-b7a3bd00-6b02-11eb-8cf2-55441ff3cd58.png)
