### PR TITLE
Prevents error on quick click when TapTargetView is playing

### DIFF
--- a/kivymd/uix/taptargetview.py
+++ b/kivymd/uix/taptargetview.py
@@ -491,6 +491,7 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
         self.ripple_max_dist = dp(90)
         self.on_outer_radius(self, self.outer_radius)
         self.on_target_radius(self, self.target_radius)
+        self.anim_ripple = None
 
         self.core_title_text = Label(
             markup=True, size_hint=(None, None), bold=self.title_text_bold
@@ -591,7 +592,8 @@ class MDTapTargetView(ThemableBehavior, EventDispatcher):
         """Starts widget close animation."""
 
         # It needs a better implementation.
-        self.anim_ripple.unbind(on_complete=self._repeat_ripple)
+        if self.anim_ripple is not None:
+        	self.anim_ripple.unbind(on_complete=self._repeat_ripple)
         self.core_title_text.opacity = 0
         self.core_description_text.opacity = 0
         anim = Animation(


### PR DESCRIPTION
### Description of Changes
During the showing of a TapTargetView object, if you click before the ripple animation is created then the full application stops, because it tries to unbind the repetition by accessing the attribute anim_ripple that might not exist. This commit initializes the attribute and checks if the attribute is really created before trying to access it to unbind the repetition. 
