### PR TITLE
MD Tab Update

### DIFF
--- a/demos/kitchen_sink/assets/usage/Components-Tabs.txt
+++ b/demos/kitchen_sink/assets/usage/Components-Tabs.txt
@@ -35,12 +35,13 @@ class Example(MDApp):
 
     def on_start(self):
         for i in range(20):
-            self.root.ids.tabs.add_widget(Tab(text=f"Tab {i}"))
+            # Add a new tab to the MDTabs Layout.
+            self.root.ids.tabs.add_widget(Tab(title=f"Tab {i}"))
 
     def on_tab_switch(
         self, instance_tabs, instance_tab, instance_tab_label, tab_text
     ):
-        """Called when switching tabs.
+        """Called when the tab is switched.
 
         :type instance_tabs: <kivymd.uix.tab.MDTabs object>;
         :param instance_tab: <__main__.Tab object>;
@@ -48,7 +49,7 @@ class Example(MDApp):
         :param tab_text: text or name icon of tab;
         """
 
-        instance_tab.ids.label.text = tab_text
+        instance_tab.ids.label.text = f" This is the content of {tab_text}"
 
 
 Example().run()

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -166,8 +166,8 @@ from kivy.utils import get_color_from_hex
 
 from kivymd import images_path
 from kivymd.color_definitions import colors, hue, palette
-from kivymd.material_resources import DEVICE_IOS, DEVICE_TYPE
 from kivymd.font_definitions import theme_font_styles
+from kivymd.material_resources import DEVICE_IOS, DEVICE_TYPE
 
 
 class ThemeManager(EventDispatcher):
@@ -1057,7 +1057,7 @@ class ThemeManager(EventDispatcher):
         self.colors = colors
         Clock.schedule_once(self.sync_theme_styles)
 
-    def sync_theme_styles(self,*args):
+    def sync_theme_styles(self, *args):
         # Syncs the values from self.font_styles to theme_font_styles
         # this will ensure continuity when someone registers a new font_style.
         for num, style in enumerate(theme_font_styles):
@@ -1065,7 +1065,6 @@ class ThemeManager(EventDispatcher):
                 theme_font_styles.pop(num)
         for style in self.font_styles.keys():
             theme_font_styles.append(style)
-
 
 
 class ThemableBehavior(EventDispatcher):

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -167,6 +167,7 @@ from kivy.utils import get_color_from_hex
 from kivymd import images_path
 from kivymd.color_definitions import colors, hue, palette
 from kivymd.material_resources import DEVICE_IOS, DEVICE_TYPE
+from kivymd.font_definitions import theme_font_styles
 
 
 class ThemeManager(EventDispatcher):
@@ -1052,7 +1053,19 @@ class ThemeManager(EventDispatcher):
         Clock.schedule_once(lambda x: self.on_theme_style(0, self.theme_style))
         self._determine_device_orientation(None, Window.size)
         Window.bind(size=self._determine_device_orientation)
+        self.bind(font_styles=self.sync_theme_styles)
         self.colors = colors
+        Clock.schedule_once(self.sync_theme_styles)
+
+    def sync_theme_styles(self,*args):
+        # Syncs the values from self.font_styles to theme_font_styles
+        # this will ensure continuity when someone registers a new font_style.
+        for num, style in enumerate(theme_font_styles):
+            if style not in self.font_styles:
+                theme_font_styles.pop(num)
+        for style in self.font_styles.keys():
+            theme_font_styles.append(style)
+
 
 
 class ThemableBehavior(EventDispatcher):

--- a/kivymd/uix/carousel.py
+++ b/kivymd/uix/carousel.py
@@ -1,3 +1,57 @@
+"""
+Components/Carousel
+=====================
+
+:class:`~kivy.uix.boxlayout.Carousel` class equivalent. Simplifies working
+with some widget properties. For example:
+
+
+Carousel
+---------
+
+.. code-block:: python
+
+    kv='''
+        YourCarousel:
+            BoxLayout:
+                [...]
+            BoxLayout:
+                [...]
+            BoxLayout:
+                [...]
+    '''
+    builder.load_string(kv)
+
+    class YourCarousel(Carousel):
+        def __init__(self,*kwargs):
+            self.register_event_type("on_slide_progress")
+            self.register_event_type("on_slide_complete")
+
+        def on_touch_down(self, *args):
+            ["Code to detect when the slide changes"]
+
+        def on_touch_up(self, *args):
+            ["Code to detect when the slide changes"]
+
+        def Calculate_slide_pos(self, *args):
+            ["Code to calculate the current position of the slide"]
+
+        def do_custom_animation(self, *args)
+            ["Code to recreate an animation"]
+
+
+MDCarousel
+-----------
+
+.. code-block:: kv
+
+    MDCarousel:
+        on_slide_progress:
+            do_something()
+        on_slide_complete:
+            do_something()
+
+"""
 # TODO: Add documentation.
 
 from kivy.animation import Animation
@@ -5,6 +59,12 @@ from kivy.uix.carousel import Carousel
 
 
 class MDCarousel(Carousel):
+    """
+    based on kivy's carousel.
+
+    .. seealso::
+        `kivy.uix.carousel.Carousel <https://kivy.org/doc/stable/api-kivy.uix.carousel.html>`_
+    """
 
     _scrolling = False
 
@@ -14,9 +74,17 @@ class MDCarousel(Carousel):
         self.register_event_type("on_slide_complete")
 
     def on_slide_progress(self, *args):
+        """
+        Event launched when the Slide animation is progress.
+        rememebr to bind and unbid to this method.
+        """
         pass
 
     def on_slide_complete(self, *args):
+        """
+        Event launched when the Slide animation is complete.
+        rememebr to bind and unbid to this method.
+        """
         pass
 
     def _position_visible_slides(self, *args):

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -708,8 +708,10 @@ class MDTabsBase(Widget):
     and defaults to `''`.
     """
 
-    text = StringProperty()
+    text = StringProperty(deprecated=True)
     """
+    This property is deprecated, use :attr:`tab_label_text` instead,
+
     This property is the actual title of the tab.
     use the property :attr:`icon` and :attr:`title` to set this property
     correctly.
@@ -718,6 +720,19 @@ class MDTabsBase(Widget):
     purposes.
 
     :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+    """
+
+    tab_label_text = StringProperty()
+    """
+    This property is the actual title's Label of the tab.
+    use the property :attr:`icon` and :attr:`title` to set this property
+    correctly.
+
+    This property is kept public for specific and backward compatibility
+    purposes.
+
+    :attr:`tab_label_text` is an :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
@@ -760,6 +775,8 @@ class MDTabsBase(Widget):
             icon=self._update_text,
             title=self._update_text,
             title_icon_mode=self._update_text,
+            text=self.update_label_text,
+            tab_label_text=self.update_label_text,
         )
         Clock.schedule_once(
             self._update_text
@@ -805,10 +822,13 @@ class MDTabsBase(Widget):
                 self.tab_label.height = dp(72)
         else:
             self.tab_label.height = dp(48)
-        self.on_text(None, None)
+        self.update_label_text(None, self.tab_label_text)
 
+    def update_label_text(self, widget, value):
+        self.tab_label.text = self.tab_label_text
+        
     def on_text(self, widget, text):
-        self.tab_label.text = self.text
+        self.tab_label_text = self.text
 
 
 class MDTabsMain(MDBoxLayout):

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1321,7 +1321,9 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         if not self.ids.layout.children:
             return
         if self.tab_hint_x is True:
-            self.fixed_tab_label_width = self.width//len(self.ids.layout.children)
+            self.fixed_tab_label_width = self.width // len(
+                self.ids.layout.children
+            )
             self.allow_stretch = False
         else:
             self.allow_stretch = True
@@ -1428,7 +1430,8 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                     fixed_tab_label_width=widget.tab_label._update_text_size,
                     font_name=widget.tab_label.setter("font_name"),
                     text_color_active=widget.tab_label.setter(
-                        "text_color_active"),
+                        "text_color_active"
+                    ),
                     text_color_normal=widget.tab_label.setter(
                         "text_color_normal"
                     ),

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -566,9 +566,6 @@ Builder.load_string(
             anim_move_duration: root.anim_duration
             on_index: root.on_carousel_index(*args)
             on__offset: tab_bar.android_animation(*args)
-            on_slides:
-                self.index = root.default_tab
-                root.on_carousel_index(self, 0)
 
     MDTabsBar:
         id: tab_bar

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1174,7 +1174,12 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
 
     allow_stretch = BooleanProperty(True)
     """
-    If False - tabs will not stretch to full screen.
+    If `True`, The tab will update dynamically to it's content width, and wrap
+    any text if the widget is bigger than `"360dp"`.
+
+    If `False`, the tab won't update to it's maximum texture width.
+    this means that the `fixed_tab_label_width` will be used as the label
+    width.
 
     :attr:`allow_stretch` is an :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -553,6 +553,9 @@ Builder.load_string(
     _line_height: 0
     _line_radius: 0
 
+    on_size:
+        root._update_padding(layout)
+
     MDTabsMain:
         padding: 0, tab_bar.height, 0, 0
 
@@ -588,7 +591,8 @@ Builder.load_string(
                 rows: 1
                 size_hint_y: 1
                 adaptive_width: True
-                padding: dp(0 if self.width <= scrollview.width else 52),0
+                on_size:
+                    root._update_padding(layout)
                 canvas.before:
                     Color:
                         rgba:
@@ -1441,3 +1445,17 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         if not current_tab_label:
             current_tab_label = self.tab_bar.layout.children[-1]
         Clock.schedule_once(update_indicator)
+
+    def _update_padding(self, layout, *args):
+        padding = [0,0]
+        # this is more efficient than to use sum([layout.children])
+        width = layout.width - (layout.padding[0]*2)
+        # Forcess the padding of the tab_bar when the tab_bar is scrollable
+        if width > self.width:
+            padding = [dp(52),0]
+        # set the new padding
+        layout.padding = padding
+        # Update the indicator
+        if self.carousel.current_slide:
+            self._update_indicator(self.carousel.current_slide.tab_label)
+        return True

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -837,19 +837,22 @@ class MDTabsBase(Widget):
         )  # This will ensure the text is correct
 
     def _update_text(self, *args):
-        x = False
+        # ensures that the title is in capital letters.
         if self.title:
             if self.title != self.title.upper():
                 self.title = self.title.upper()
+                # Avoids event recursion.
+                return
+        # Add the icon.
         if self.icon and self.icon in md_icons:
-            x = True
-            self.text = f"[size=24sp][font={fonts[-1]['fn_regular']}]{md_icons[self.icon]}[/size][/font]"
+            self.tab_label_text = f"[size=24sp][font={fonts[-1]['fn_regular']}]{md_icons[self.icon]}[/size][/font]"
             if self.title:
-                self.text = (
+                self.tab_label_text = (
                     self.text
                     + (" " if self.title_icon_mode == "Lead" else "\n")
                     + self.title
                 )
+        # add the title
         else:
             if self.icon:
                 Logger.error(
@@ -857,7 +860,7 @@ class MDTabsBase(Widget):
                     f"Icon '{self.icon}' not found in md_icons"
                 )
             if self.title:
-                self.text = self.title
+                self.tab_label_text = self.title
             else:
                 if not self.tab_label_text:
                     raise ValueError(
@@ -869,13 +872,6 @@ class MDTabsBase(Widget):
                     )
 
         self.tab_label.padding = dp(16), 0
-        if self.title:
-            if x is True:
-                self.tab_label.height = dp(48)
-            else:
-                self.tab_label.height = dp(72)
-        else:
-            self.tab_label.height = dp(48)
         self.update_label_text(None, self.tab_label_text)
 
     def update_label_text(self, widget, value):

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -775,8 +775,7 @@ class MDTabsBase(Widget):
                         f"Title\t= '{self.title}'\n\t"
                     )
 
-        self.tab_label.font_size = sp(14)
-        self.tab_label.padding = dp(16), dp(12 if x is True else 17)
+        self.tab_label.padding = dp(16),0
         if self.title:
             if x is True:
                 self.tab_label.height = dp(48)

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -628,7 +628,7 @@ class MDTabsLabel(ToggleButtonBehavior, RectangularRippleBehavior, MDLabel):
     font_name = StringProperty("Roboto")
 
     def __init__(self, **kwargs):
-        self.split_str=" ,-"
+        self.split_str = " ,-"
         super().__init__(**kwargs)
         self.max_lines = 2
         self.size_hint_x = None
@@ -733,7 +733,7 @@ class MDTabsBase(Widget):
         if self.tab_label:
             return self.tab_label.font_style
 
-    def _set_label_font_style(self,value):
+    def _set_label_font_style(self, value):
         if self.tab_label:
             if value in theme_font_styles:
                 self.tab_label.font_style = value
@@ -744,14 +744,14 @@ class MDTabsBase(Widget):
                     f"font_style = {value}"
                 )
         else:
-            Clock.schedule_once(lambda x:self._set_label_font_style(value))
+            Clock.schedule_once(lambda x: self._set_label_font_style(value))
             return True
 
     tab_label_font_style = AliasProperty(
         _get_label_font_style,
         _set_label_font_style,
         cache=True,
-        )
+    )
 
     def __init__(self, **kwargs):
         self.tab_label = MDTabsLabel(tab=self)
@@ -761,7 +761,9 @@ class MDTabsBase(Widget):
             title=self._update_text,
             title_icon_mode=self._update_text,
         )
-        Clock.schedule_once(self._update_text) # This will ensure the text is correct
+        Clock.schedule_once(
+            self._update_text
+        )  # This will ensure the text is correct
 
     def _update_text(self, *args):
         x = False
@@ -795,7 +797,7 @@ class MDTabsBase(Widget):
                         f"Title\t= '{self.title}'\n\t"
                     )
 
-        self.tab_label.padding = dp(16),0
+        self.tab_label.padding = dp(16), 0
         if self.title:
             if x is True:
                 self.tab_label.height = dp(48)
@@ -807,6 +809,7 @@ class MDTabsBase(Widget):
 
     def on_text(self, widget, text):
         self.tab_label.text = self.text
+
 
 class MDTabsMain(MDBoxLayout):
     """
@@ -1283,8 +1286,8 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                     else self.specific_text_color
                 )
                 self.bind(
-                    allow_stretch = widget.tab_label._update_text_size,
-                    fixed_tab_label_width = widget.tab_label._update_text_size
+                    allow_stretch=widget.tab_label._update_text_size,
+                    fixed_tab_label_width=widget.tab_label._update_text_size,
                 )
                 self.bind(font_name=widget.tab_label.setter("font_name"))
                 self.bind(
@@ -1302,7 +1305,9 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                 self.carousel.add_widget(widget)
                 if self.force_title_icon_mode is True:
                     widget.title_icon_mode = self.title_icon_mode
-                Clock.schedule_once(self.tab_bar._label_request_indicator_update,0)
+                Clock.schedule_once(
+                    self.tab_bar._label_request_indicator_update, 0
+                )
                 return
             except AttributeError:
                 pass
@@ -1435,12 +1440,12 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         Clock.schedule_once(update_indicator)
 
     def _update_padding(self, layout, *args):
-        padding = [0,0]
+        padding = [0, 0]
         # this is more efficient than to use sum([layout.children])
-        width = layout.width - (layout.padding[0]*2)
+        width = layout.width - (layout.padding[0] * 2)
         # Forcess the padding of the tab_bar when the tab_bar is scrollable
         if width > self.width:
-            padding = [dp(52),0]
+            padding = [dp(52), 0]
         # set the new padding
         layout.padding = padding
         # Update the indicator

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -837,7 +837,8 @@ class MDTabsBase(Widget):
     def _update_text(self, *args):
         x = False
         if self.title:
-            self.title = self.title.upper()
+            if self.title != self.title.upper():
+                self.title = self.title.upper()
         if self.icon and self.icon in md_icons:
             x = True
             self.text = f"[size=24sp][font={fonts[-1]['fn_regular']}]{md_icons[self.icon]}[/size][/font]"

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1321,30 +1321,37 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
 
         `search_by` will look up through the properties of every tab.
 
+        if the value doesnt match, it will raise a ValueError.
+
         search_by options:
-            text : will search by the raw text of the label
+            text : will search by the raw text of the label (`tab_label_text`)
             icon : will search by the `icon` property
             title : will search by the `title` property
         """
         if isinstance(name_tab, str):
-            if search_by == "tab_label_text":
-                for instance_tab in self.tab_bar.parent.carousel.slides:
-                    if instance_tab.tab_label_text == name_tab:
-                        self.carousel.load_slide(instance_tab)
+            if search_by == "title":
+
+                for tab_instance in self.tab_bar.parent.carousel.slides:
+                    if tab_instance.title_is_capital is True:
+                        _name_tab = name_tab.upper()
+                    else:
+                        _name_tab = name_tab
+                    if tab_instance.title == _name_tab:
+                        self.carousel.load_slide(tab_instance)
                         return
 
             # search by icon.
             elif search_by == "icon":
-                for instance_tab in self.tab_bar.parent.carousel.slides:
-                    if instance_tab.icon == name_tab:
-                        self.carousel.load_slide(instance_tab)
+                for tab_instance in self.tab_bar.parent.carousel.slides:
+                    if tab_instance.icon == name_tab:
+                        self.carousel.load_slide(tab_instance)
                         return
 
             # search by title
             else:
-                for instance_tab in self.tab_bar.parent.carousel.slides:
-                    if instance_tab.title == name_tab.upper():
-                        self.carousel.load_slide(instance_tab)
+                for tab_instance in self.tab_bar.parent.carousel.slides:
+                    if tab_instance.tab_label_text == name_tab:
+                        self.carousel.load_slide(tab_instance)
                         return
 
             raise ValueError(

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -485,7 +485,7 @@ from kivy.uix.scrollview import ScrollView
 from kivy.uix.widget import Widget
 from kivy.utils import boundary
 
-from kivymd.font_definitions import fonts
+from kivymd.font_definitions import fonts, theme_font_styles
 from kivymd.icon_definitions import md_icons
 from kivymd.theming import ThemableBehavior
 from kivymd.uix.behaviors import (
@@ -732,10 +732,32 @@ class MDTabsBase(Widget):
     and defaults to `None`.
     """
 
+    def _get_label_font_style(self):
+        if self.tab_label:
+            return self.tab_label.font_style
+    def _set_label_font_style(self,value):
+        if self.tab_label:
+            if value in theme_font_styles:
+                self.tab_label.font_style = value
+            else:
+                raise ValueError(
+                    "tab_label_font_style:\n\t"
+                    "font_style not found in theme_font_styles\n\t"
+                    f"font_style = {value}"
+                )
+        else:
+            Clock.schedule_once(lambda x:self._set_label_font_style(value))
+            return True
+
+    tab_label_font_style = AliasProperty(
+        _get_label_font_style,
+        _set_label_font_style,
+        cache=True,
+        )
+
     def __init__(self, **kwargs):
         self.tab_label = MDTabsLabel(tab=self)
         super().__init__(**kwargs)
-        self.font_style = "Button"
         self.bind(
             icon=self._update_text,
             title=self._update_text,
@@ -1262,7 +1284,10 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                     if self.text_color_active
                     else self.specific_text_color
                 )
-                self.bind(allow_stretch = widget.tab_label._update_text_size)
+                self.bind(
+                    allow_stretch = widget.tab_label._update_text_size,
+                    fixed_tab_label_width = widget.tab_label._update_text_size
+                )
                 self.bind(font_name=widget.tab_label.setter("font_name"))
                 self.bind(
                     text_color_active=widget.tab_label.setter(
@@ -1292,7 +1317,10 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
             raise MDTabsException(
                 "MDTabs can remove only subclass of MDTabsLabel"
             )
-        self.unbind(allow_stretch = widget.tab_label._update_text_size)
+        self.unbind(
+            allow_stretch = widget.tab_label._update_text_size,
+            fixed_tab_label_width = widget.tab_label._update_text_size,
+        )
         self.unbind(font_name=widget.tab_label.setter("font_name"))
         self.unbind(
             text_color_active=widget.tab_label.setter(

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -506,7 +506,6 @@ Builder.load_string(
     size_hint: None, 1
     halign: "center"
     valign: "center"
-    padding: "12dp", 0
     group: "tabs"
     font: root.font_name
     allow_no_selection: False
@@ -516,8 +515,6 @@ Builder.load_string(
         self.tab_bar.parent._update_indicator( \
         self.tab_bar.parent.carousel.current_slide.tab_label); \
         self._set_start_tab = True
-        if self.width < dp(90): \
-        self.width = dp(90)
     on_tab_bar:
         self.text_size = (None, None) \
         if self.tab_bar.parent.allow_stretch else (self.width, None)

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -585,13 +585,14 @@ Builder.load_string(
 
         MDTabsScrollView:
             id: scrollview
+            do_scroll_x: False if layout.width <= self.width else True
 
             MDGridLayout:
                 id: layout
                 rows: 1
                 size_hint_y: 1
                 adaptive_width: True
-
+                padding: dp(0 if self.width <= scrollview.width else 52),0
                 canvas.before:
                     Color:
                         rgba:

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -699,10 +699,14 @@ class MDTabsBase(Widget):
         As a side note.
 
         All tabs have set `markup = True`.
-        Thanks to this, you can use the kivy markup languaje to set colorful
+        Thanks to this, you can use the kivy markup languaje to set a colorful
         and fully customizable tabs titles.
 
+    .. warning::
 
+        The material design requires that every title label is written in
+        capital letters, because of this, the `string.upper()` will be applied
+        to it's contents.
 
     :attr:`text` is an :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
@@ -767,6 +771,15 @@ class MDTabsBase(Widget):
         _set_label_font_style,
         cache=True,
     )
+    """
+    :attr:`tab_label_font_style` is an :class:`~kivy.properties.AliasProperty`
+    that behavies similar to an :class:`~kivy.properties.OptionProperty`
+    This property behaviors allows the developer to use any new label style
+    registered to the app.
+
+    this property will affect the Tab's Title Label widget.
+
+    """
 
     def __init__(self, **kwargs):
         self.tab_label = MDTabsLabel(tab=self)

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -650,7 +650,7 @@ class MDTabsLabel(ToggleButtonBehavior, RectangularRippleBehavior, MDLabel):
     def on_texture(self, widget, texture):
         # just save the minimum width of the label based of the content
         if texture:
-            max_width = dp(150)
+            max_width = dp(360)
             min_width = dp(90)
             if texture.width > max_width:
                 self.width = max_width

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -25,16 +25,17 @@ content for the tab.
 
     class Tab(MDFloatLayout, MDTabsBase):
         '''Class implementing content for a tab.'''
+        content_text = StringProperty("")
 
 .. code-block:: kv
 
     <Tab>
-
+        content_text
         MDLabel:
-            text: "Content"
+            text: root.content_text
             pos_hint: {"center_x": .5, "center_y": .5}
 
-Tabs must be placed in the :class:`~MDTabs` container:
+All tabs must be contained inside a :class:`~MDTabs` widget:
 
 .. code-block:: kv
 
@@ -43,10 +44,12 @@ Tabs must be placed in the :class:`~MDTabs` container:
         MDTabs:
 
             Tab:
-                text: "Tab 1"
+                title: "Tab 1"
+                content_text: f"This is an example text for {self.title}"
 
             Tab:
-                text: "Tab 1"
+                title: "Tab 2"
+                content_text: f"This is an example text for {self.title}"
 
             ...
 
@@ -78,7 +81,7 @@ Example with tab icon
 
         MDIconButton:
             id: icon
-            icon: app.icons[0]
+            icon: root.icon
             user_font_size: "48sp"
             pos_hint: {"center_x": .5, "center_y": .5}
     '''
@@ -95,8 +98,8 @@ Example with tab icon
             return Builder.load_string(KV)
 
         def on_start(self):
-            for name_tab in self.icons:
-                self.root.ids.tabs.add_widget(Tab(icon=name_tab))
+            for tab_name in self.icons:
+                self.root.ids.tabs.add_widget(Tab(icon=tab_name))
 
         def on_tab_switch(
             self, instance_tabs, instance_tab, instance_tab_label, tab_text
@@ -109,12 +112,14 @@ Example with tab icon
             :param instance_tab_label: <kivymd.uix.tab.MDTabsLabel object>;
             :param tab_text: text or name icon of tab;
             '''
-
-            count_icon = [k for k, v in md_icons.items() if v in tab_text]
-            instance_tab.ids.icon.icon = count_icon[0]
+            # get the tab icon.
+            count_icon = instance_tab.icon
+            # print it on shell/bash.
+            print(f"Welcome to {count_icon}' tab'")
 
 
     Example().run()
+
 
 .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/tabs-simple-example.gif
     :align: center
@@ -125,8 +130,9 @@ Example with tab text
 .. Note:: The :class:`~MDTabsBase` class has an icon parameter and, by default,
     tries to find the name of the icon in the file
     ``kivymd/icon_definitions.py``. If the name of the icon is not found,
-    then the name of the tab will be plain text, if found, the tab will look
-    like the corresponding icon.
+    The class will send a message stating that the icon could not be found.
+    if the tab has no icon,title or tab_label_text, the class will raise a
+    ValueError.
 
 .. code-block:: python
 
@@ -167,7 +173,7 @@ Example with tab text
 
         def on_start(self):
             for i in range(20):
-                self.root.ids.tabs.add_widget(Tab(text=f"Tab {i}"))
+                self.root.ids.tabs.add_widget(Tab(title=f"Tab {i}"))
 
         def on_tab_switch(
             self, instance_tabs, instance_tab, instance_tab_label, tab_text
@@ -299,7 +305,7 @@ Dynamic tab management
             if self.index > 1:
                 self.index -= 1
             self.root.ids.tabs.remove_widget(
-                self.root.ids.tabs.get_tab_list()[0]
+                self.root.ids.tabs.get_tab_list()[-1]
             )
 
 

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1160,6 +1160,14 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     :attr:`tab_indicator_type` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'line'`.
     """
+    tab_hint_x = BooleanProperty(False)
+    """
+    This option affects the size of each child. if it's `True`, the size of
+    each tab will be igonred and will use the size available by the container.
+
+    :attr:`tab_hint_x` is an :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
 
     anim_duration = NumericProperty(0.2)
     """
@@ -1307,6 +1315,16 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
             force_title_icon_mode=self._parse_icon_mode,
             title_icon_mode=self._parse_icon_mode,
         )
+        self.bind(tab_hint_x=self._update_tab_hint_x)
+
+    def _update_tab_hint_x(self, *args):
+        if not self.ids.layout.children:
+            return
+        if self.tab_hint_x is True:
+            self.fixed_tab_label_width = self.width//len(self.ids.layout.children)
+            self.allow_stretch = False
+        else:
+            self.allow_stretch = True
 
     def _parse_icon_mode(self, *args):
         if self.force_title_icon_mode is True:
@@ -1555,6 +1573,10 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         Clock.schedule_once(update_indicator)
 
     def _update_padding(self, layout, *args):
+        if self.tab_hint_x is True:
+            layout.padding = [0, 0]
+            Clock.schedule_once(self._update_tab_hint_x)
+            return True
         padding = [0, 0]
         # this is more efficient than to use sum([layout.children])
         width = layout.width - (layout.padding[0] * 2)

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -751,6 +751,14 @@ class MDTabsBase(Widget):
     and defaults to `''`.
     """
 
+    title_is_capital = BooleanProperty(False)
+    """
+    This value contros wether if the title property should be converted to
+    captial letters.
+    :attr:`title_is_capital` is an :class:`~kivy.properties.BooleanProperty`
+    and defaults to `True`.
+    """
+
     text = StringProperty(deprecated=True)
     """
     This property is the actual title of the tab.
@@ -831,6 +839,7 @@ class MDTabsBase(Widget):
             title_icon_mode=self._update_text,
             text=self.update_label_text,
             tab_label_text=self.update_label_text,
+            title_is_capital=self.update_label_text,
         )
         Clock.schedule_once(
             self._update_text
@@ -838,7 +847,7 @@ class MDTabsBase(Widget):
 
     def _update_text(self, *args):
         # ensures that the title is in capital letters.
-        if self.title:
+        if self.title and self.title_is_capital is True:
             if self.title != self.title.upper():
                 self.title = self.title.upper()
                 # Avoids event recursion.

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -503,7 +503,7 @@ __all__ = ("MDTabs", "MDTabsBase")
 from kivy.clock import Clock
 from kivy.lang import Builder
 from kivy.logger import Logger
-from kivy.metrics import dp, sp
+from kivy.metrics import dp
 from kivy.properties import (
     AliasProperty,
     BooleanProperty,
@@ -1339,7 +1339,6 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         else:
             self.carousel.load_slide(name_tab.tab)
 
-
     def get_tab_list(self):
         """Returns a list of tab objects."""
 
@@ -1539,5 +1538,10 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         # Update the indicator
         if self.carousel.current_slide:
             self._update_indicator(self.carousel.current_slide.tab_label)
-            Clock.schedule_once(lambda x:setattr(self.carousel.current_slide.tab_label,"state","down"),-1)
+            Clock.schedule_once(
+                lambda x: setattr(
+                    self.carousel.current_slide.tab_label, "state", "down"
+                ),
+                -1,
+            )
         return True

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1351,7 +1351,8 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                         self.carousel.load_slide(instance_tab)
                         return
 
-            raise ValueError("switch_tab:\n\t"
+            raise ValueError(
+                "switch_tab:\n\t"
                 "name_tab not found in the tab list\n\t"
                 f"search_by = {repr(search_by)} \n\t"
                 f"name_tab = {repr(name_tab)} \n\t"

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -631,10 +631,12 @@ class MDTabsLabel(ToggleButtonBehavior, RectangularRippleBehavior, MDLabel):
     font_name = StringProperty("Roboto")
 
     def __init__(self, **kwargs):
+        self.split_str=" ,-"
         super().__init__(**kwargs)
+        self.max_lines = 2
         self.size_hint_x = None
         self.size_hint_min_x = dp(90)
-        self.min_space = 0
+        self.min_space = dp(98)
         self.bind(
             text=self._update_text_size,
         )

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -731,6 +731,7 @@ class MDTabsBase(Widget):
     def _get_label_font_style(self):
         if self.tab_label:
             return self.tab_label.font_style
+
     def _set_label_font_style(self,value):
         if self.tab_label:
             if value in theme_font_styles:
@@ -759,7 +760,7 @@ class MDTabsBase(Widget):
             title=self._update_text,
             title_icon_mode=self._update_text,
         )
-        self._update_text()
+        Clock.schedule_once(self._update_text) # This will ensure the text is correct
 
     def _update_text(self, *args):
         x = False

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1292,6 +1292,18 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
             raise MDTabsException(
                 "MDTabs can remove only subclass of MDTabsLabel"
             )
+        self.unbind(allow_stretch = widget.tab_label._update_text_size)
+        self.unbind(font_name=widget.tab_label.setter("font_name"))
+        self.unbind(
+            text_color_active=widget.tab_label.setter(
+                "text_color_active"
+            )
+        )
+        self.unbind(
+            text_color_normal=widget.tab_label.setter(
+                "text_color_normal"
+            )
+        )
         # The last tab is not deleted.
         if len(self.tab_bar.layout.children) == 1:
             return

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1483,4 +1483,5 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         # Update the indicator
         if self.carousel.current_slide:
             self._update_indicator(self.carousel.current_slide.tab_label)
+            Clock.schedule_once(lambda x:setattr(self.carousel.current_slide.tab_label,"state","down"),-1)
         return True

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1311,17 +1311,34 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
             if not self.text_color_active:
                 tab_label.text_color_active = self.specific_secondary_text_color
 
-    def switch_tab(self, name_tab):
-        """Switching the tab by name."""
+    def switch_tab(self, name_tab, search_by="tab_label_text"):
+        """This funciont switch between tabs
+        name_tab can be either a String or a MDTabsBase.
 
-        for instance_tab in self.tab_bar.parent.carousel.slides:
-            if instance_tab.text == name_tab:
-                self.tab_bar.parent.carousel.load_slide(instance_tab)
-                break
-        for tab_label in self.get_tab_list():
-            if name_tab == tab_label.text:
-                self.ids.scrollview.scroll_to(tab_label)
-                break
+        search_by will look up through the properties of every tab
+        """
+        if isinstance(name_tab, str):
+            if search_by == "tab_label_text":
+                for instance_tab in self.tab_bar.parent.carousel.slides:
+                    if instance_tab.tab_label_text == name_tab:
+                        self.carousel.load_slide(instance_tab)
+                        break
+            # search by icon.
+            elif search_by == "icon":
+                for instance_tab in self.tab_bar.parent.carousel.slides:
+                    if instance_tab.icon == name_tab:
+                        self.carousel.load_slide(instance_tab)
+                        break
+            # search by title
+            else:
+                for instance_tab in self.tab_bar.parent.carousel.slides:
+                    if instance_tab.title == name_tab:
+                        self.carousel.load_slide(instance_tab)
+                        break
+
+        else:
+            self.carousel.load_slide(name_tab.tab)
+
 
     def get_tab_list(self):
         """Returns a list of tab objects."""

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -746,7 +746,7 @@ class MDTabsBase(Widget):
                 self.text = (
                     self.text
                     + (" " if self.title_icon_mode == "Lead" else "\n")
-                    + f"[b]{self.title.upper()}[/b]"
+                    + self.title.upper()
                 )
         else:
             if self.icon:
@@ -755,7 +755,8 @@ class MDTabsBase(Widget):
                     f"Icon '{self.icon}' not found in md_icons"
                 )
             if self.title:
-                self.text = f"[b]{self.title.upper()}[/b]"
+
+                self.text = self.title.upper()
             else:
                 if not self.text:
                     raise ValueError(

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1408,17 +1408,12 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                 self.bind(
                     allow_stretch=widget.tab_label._update_text_size,
                     fixed_tab_label_width=widget.tab_label._update_text_size,
-                )
-                self.bind(font_name=widget.tab_label.setter("font_name"))
-                self.bind(
+                    font_name=widget.tab_label.setter("font_name"),
                     text_color_active=widget.tab_label.setter(
-                        "text_color_active"
-                    )
-                )
-                self.bind(
+                        "text_color_active"),
                     text_color_normal=widget.tab_label.setter(
                         "text_color_normal"
-                    )
+                    ),
                 )
                 Clock.schedule_once(widget.tab_label._update_text_size, 0)
                 self.tab_bar.layout.add_widget(widget.tab_label)

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1312,31 +1312,43 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
             if not self.text_color_active:
                 tab_label.text_color_active = self.specific_secondary_text_color
 
-    def switch_tab(self, name_tab, search_by="tab_label_text"):
+    def switch_tab(self, name_tab, search_by="text"):
         """This funciont switch between tabs
         name_tab can be either a String or a MDTabsBase.
 
-        search_by will look up through the properties of every tab
+        `search_by` will look up through the properties of every tab.
+
+        search_by options:
+            text : will search by the raw text of the label
+            icon : will search by the `icon` property
+            title : will search by the `title` property
         """
         if isinstance(name_tab, str):
             if search_by == "tab_label_text":
                 for instance_tab in self.tab_bar.parent.carousel.slides:
                     if instance_tab.tab_label_text == name_tab:
                         self.carousel.load_slide(instance_tab)
-                        break
+                        return
+
             # search by icon.
             elif search_by == "icon":
                 for instance_tab in self.tab_bar.parent.carousel.slides:
                     if instance_tab.icon == name_tab:
                         self.carousel.load_slide(instance_tab)
-                        break
+                        return
+
             # search by title
             else:
                 for instance_tab in self.tab_bar.parent.carousel.slides:
-                    if instance_tab.title == name_tab:
+                    if instance_tab.title == name_tab.upper():
                         self.carousel.load_slide(instance_tab)
-                        break
+                        return
 
+            raise ValueError("switch_tab:\n\t"
+                "name_tab not found in the tab list\n\t"
+                f"search_by = {repr(search_by)} \n\t"
+                f"name_tab = {repr(name_tab)} \n\t"
+            )
         else:
             self.carousel.load_slide(name_tab.tab)
 

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -793,7 +793,7 @@ class MDTabsBase(Widget):
                 self.text = (
                     self.text
                     + (" " if self.title_icon_mode == "Lead" else "\n")
-                    + self.title.upper()
+                    + self.title
                 )
         else:
             if self.icon:
@@ -802,10 +802,9 @@ class MDTabsBase(Widget):
                     f"Icon '{self.icon}' not found in md_icons"
                 )
             if self.title:
-
-                self.text = self.title.upper()
+                self.text = self.title
             else:
-                if not self.text:
+                if not self.tab_label_text:
                     raise ValueError(
                         f"{self}: [UID] = [{self.uid}]:\n\t"
                         "No valid Icon was found.\n\t"
@@ -826,7 +825,7 @@ class MDTabsBase(Widget):
 
     def update_label_text(self, widget, value):
         self.tab_label.text = self.tab_label_text
-        
+
     def on_text(self, widget, text):
         self.tab_label_text = self.text
 

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -747,14 +747,12 @@ class MDTabsBase(Widget):
         capital letters, because of this, the `string.upper()` will be applied
         to it's contents.
 
-    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    :attr:`title` is an :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
 
     text = StringProperty(deprecated=True)
     """
-    This property is deprecated, use :attr:`tab_label_text` instead,
-
     This property is the actual title of the tab.
     use the property :attr:`icon` and :attr:`title` to set this property
     correctly.
@@ -764,6 +762,9 @@ class MDTabsBase(Widget):
 
     :attr:`text` is an :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
+
+    .. warning::
+        This property is deprecated, use :attr:`tab_label_text` instead,
     """
 
     tab_label_text = StringProperty()
@@ -812,11 +813,12 @@ class MDTabsBase(Widget):
     )
     """
     :attr:`tab_label_font_style` is an :class:`~kivy.properties.AliasProperty`
-    that behavies similar to an :class:`~kivy.properties.OptionProperty`
-    This property behaviors allows the developer to use any new label style
+    that behavies similar to an :class:`~kivy.properties.OptionProperty`.
+
+    This property's behavior allows the developer to use any new label style
     registered to the app.
 
-    this property will affect the Tab's Title Label widget.
+    This property will affect the Tab's Title Label widget.
 
     """
 
@@ -877,7 +879,7 @@ class MDTabsBase(Widget):
         self.update_label_text(None, self.tab_label_text)
 
     def update_label_text(self, widget, value):
-        self.tab_label.text = self.tab_label_text
+        self.tab_label.text = self.text = self.tab_label_text
 
     def on_text(self, widget, text):
         self.tab_label_text = self.text
@@ -1175,11 +1177,11 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     allow_stretch = BooleanProperty(True)
     """
     If `True`, The tab will update dynamically to it's content width, and wrap
-    any text if the widget is bigger than `"360dp"`.
+    any text if the widget is wider than `"360dp"`.
 
     If `False`, the tab won't update to it's maximum texture width.
     this means that the `fixed_tab_label_width` will be used as the label
-    width.
+    width. this will wrap any text inside to fit the fixed value.
 
     :attr:`allow_stretch` is an :class:`~kivy.properties.BooleanProperty`
     and defaults to `True`.

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -788,18 +788,6 @@ class MDTabsBase(Widget):
     def on_text(self, widget, text):
         self.tab_label.text = self.text
 
-    #     # # Set the icon
-    #     # if text in md_icons:
-    #     #     self.tab_label.font_name = (
-    #     #         fonts_path + "materialdesignicons-webfont.ttf"
-    #     #     )
-    #     #     self.tab_label.text = md_icons[self.text]
-    #     #     self.tab_label.font_size = "24sp"
-    #     # # Set the label text
-    #     # else:
-    #     #     self.tab_label.text = self.text
-
-
 class MDTabsMain(MDBoxLayout):
     """
     This class is just a boxlayout that contain the carousel.

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -1255,7 +1255,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
     def get_tab_list(self):
         """Returns a list of tab objects."""
 
-        return self.tab_bar.layout.children
+        return self.tab_bar.layout.children[::-1]
 
     def get_slides(self):
         return self.carousel.slides

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -711,7 +711,7 @@ class MDTabsBase(Widget):
     text = StringProperty()
     """
     This property is the actual title of the tab.
-    use the property :att:`icon` and :attr:`title` to set this property
+    use the property :attr:`icon` and :attr:`title` to set this property
     correctly.
 
     This property is kept public for specific and backward compatibility

--- a/kivymd/uix/tab.py
+++ b/kivymd/uix/tab.py
@@ -129,9 +129,12 @@ Example with tab text
 
 .. Note:: The :class:`~MDTabsBase` class has an icon parameter and, by default,
     tries to find the name of the icon in the file
-    ``kivymd/icon_definitions.py``. If the name of the icon is not found,
-    The class will send a message stating that the icon could not be found.
-    if the tab has no icon,title or tab_label_text, the class will raise a
+    ``kivymd/icon_definitions.py``.
+
+    If the name of the icon is not found, the class will send a message
+    stating that the icon could not be found.
+
+    if the tab has no icon, title or tab_label_text, the class will raise a
     ValueError.
 
 .. code-block:: python
@@ -407,11 +410,10 @@ Switching the tab by name
 .. code-block:: python
 
     from kivy.lang import Builder
-
     from kivymd.app import MDApp
+    from kivymd.icon_definitions import md_icons
     from kivymd.uix.floatlayout import MDFloatLayout
     from kivymd.uix.tab import MDTabsBase
-    from kivymd.icon_definitions import md_icons
 
     KV = '''
     MDBoxLayout:
@@ -425,13 +427,26 @@ Switching the tab by name
 
 
     <Tab>
-
-        MDIconButton:
-            id: icon
-            icon: "arrow-right"
-            user_font_size: "48sp"
+        MDBoxLayout:
+            orientation: "vertical"
             pos_hint: {"center_x": .5, "center_y": .5}
-            on_release: app.switch_tab()
+            size_hint: None, None
+            spacing: dp(48)
+            MDIconButton:
+                id: icon
+                icon: "arrow-right"
+                user_font_size: "48sp"
+
+                on_release:
+                    app.switch_tab_by_name()
+
+            MDIconButton:
+                id: icon2
+                icon: "page-next"
+                user_font_size: "48sp"
+
+                on_release:
+                    app.switch_tab_by_object()
     '''
 
 
@@ -443,19 +458,37 @@ Switching the tab by name
         icons = list(md_icons.keys())[15:30]
 
         def build(self):
-            self.iter_list = iter(list(self.icons))
-            return Builder.load_string(KV)
+            self.iter_list_names = iter(list(self.icons))
+            root = Builder.load_string(KV)
+            return root
 
         def on_start(self):
             for name_tab in list(self.icons):
-                self.root.ids.tabs.add_widget(Tab(text=name_tab))
+                self.root.ids.tabs.add_widget(Tab(tab_label_text=name_tab))
+            self.iter_list_objects = iter(list(self.root.ids.tabs.get_tab_list()))
 
-        def switch_tab(self):
+        def switch_tab_by_object(self):
+            try:
+                x = next(self.iter_list_objects)
+                print(f"Switch slide by object, \n\tnex element to show: [{x}]")
+                self.root.ids.tabs.switch_tab(x)
+            except StopIteration:
+                # reset the iterator an begin again.
+                self.iter_list_objects = iter(list(self.root.ids.tabs.get_tab_list()))
+                self.switch_tab_by_object()
+                pass
+
+        def switch_tab_by_name(self):
             '''Switching the tab by name.'''
 
             try:
-                self.root.ids.tabs.switch_tab(next(self.iter_list))
+                x = next(self.iter_list_names)
+                print(f"Switch slide by name, \n\tnex element to show: [{x}]")
+                self.root.ids.tabs.switch_tab(x)
             except StopIteration:
+                # reset the iterator an begin again.
+                self.iter_list_names = iter(list(self.icons))
+                self.switch_tab_by_name()
                 pass
 
 


### PR DESCRIPTION
### Description of Changes
this is a fix for some problems that surged from the last pull request, as well add some improvements and upgrades to the class.

Possible fix for #770 
Possible fix for #874 
Possible fix for #878 
Possible fix for #880 
Possible fix for #885

This is a big change for the class, it has been proven with every example code provided by the documentation and kitchen sink.

This updates the documentation for the new implemented methods.

Between the fixes there are:
- simplified the `remove_widget ` function from `MDTabs`
- `remove_widget ` now removes binds created on `add_widget` for new tabs.
- max width of every tabt's title label is set to `"360dp"`
- both kv and python instance creation reviewed. (small differences that affected its behavior on new widgets)
- added exception raises if something is not filled correctly or found.
- Added more specific Exceptions to allow developers know what exactly went wrong.
- Added basic `MDCarousel` Documentation.
- `MDTabsBase.text` is now deprecated, still has backward compatibility, but the use `tab_label_text` is now enforced and the use of this property will show a message in the kivy logger.
- Fixed reference bug in which, if the tab with the reference was pressed, the selected tab would be missing its state.
- Tab_bar now behaves on the content's width. 
If the width of the tab's inside is bigger than the scroll view, the `tab_bar` will be set to scrollable, the padding of the layout will be set to `["52dp", 0]` and allow scroll, if the width is lesser or equal to the scrollview width, the scroll then is locked, and the canvas padding is set to `[0,0]`,  `ScrollView.do_scroll_x` is set to `False` in this scenario.
- Some duplicated code was removed
- Some duplicated movements were removed, since some steps were already done by the children widget or by another event.    
- Fixed some small recursions.

Adds:
- tab_label_text namespace will store the raw tab's title label text. Replaces `MDTabsBase.text` property.
-  Tabs.switch_to is now more flexible, you can toggle between text, Tab_objects and if it's a string, search by its icon, title or raw text.
- Any text parsed to the Title property will be set with upper(). (this is to maintain every tab title clear)
- added title_is_capital, if the value is True, it will update the self. Text to be all capitals.

    