### PR TITLE
WIP - MDTabs: bugfixes and improvements

### DIFF
--- a/demos/kitchen_sink/libs/baseclass/tabs.py
+++ b/demos/kitchen_sink/libs/baseclass/tabs.py
@@ -5,40 +5,52 @@ from kivymd.icon_definitions import md_icons
 
 
 class KitchenSinkTabs(Screen):
+    # Icons to be used to populate the tabs.
     list_name_icons = list(md_icons.keys())[0:15]
+    # lock the memory to avoid duplicity.
     tabs_created = False
 
     def on_enter(self):
+        # updates the screen afther the animation ends.
         if not self.tabs_created:
             for name_tab in self.list_name_icons:
                 self.ids.android_tabs.add_widget(
-                    Factory.KitchenSinkTabItem(text=name_tab)
+                    Factory.KitchenSinkTabItem(title=name_tab)
                 )
             self.tabs_created = True
 
     def switch_tabs_to_text(self, instance_android_tabs):
-        for instance_tab in instance_android_tabs.ids.scrollview.children[
-            0
-        ].children:
-            for k, v in md_icons.items():
-                if v == instance_tab.text:
-                    instance_android_tabs.ids.scrollview.children[
-                        0
-                    ].remove_widget(instance_tab)
-                    instance_android_tabs.add_widget(
-                        Factory.KitchenSinkTabItem(
-                            text=" ".join(k.split("-")).capitalize()
-                        )
-                    )
-                    break
+        # This function will toggle between text title label to icon title
+        # label for each tab
+        slides = instance_android_tabs.get_slides()
+        for slide in slides:
+            if slide.icon:
+                slide.title = slide.icon
+                slide.icon = ""
 
     def switch_tabs_to_icon(self, instance_android_tabs):
-        for i, instance_tab in enumerate(
-            instance_android_tabs.ids.scrollview.children[0].children
-        ):
-            instance_android_tabs.ids.scrollview.children[0].remove_widget(
-                instance_tab
-            )
-            instance_android_tabs.add_widget(
-                Factory.KitchenSinkTabItem(text=self.list_name_icons[i])
-            )
+        # This function will toggle between text title label to icon title
+        # label for each tab
+        slides = instance_android_tabs.get_slides()
+        for slide in slides:
+            if slide.title:
+                slide.icon = slide.title.lower()
+                slide.title = ""
+
+    def new_update_label(self, instance_android_tabs):
+        # This function will add either the tittle or the icon to the
+        # tab's title label.
+        slides = instance_android_tabs.get_slides()
+        for slide in slides:
+            if slide.icon:
+                slide.title = slide.icon
+            elif slide.title:
+                slide.icon = slide.title.lower()
+
+    def update_mode(self, instance_android_tabs):
+        # This function will update the way in wich the title label displays
+        # the title text and icon.
+        if instance_android_tabs.title_icon_mode == "Lead":
+            instance_android_tabs.title_icon_mode = "Top"
+        else:
+            instance_android_tabs.title_icon_mode = "Lead"

--- a/demos/kitchen_sink/libs/kv/tabs.kv
+++ b/demos/kitchen_sink/libs/kv/tabs.kv
@@ -11,6 +11,7 @@
             id: android_tabs
             tab_indicator_anim: False
             # background_color: app.theme_cls.primary_color
+            tab_indicator_anim: True
 
         BoxLayout:
             size_hint_y: None

--- a/demos/kitchen_sink/libs/kv/tabs.kv
+++ b/demos/kitchen_sink/libs/kv/tabs.kv
@@ -10,7 +10,7 @@
         MDTabs:
             id: android_tabs
             tab_indicator_anim: False
-            background_color: app.theme_cls.primary_color
+            # background_color: app.theme_cls.primary_color
 
         BoxLayout:
             size_hint_y: None
@@ -21,17 +21,26 @@
             MDCheckbox:
                 size_hint: None, None
                 size: "48dp", "48dp"
+                state:"down"
                 on_state:
                     root.switch_tabs_to_text(android_tabs) if self.state == "down" \
                     else root.switch_tabs_to_icon(android_tabs)
             MDLabel:
                 text: "Use text tabs"
+            MDRaisedButton:
+                text:'Use Icon+Label'
+                elevation:4
+                on_release: root.new_update_label(android_tabs)
+            MDRaisedButton:
+                text:'Toggle Title Icon Mode Lead|Top'
+                elevation:4
+                on_release: root.update_mode(android_tabs)
 
             Widget:
 
 
 <KitchenSinkTabItem@BoxLayout+MDTabsBase>
-
+    allow_stretch:False
     FloatLayout:
 
         MDLabel:

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -468,6 +468,8 @@ __all__ = ("MDTabs", "MDTabsBase")
 from kivy.clock import Clock
 from kivy.graphics import RoundedRectangle
 from kivy.lang import Builder
+from kivy.logger import Logger
+from kivy.metrics import dp, sp
 from kivy.properties import (
     AliasProperty,
     BooleanProperty,
@@ -484,7 +486,7 @@ from kivy.uix.scrollview import ScrollView
 from kivy.uix.widget import Widget
 from kivy.utils import boundary
 
-from kivymd import fonts_path
+from kivymd.font_definitions import fonts
 from kivymd.icon_definitions import md_icons
 from kivymd.theming import ThemableBehavior
 from kivymd.uix.behaviors import (
@@ -500,11 +502,11 @@ Builder.load_string(
     """
 #:import DampedScrollEffect kivy.effects.dampedscroll.DampedScrollEffect
 
-
 <MDTabsLabel>
     _set_start_tab: False
     size_hint: None, 1
     halign: "center"
+    valign: "center"
     padding: "12dp", 0
     group: "tabs"
     font: root.font_name
@@ -515,6 +517,8 @@ Builder.load_string(
         self.tab_bar.parent._update_indicator( \
         self.tab_bar.parent.carousel.current_slide.tab_label); \
         self._set_start_tab = True
+        if self.width < dp(90): \
+        self.width = dp(90)
     on_tab_bar:
         self.text_size = (None, None) \
         if self.tab_bar.parent.allow_stretch else (self.width, None)
@@ -585,17 +589,16 @@ Builder.load_string(
 
         MDTabsScrollView:
             id: scrollview
-            on_width: tab_bar._trigger_update_tab_bar()
+            # on_width: tab_bar._trigger_update_tab_bar()
 
-            GridLayout:
+            MDGridLayout:
                 id: layout
                 rows: 1
                 size_hint_y: 1
-                size_hint_x: None
-                width: self.minimum_width
-                on_width: tab_bar._trigger_update_tab_bar()
+                adaptive_width: True
+                # on_width: tab_bar._trigger_update_tab_bar()
 
-                canvas.before:
+                canvas:
                     Color:
                         rgba:
                             root.theme_cls.accent_color \
@@ -633,7 +636,12 @@ class MDTabsLabel(ToggleButtonBehavior, RectangularRippleBehavior, MDLabel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.size_hint_x = None
+        self.size_hint_min_x = dp(90)
         self.min_space = 0
+        self.bind(
+            text=self._update_text_size,
+        )
 
     def on_release(self):
         self.tab_bar.parent.dispatch("on_tab_switch", self.tab, self, self.text)
@@ -647,6 +655,14 @@ class MDTabsLabel(ToggleButtonBehavior, RectangularRippleBehavior, MDLabel):
             self.width = texture.width
             self.min_space = self.width
 
+    def _update_text_size(self, *args):
+        if not self.tab_bar:
+            return
+        if self.tab_bar.parent.allow_stretch is True:
+            self.text_size = (None, None)
+        else:
+            self.text_size = (self.width, None)
+
 
 class MDTabsBase(Widget):
     """
@@ -655,9 +671,47 @@ class MDTabsBase(Widget):
     In this way you have total control over the views of your tabbed panel.
     """
 
+    icon = StringProperty()
+    """
+    This property will set the Tab's Label Icon.
+
+    :attr:`icon` is an :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+    """
+
+    title_icon_mode = OptionProperty("Lead", options=["Lead", "Top"])
+    """
+    This property sets the mode in wich the tab's title and icon are shown.
+
+    :attr:`title_icon_mode` is an :class:`~kivy.properties.OptionProperty`
+    and defaults to `'Lead'`.
+    """
+
+    title = StringProperty()
+    """
+    This property will set the Name of the tab.
+
+    .. note::
+        As a side note.
+
+        All tabs have set `markup = True`.
+        Thanks to this, you can use the kivy markup languaje to set colorful
+        and fully customizable tabs titles.
+
+
+
+    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+    """
+
     text = StringProperty()
     """
-    It will be the label text of the tab.
+    This property is the actual title of the tab.
+    use the property :att:`icon` and :attr:`title` to set this property
+    correctly.
+
+    This property is kept public for specific and backward compatibility
+    purposes.
 
     :attr:`text` is an :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
@@ -674,18 +728,69 @@ class MDTabsBase(Widget):
     def __init__(self, **kwargs):
         self.tab_label = MDTabsLabel(tab=self)
         super().__init__(**kwargs)
+        self.font_style = "Button"
+        self.bind(
+            icon=self._update_text,
+            title=self._update_text,
+            title_icon_mode=self._update_text,
+        )
+        self._update_text()
+
+    def _update_text(self, *args):
+        x = False
+        if self.title:
+            self.title = self.title.upper()
+        if self.icon and self.icon in md_icons:
+            x = True
+            self.text = f"[size=24sp][font={fonts[-1]['fn_regular']}]{md_icons[self.icon]}[/size][/font]"
+            if self.title:
+                self.text = (
+                    self.text
+                    + (" " if self.title_icon_mode == "Lead" else "\n")
+                    + f"[b]{self.title.upper()}[/b]"
+                )
+        else:
+            if self.icon:
+                Logger.error(
+                    f"{self}: [UID] = [{self.uid}]:\n\t"
+                    f"Icon '{self.icon}' not found in md_icons"
+                )
+            if self.title:
+                self.text = f"[b]{self.title.upper()}[/b]"
+            else:
+                if not self.text:
+                    raise ValueError(
+                        f"{self}: [UID] = [{self.uid}]:\n\t"
+                        "No valid Icon was found.\n\t"
+                        "No valid Title was found.\n\t"
+                        f"Icon\t= '{self.icon}'\n\t"
+                        f"Title\t= '{self.title}'\n\t"
+                    )
+
+        self.tab_label.font_size = sp(14)
+        self.tab_label.padding = dp(16), dp(12 if x is True else 17)
+        if self.title:
+            if x is True:
+                self.tab_label.height = dp(48)
+            else:
+                self.tab_label.height = dp(72)
+        else:
+            self.tab_label.height = dp(48)
+        self.on_text(None, None)
 
     def on_text(self, widget, text):
-        # Set the icon
-        if text in md_icons:
-            self.tab_label.font_name = (
-                fonts_path + "materialdesignicons-webfont.ttf"
-            )
-            self.tab_label.text = md_icons[self.text]
-            self.tab_label.font_size = "24sp"
-        # Set the label text
-        else:
-            self.tab_label.text = self.text
+        self.tab_label.text = self.text
+
+    #     # # Set the icon
+    #     # if text in md_icons:
+    #     #     self.tab_label.font_name = (
+    #     #         fonts_path + "materialdesignicons-webfont.ttf"
+    #     #     )
+    #     #     self.tab_label.text = md_icons[self.text]
+    #     #     self.tab_label.font_size = "24sp"
+    #     # # Set the label text
+    #     # else:
+    #     #     self.tab_label.text = self.text
 
 
 class MDTabsMain(MDBoxLayout):
@@ -815,32 +920,32 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
     """
 
     def __init__(self, **kwargs):
-        self._trigger_update_tab_bar = Clock.schedule_once(
-            self._update_tab_bar, 0
-        )
+        # self._trigger_update_tab_bar = Clock.schedule_once(
+        #     self._update_tab_bar, 0
+        # )
         super().__init__(**kwargs)
 
-    def _update_tab_bar(self, *args):
-        if self.parent.allow_stretch:
-            # update width of the labels when it is needed
-            width, tabs = self.scrollview.width, self.layout.children
-            tabs_widths = [t.min_space for t in tabs if t.min_space]
-            tabs_space = float(sum(tabs_widths))
-
-            if not tabs_space:
-                return
-
-            ratio = width / tabs_space
-            use_ratio = True in (width / len(tabs) < w for w in tabs_widths)
-
-            for t in tabs:
-                t.width = (
-                    t.min_space
-                    if tabs_space > width
-                    else t.min_space * ratio
-                    if use_ratio is True
-                    else width / len(tabs)
-                )
+    # def _update_tab_bar(self, *args):
+    #     if self.parent.allow_stretch:
+    #         # update width of the labels when it is needed
+    #         width, tabs = self.scrollview.width, self.layout.children
+    #         tabs_widths = [t.min_space for t in tabs if t.min_space]
+    #         tabs_space = float(sum(tabs_widths))
+    #
+    #         if not tabs_space:
+    #             return
+    #
+    #         ratio = width / tabs_space
+    #         use_ratio = True in (width / len(tabs) < w for w in tabs_widths)
+    #
+    #         for t in tabs:
+    #             t.width = (
+    #                 t.min_space
+    #                 if tabs_space > width
+    #                 else t.min_space * ratio
+    #                 if use_ratio is True
+    #                 else width / len(tabs)
+    #             )
 
     def update_indicator(self, x, w, radius=None):
         # update position and size of the indicator
@@ -861,7 +966,7 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
 
     def tab_bar_autoscroll(self, target, step):
         # automatic scroll animation of the tab bar.
-        bound_left = self.center_x
+        bound_left = self.center_x - self.x
         bound_right = self.layout.width - bound_left
         dt = target.center_x - bound_left
         sx, sy = self.scrollview.convert_distance_to_scroll(dt, 0)
@@ -881,7 +986,6 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
             x = lsx - dst
         else:
             return
-
         x = boundary(x, 0.0, 1.0)
         self.scrollview.goto(x, None)
 
@@ -1109,14 +1213,46 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     and defaults to `True`.
     """
 
+    title_icon_mode = OptionProperty("Lead", options=["Lead", "Top"])
+    """
+    This property sets the mode in wich the tab's title and icon are shown.
+
+    :attr:`title_icon_mode` is an :class:`~kivy.properties.OptionProperty`
+    and defaults to `'Lead'`.
+    """
+
+    force_title_icon_mode = BooleanProperty(True)
+    """
+    If this property is se to `True`, it will force the class to update every
+    tab inside the scroll view to the current `title_icon_mode`
+
+    :attr:`title_icon_mode` is an :class:`~kivy.properties.BooleanProperty`
+    and defaults to `True`.
+    """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.register_event_type("on_tab_switch")
         self.register_event_type("on_ref_press")
         self.register_event_type("on_slide_progress")
         Clock.schedule_once(self._carousel_bind, 1)
-        self.theme_cls.bind(primary_palette=self.update_icon_color)
-        self.theme_cls.bind(theme_style=self.update_icon_color)
+        self.theme_cls.bind(
+            primary_palette=self.update_icon_color,
+            theme_style=self.update_icon_color,
+        )
+        self.bind(
+            force_title_icon_mode=self._parse_icon_mode,
+            title_icon_mode=self._parse_icon_mode,
+        )
+
+    def _parse_icon_mode(self, *args):
+        if self.force_title_icon_mode is True:
+            for slide in self.carousel.slides:
+                slide.title_icon_mode = self.title_icon_mode
+                if self.title_icon_mode == "Top":
+                    self.tab_bar_height = dp(72)
+                else:
+                    self.tab_bar_height = dp(48)
 
     def update_icon_color(self, instance, value):
         for tab_label in self.get_tab_list():
@@ -1142,9 +1278,17 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
 
         return self.tab_bar.layout.children
 
+    def get_slides(self):
+        return self.carousel.slides
+
     def add_widget(self, widget, index=0, canvas=None):
         # You can add only subclass of MDTabsBase.
-        if issubclass(widget.__class__, MDTabsBase):
+        if not isinstance(widget, (MDTabsBase, MDTabsMain, MDTabsBar)):
+            raise ValueError(
+                f"MDTabs[{self.uid}].add_widget:\n\t"
+                "The widget provided is not a subclass of MDTabsBase."
+            )
+        if len(self.children) >= 2:
             try:
                 # FIXME: Can't set the value of the `no_ripple_effect`
                 #  and `ripple_duration` properties for widget.tab_label.
@@ -1155,12 +1299,12 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                 widget.tab_label.text_color_normal = (
                     self.text_color_normal
                     if self.text_color_normal
-                    else self.theme_cls.text_color
+                    else self.specific_secondary_text_color
                 )
                 widget.tab_label.text_color_active = (
                     self.text_color_active
                     if self.text_color_active
-                    else self.specific_secondary_text_color
+                    else self.specific_text_color
                 )
                 self.bind(font_name=widget.tab_label.setter("font_name"))
                 self.bind(
@@ -1175,6 +1319,8 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                 )
                 self.tab_bar.layout.add_widget(widget.tab_label)
                 self.carousel.add_widget(widget)
+                if self.force_title_icon_mode is True:
+                    widget.title_icon_mode = self.title_icon_mode
                 return
             except AttributeError:
                 pass
@@ -1222,6 +1368,8 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
             if current_tab_label.state == "normal":
                 # current_tab_label._do_press()
                 current_tab_label.dispatch("on_release")
+                current_tab_label._release_group(self)
+                current_tab_label.state = "down"
 
             if self.tab_indicator_type == "round":
                 self.tab_indicator_height = self.tab_bar_height

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -588,14 +588,12 @@ Builder.load_string(
 
         MDTabsScrollView:
             id: scrollview
-            # on_width: tab_bar._trigger_update_tab_bar()
 
             MDGridLayout:
                 id: layout
                 rows: 1
                 size_hint_y: 1
                 adaptive_width: True
-                # on_width: tab_bar._trigger_update_tab_bar()
 
                 canvas.before:
                     Color:

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1357,10 +1357,15 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                 break
 
     def on_slide_progress(self, *args):
-        """Called while the slide is scrolling."""
+        """
+        This event is deployed every available frame while the tab is scrolling.
+        """
 
     def on_carousel_index(self, carousel, index):
-        """Called when the carousel index changes."""
+        """Called when the Tab index have changed.
+
+        This event is deployed by the built in carousel of the class.
+        """
 
         # When the index of the carousel change, update tab indicator,
         # select the current tab and reset threshold data.
@@ -1416,11 +1421,11 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                 )
 
     def on_ref_press(self, *args):
-        """The method will be called when the ``on_ref_press`` event
-        occurs when you, for example, use markup text for tabs."""
+        """This event will be launched every time the user press a markup enabled
+        label with a link or reference inside."""
 
     def on_tab_switch(self, *args):
-        """Called when switching tabs."""
+        """This event is launched every time the current tab changes."""
 
     def on_size(self, *args):
         if self.carousel.current_slide:

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -971,11 +971,6 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
             forward = offset < 0
             offset = abs(offset)
             step = offset / float(carousel.width)
-            distance = abs(offset - carousel.width)
-            threshold = self.parent.anim_threshold
-            breakpoint = carousel.width - (carousel.width * threshold)
-            traveled = distance / breakpoint if breakpoint else 0
-            break_step = 1.0 - traveled
             indicator_animation = self.parent.tab_indicator_anim
 
             skip_slide = (
@@ -995,38 +990,16 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
             b = self.target.tab_label
             self.tab_bar_autoscroll(b, step)
 
-            if not indicator_animation:
+            # avoids the animation if `indicator_animation` is True
+            if indicator_animation is False:
                 return
-
-            if step <= threshold:
-                if forward:
-                    gap_w = abs((a.x + a.width) - (b.x + b.width))
-                    w_step = a.width + (gap_w * step)
-                    x_step = a.x
-                else:
-                    gap = abs((a.x - b.x))
-                    x_step = a.x - gap * step
-                    w_step = a.width + gap * step
+            gap_x = abs((a.x) - (b.x))
+            gap_w = (b.width) - (a.width)
+            if forward:
+                x_step = a.x + (gap_x * step)
             else:
-                if forward:
-                    x_step = a.x + abs((a.x - b.x)) * break_step
-                    gap_w = abs((a.x + a.width) - (b.x + b.width))
-                    ind_width = a.width + gap_w * threshold
-                    gap_w = ind_width - b.width
-                    w_step = ind_width - (gap_w * break_step)
-                else:
-                    x_step = a.x - abs((a.x - b.x)) * threshold
-                    x_step = x_step - abs(x_step - b.x) * break_step
-                    ind_width = (
-                        (a.x + a.width) - x_step if threshold else a.width
-                    )
-                    gap_w = ind_width - b.width
-                    w_step = ind_width - (gap_w * break_step)
-                    w_step = (
-                        w_step
-                        if w_step + x_step <= a.x + a.width
-                        else ind_width
-                    )
+                x_step = a.x - gap_x * step
+            w_step = a.width + (gap_w * step)
             self.update_indicator(x_step, w_step)
 
 

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -660,6 +660,7 @@ class MDTabsLabel(ToggleButtonBehavior, RectangularRippleBehavior, MDLabel):
             self.text_size = (None, None)
         else:
             self.text_size = (self.width, None)
+        Clock.schedule_once(self.tab_bar._label_request_indicator_update, 0)
 
 
 class MDTabsBase(Widget):
@@ -999,6 +1000,10 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
                 x_step = a.x - gap_x * step
             w_step = a.width + (gap_w * step)
             self.update_indicator(x_step, w_step)
+
+    def _label_request_indicator_update(self, *args):
+        widget = self.carousel.current_slide.tab_label
+        self.update_indicator(widget.x, widget.width)
 
 
 class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -466,7 +466,6 @@ Switching the tab by name
 __all__ = ("MDTabs", "MDTabsBase")
 
 from kivy.clock import Clock
-from kivy.graphics import RoundedRectangle
 from kivy.lang import Builder
 from kivy.logger import Logger
 from kivy.metrics import dp, sp
@@ -598,12 +597,13 @@ Builder.load_string(
                 adaptive_width: True
                 # on_width: tab_bar._trigger_update_tab_bar()
 
-                canvas:
+                canvas.before:
                     Color:
                         rgba:
                             root.theme_cls.accent_color \
                             if not root.indicator_color else root.indicator_color
                     RoundedRectangle:
+                        group: "Indicator_line"
                         pos: self.pos
                         size: 0, root.tab_indicator_height
                         radius: [0,]
@@ -894,9 +894,10 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
     """
 
     def get_rect_instruction(self):
-        for canvas_instruction in self.layout.canvas.before.children:
-            if isinstance(canvas_instruction, RoundedRectangle):
-                return canvas_instruction
+        canvas_instructions = self.layout.canvas.before.get_group(
+            "Indicator_line"
+        )
+        return canvas_instructions[0]
 
     indicator = AliasProperty(get_rect_instruction, cache=True)
     """

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -921,32 +921,7 @@ class MDTabsBar(ThemableBehavior, RectangularElevationBehavior, MDBoxLayout):
     """
 
     def __init__(self, **kwargs):
-        # self._trigger_update_tab_bar = Clock.schedule_once(
-        #     self._update_tab_bar, 0
-        # )
         super().__init__(**kwargs)
-
-    # def _update_tab_bar(self, *args):
-    #     if self.parent.allow_stretch:
-    #         # update width of the labels when it is needed
-    #         width, tabs = self.scrollview.width, self.layout.children
-    #         tabs_widths = [t.min_space for t in tabs if t.min_space]
-    #         tabs_space = float(sum(tabs_widths))
-    #
-    #         if not tabs_space:
-    #             return
-    #
-    #         ratio = width / tabs_space
-    #         use_ratio = True in (width / len(tabs) < w for w in tabs_widths)
-    #
-    #         for t in tabs:
-    #             t.width = (
-    #                 t.min_space
-    #                 if tabs_space > width
-    #                 else t.min_space * ratio
-    #                 if use_ratio is True
-    #                 else width / len(tabs)
-    #             )
 
     def update_indicator(self, x, w, radius=None):
         # update position and size of the indicator
@@ -1425,7 +1400,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         label with a link or reference inside."""
 
     def on_tab_switch(self, *args):
-        """This event is launched every time the current tab changes."""
+        """This event is launched every time the current tab is changed."""
 
     def on_size(self, *args):
         if self.carousel.current_slide:


### PR DESCRIPTION
### Description of Changes

- Fixed animation, issue #770

- Fixed tab size,  issue #874

- Fixed toggle behavior missing group release.

- Fixed Toggle behavior when the tab container is displayed on screen (the 
current label wasn't toggled down, and the group wasn't released)

- Simplify the work with icons, text and mixed labels.

- Added documentation for every new property.

- Fixed some minor issues.

- Kitchen sink demo was updated.

- Indicator canvas instruction fixed:
The prior method used the class instance instead of a group name inside  the canvas layers.
This method ensures that the instruction referred to is always the correct.

- Minor doc updates on event description.

- Indicator Animation simplified.

- This fix allows the indicator to change size every time theres a label 
size update.

- Removed some unused kv code

- Simplified Android Animation processing.


#### NEW:

1.- you can set the title label directly with text in the current 
font_style for buttons.

2.- You can now set the icon easier and edit it in a simplified way for 
dynamic title labels.

3.- Title label complies with Material IO spec definitions.

4.- You can set the title label mode for mixed labels (Modes available `"Lead"`, `"Top"`) inside each tab.

5.- You can now force a mode for every tabs label title.

6.- The scroll_view in which the title labels are stored now changes size depending on the mode selected. (only works for fixed mode. Done inside class MDTabs():)

7.- Now you can get the slides list directly from class MDTabs.

8.- the tabs label minimum size is set to 90 dpi as the Material IO 
requires.

9.- removes some trigger updates that weren't necessary. (duplicated the behavior form MDLabel, and its container.)

10.- The kitchen sink demo features the current simplified method to update the tab's label.

### Screenshots

#### Before

https://user-images.githubusercontent.com/5509325/108486224-79756e80-7263-11eb-89e8-1af9ee47bcd5.mp4


#### After

https://user-images.githubusercontent.com/5509325/108486236-7c705f00-7263-11eb-8b20-993e48198265.mp4

