### PR TITLE
Bug fix and compliance to "material IO" spec  update.

### DIFF
--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -112,7 +112,7 @@ Builder.load_string(
         orientation: "vertical"
         size_hint_y: None
         height: self.minimum_height
-        elevation: 4
+        elevation: 24
         md_bg_color: 0, 0, 0, 0
         padding: "24dp", "24dp", "8dp", "8dp"
 
@@ -187,10 +187,12 @@ class BaseDialog(ThemableBehavior, ModalView):
 
     .. code-block:: python
 
-        self.dialog = MDDialog(
-            text="Oops! Something seems to have gone wrong!",
-            radius=[20, 7, 20, 7],
-        )
+        [...]
+            self.dialog = MDDialog(
+                text="Oops! Something seems to have gone wrong!",
+                radius=[20, 7, 20, 7],
+            )
+            [...]
 
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-radius.png
         :align: center
@@ -210,17 +212,19 @@ class MDDialog(BaseDialog):
 
     .. code-block:: python
 
-        self.dialog = MDDialog(
-            title="Reset settings?",
-            buttons=[
-                MDFlatButton(
-                    text="CANCEL", text_color=self.theme_cls.primary_color
-                ),
-                MDFlatButton(
-                    text="ACCEPT", text_color=self.theme_cls.primary_color
-                ),
-            ],
-        )
+        [...]
+            self.dialog = MDDialog(
+                title="Reset settings?",
+                buttons=[
+                    MDFlatButton(
+                        text="CANCEL", text_color=self.theme_cls.primary_color
+                    ),
+                    MDFlatButton(
+                        text="ACCEPT", text_color=self.theme_cls.primary_color
+                    ),
+                ],
+            )
+            [...]
 
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-title.png
         :align: center
@@ -235,18 +239,20 @@ class MDDialog(BaseDialog):
 
     .. code-block:: python
 
-        self.dialog = MDDialog(
-            title="Reset settings?",
-            text="This will reset your device to its default factory settings.",
-            buttons=[
-                MDFlatButton(
-                    text="CANCEL", text_color=self.theme_cls.primary_color
-                ),
-                MDFlatButton(
-                    text="ACCEPT", text_color=self.theme_cls.primary_color
-                ),
-            ],
-        )
+        [...]
+            self.dialog = MDDialog(
+                title="Reset settings?",
+                text="This will reset your device to its default factory settings.",
+                buttons=[
+                    MDFlatButton(
+                        text="CANCEL", text_color=self.theme_cls.primary_color
+                    ),
+                    MDFlatButton(
+                        text="ACCEPT", text_color=self.theme_cls.primary_color
+                    ),
+                ],
+            )
+            [...]
 
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-text.png
         :align: center
@@ -262,12 +268,14 @@ class MDDialog(BaseDialog):
 
     .. code-block:: python
 
-        self.dialog = MDDialog(
-            text="Discard draft?",
-            buttons=[
-                MDFlatButton(text="CANCEL"), MDRaisedButton(text="DISCARD"),
-            ],
-        )
+        [...]
+            self.dialog = MDDialog(
+                text="Discard draft?",
+                buttons=[
+                    MDFlatButton(text="CANCEL"), MDRaisedButton(text="DISCARD"),
+                ],
+            )
+            [...]
 
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/dialog-buttons.png
         :align: center
@@ -606,8 +614,11 @@ class MDDialog(BaseDialog):
         instance_item._txt_left_pad = "56dp"
 
     def create_items(self):
-        self.ids.container.remove_widget(self.ids.text)
-        height = 0
+        if not self.text:
+            self.ids.container.remove_widget(self.ids.text)
+            height = 0
+        else:
+            height = self.ids.text.height
 
         for item in self.items:
             if issubclass(item.__class__, BaseListItem):


### PR DESCRIPTION
### Description of Changes
Fix for #503: the text widget was removed either was needed or not.

Fixed Dialog elevation, from 4 to 24 as the standard requires.
https://material.io/components/dialogs#anatomy

Minor doc fix.

``` python
from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.button import MDFlatButton
from kivymd.uix.dialog import MDDialog

KV = '''
FloatLayout:

    MDFlatButton:
        text: "ALERT DIALOG"
        pos_hint: {'center_x': .5, 'center_y': .5}
        on_release: app.show_alert_dialog()
'''


class Example(MDApp):
    dialog = None

    def build(self):
        return Builder.load_string(KV)

    def show_alert_dialog(self):
        if not self.dialog:
            self.dialog = MDDialog(
                type="simple",
                text="Discard draft?",
                title="Example Title",
                buttons=[
                    MDFlatButton(
                        text="CANCEL", text_color=self.theme_cls.primary_color
                    ),
                    MDFlatButton(
                        text="DISCARD", text_color=self.theme_cls.primary_color
                    ),
                ],
            )
        self.dialog.open()


Example().run()

```
### Screenshots

Before:
![Captura de pantalla de 2021-02-11 01-14-31](https://user-images.githubusercontent.com/5509325/107610189-ad6ae700-6c06-11eb-9b04-2c791a93e1a1.png)

After:
![Captura de pantalla de 2021-02-11 01-14-12](https://user-images.githubusercontent.com/5509325/107610194-b065d780-6c06-11eb-9a6b-220d7ce6fbaa.png)
