### PR TITLE
New Version of HoverBehavior

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -14,7 +14,6 @@ Copyright (c) 2021 tshirtman - magic_behavior module
 Copyright (c) 2021 shashi278 - taptargetview module
 Copyright (c) 2020 Benedikt Zwölfer - fitimage module
 Copyright (c) 2021 Kivy Team and other contributors - components package
-Hoverable Behaviour (changing when the mouse is on the widget by O. Poyen, License: LGPL) - hover_behavior module
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/kivymd/uix/behaviors/hover_behavior.py
+++ b/kivymd/uix/behaviors/hover_behavior.py
@@ -2,7 +2,7 @@
 Behaviors/Hover
 ===============
 
-.. rubric:: Changing when the mouse is on the widget.
+.. rubric:: Changing when the mouse is on the widget and the widget is visible.
 
 To apply hover behavior, you must create a new class that is inherited from the
 widget to which you apply the behavior and from the :attr:`HoverBehavior` class.
@@ -24,6 +24,12 @@ After creating a class, you must define two methods for it:
 :attr:`HoverBehavior.on_enter` and :attr:`HoverBehavior.on_leave`, which will be automatically called
 when the mouse cursor is over the widget and when the mouse cursor goes beyond
 the widget.
+
+.. note::
+
+    :class:`~HoverBehavior` will by default check to see if the current Widget is visible (i.e. not covered by a modal or popup and not a part of a Relative Layout, MDTab or Carousel that is not currently visible etc) and will only issue events if the widget is visible.
+
+    To get the legacy behavior that the events are always triggered, you can set `detect_visible` on the Widget to `False`.
 
 .. code-block:: python
 
@@ -80,55 +86,144 @@ __all__ = ("HoverBehavior",)
 
 from kivy.core.window import Window
 from kivy.properties import BooleanProperty, ObjectProperty
+from kivy.uix.widget import Widget
 
 
 class HoverBehavior(object):
     """
     :Events:
         :attr:`on_enter`
-            Call when mouse enter the bbox of the widget.
+            Call when mouse enters the bbox of the widget AND the widget is visible
         :attr:`on_leave`
-            Call when the mouse exit the widget.
+            Call when the mouse exit the widget AND the widget is visible
     """
 
-    hovered = BooleanProperty(False)
+    hovering = BooleanProperty(False)
     """
     `True`, if the mouse cursor is within the borders of the widget.
 
-    :attr:`hovered` is an :class:`~kivy.properties.BooleanProperty`
+    Note that this is set and cleared even if the widget is not visible
+
+    :attr:`hover` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
     """
 
-    border_point = ObjectProperty(None)
-    """Contains the last relevant point received by the Hoverable.
-    This can be used in :attr:`on_enter` or :attr:`on_leave` in order
-    to know where was dispatched the event.
+    visible = BooleanProperty(False)
+    """
+    `True` if hovering is True AND is the current widget is visible
 
-    :attr:`border_point` is an :class:`~kivy.properties.ObjectProperty`
+    :attr:`visible` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
+
+    enter_point = ObjectProperty(allownone=True)
+    """
+    Holds the last position where the mouse pointer crossed into the Widget
+    if the Widget is visible and is currently in a hovering state
+
+    :attr:`enter_point` is a :class:`~kivy.properties.ObjectProperty`
     and defaults to `None`.
+    """
+
+    detect_visible = BooleanProperty(True)
+    """
+    Should this widget perform the visibility check?
+
+    :attr:`detect_visible` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to  `True`.
     """
 
     def __init__(self, **kwargs):
         self.register_event_type("on_enter")
         self.register_event_type("on_leave")
-        Window.bind(mouse_pos=self.on_mouse_pos)
+        Window.bind(mouse_pos=self.on_mouse_update)
         super(HoverBehavior, self).__init__(**kwargs)
 
-    def on_mouse_pos(self, *args):
+    def on_mouse_update(self, *args):
+        #  If the Widget currently has no parent, do nothing
         if not self.get_root_window():
-            return  # do proceed if I'm not displayed <=> If have no parent
-        pos = args[1]
-        # Next line to_widget allow to compensate for relative layout
-        inside = self.collide_point(*self.to_widget(*pos))
-        if self.hovered == inside:
-            # We have already done what was needed
             return
-        self.border_point = pos
-        self.hovered = inside
-        if inside:
+        pos = args[1]
+        #
+        #  is the pointer in the same position as the widget?
+        #  If not - then issue an on_exit event if needed
+        #
+        if not self.collide_point(*self.to_widget(*pos)):
+            self.hovering = False
+            self.enter_point = None
+            if self.visible:
+                self.visible = False
+                self.dispatch("on_leave")
+            return
+
+        #
+        # The pointer is in the same position as the widget
+        #
+
+        if self.hovering:
+            #
+            #  nothing to do here. Not - this does not handle the case where
+            #  a popup comes over an existing hover event.
+            #  This seems reasonable
+            #
+            return
+
+        #
+        # Otherewise - set the hovering attribute
+        #
+        self.hovering = True
+
+        #
+        # We need to traverse the tree to see if the Widget is visible
+        #
+        # This is a two stage process:
+        # - first go up the tree to the root Window.
+        #   At each stage - check that the Widget is actually visible
+        # - Second - At the root Window check that there is not another branch
+        #   covering the Widget
+        #
+
+        self.visible = True
+        if self.detect_visible:
+            widget: Widget = self
+            while True:
+                # Walk up the Widget tree from the target Widget
+                parent = widget.parent
+                try:
+                    # See if the mouse point collides with the parent
+                    pinside = parent.collide_point(*pos)
+                except Exception:
+                    # The collide_point will error when you reach the root Window
+                    break
+                if not pinside:
+                    self.visible = False
+                    break
+                # Iterate upwards
+                widget = parent
+
+            #
+            #  parent = root window
+            #  widget = first Widget on the current branch
+            #
+
+            children = parent.children
+            for child in children:
+                # For each top level widget - check if is current branch
+                # If it is - then break.
+                # If not then - since we start at 0 - this widget is visible
+                #
+                # Check to see if it should take the hover
+                #
+                if child == widget:
+                    # this means that the current widget is visible
+                    break
+                if child.collide_point(*pos):
+                    #  this means that the current widget is covered by a modal or popup
+                    self.visible = False
+                    break
+        if self.visible:
+            self.enter_point = pos
             self.dispatch("on_enter")
-        else:
-            self.dispatch("on_leave")
 
     def on_enter(self):
         """Call when mouse enter the bbox of the widget."""


### PR DESCRIPTION
- Created new version of HoverBehavior
- Updated Documentation
- Changed the contents of LICENSE to reflect the change

fixes #786 
fixes #783 

### Description of Changes
This version of Hover Behavior is totally new code that:
- retains the previous event API - i.e. `on_enter` and `on_leave`. That is a generic API
- is NOT compatible with the previous Widget attributes
- is defined from the ground up to only trigger events on widgets that are visible
- has the option of implementing the legacy behavior by setting the `detect_visible` attribute to `False`
