### PR TITLE
Text field left icon

### DIFF
--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -500,6 +500,20 @@ Builder.load_string(
                 self._msg_lbl.texture_size[1] - (dp(3) if root.mode in ("fill", "rectangle") else 0)
             pos: self.x + (dp(8) if root.mode == "fill" else 0), self.y + (dp(3) if root.mode in ("fill", "rectangle") else 0)
 
+        # Texture of left Icon.
+        Color:
+            rgba:
+                self.icon_left_color \
+                if self.focus else self.theme_cls.disabled_hint_text_color
+        Rectangle:
+            texture: self._lbl_icon_left.texture
+            size:
+                self._lbl_icon_left.texture_size if self.icon_left \
+                else (0, 0)
+            pos:
+                self.x, \
+                self.center[1] - self._lbl_icon_left.texture_size[1] / 2
+
         # Texture of right Icon.
         Color:
             rgba: self.icon_right_color if self.focus else self._current_hint_text_color
@@ -571,9 +585,11 @@ Builder.load_string(
     foreground_color: self.theme_cls.text_color
     bold: False
     padding:
-        0 if root.mode != "fill" else "8dp", \
+        0 if root.mode != "fill" and not root.icon_left else \
+        ("14dp" if not root.icon_left else self._lbl_icon_left.texture_size[1] + dp(20)), \
         "16dp" if root.mode != "fill" else "24dp", \
-        0 if root.mode != "fill" and not root.icon_right else ("14dp" if not root.icon_right else self._lbl_icon_right.texture_size[1] + dp(20)), \
+        0 if root.mode != "fill" and not root.icon_right else \
+        ("14dp" if not root.icon_right else self._lbl_icon_right.texture_size[1] + dp(20)), \
         "16dp" if root.mode == "fill" else "10dp"
     multiline: False
     size_hint_y: None
@@ -858,6 +874,22 @@ class MDTextField(ThemableBehavior, TextInput):
     and defaults to `None`.
     """
 
+    icon_left = StringProperty()
+    """
+    Left icon.
+
+    :attr:`icon_left` is an :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+    """
+
+    icon_left_color = ColorProperty((0, 0, 0, 1))
+    """
+    Color of left icon in ``rgba`` format.
+
+    :attr:`icon_left_color` is an :class:`~kivy.properties.ColorProperty`
+    and defaults to `(0, 0, 0, 1)`.
+    """
+
     icon_right = StringProperty()
     """
     Right icon.
@@ -922,6 +954,7 @@ class MDTextField(ThemableBehavior, TextInput):
     _msg_lbl = None
     _right_msg_lbl = None
     _hint_lbl = None
+    _lbl_icon_left = None
     _lbl_icon_right = None
 
     def __init__(self, **kwargs):
@@ -984,7 +1017,14 @@ class MDTextField(ThemableBehavior, TextInput):
             font_style="Subtitle1", halign="left", valign="middle", field=self
         )
         # MDIcon object for the icon on the right.
+        self._lbl_icon_left = MDIcon(theme_text_color="Custom")
         self._lbl_icon_right = MDIcon(theme_text_color="Custom")
+
+    def on_icon_left(self, instance, value):
+        self._lbl_icon_left.icon = value
+
+    def on_icon_left_color(self, instance, value):
+        self._lbl_icon_left.text_color = value
 
     def on_icon_right(self, instance, value):
         self._lbl_icon_right.icon = value
@@ -1143,7 +1183,7 @@ class MDTextField(ThemableBehavior, TextInput):
             self._anim_current_line_color(self.line_color_focus)
             if self.helper_text_mode == "on_error":
                 self._anim_current_error_color((0, 0, 0, 0))
-            self.on_focus(self, self.focus)
+                self.on_focus(self, self.focus)
 
         if len(self.text) != 0 and not self.focus:
             self._hint_y = dp(14)

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -393,6 +393,39 @@ Clickable icon for MDTextFieldRound
 
     Test().run()
 
+With left icon
+---------------
+
+.. code-block:: kv
+
+    MDTextField:
+        hint_text: "Name"
+        text: "left icon, mode fill"
+        mode: "fill"
+        fill_color: 0, 0, 0, .4
+        icon_left: "clock-outline"
+        icon_left_color: app.theme_cls.primary_color
+
+
+.. code-block:: kv
+
+    MDTextField:
+        hint_text: "Name"
+        text: "left icon"
+        icon_left: "clock-outline"
+        icon_left_color: app.theme_cls.primary_color
+
+
+.. code-block:: kv
+
+    MDTextField:
+        hint_text: "Name"
+        text: "left icon, mode rectangle"
+        mode: "rectangle"
+        icon_left: "clock-outline"
+        icon_left_color: app.theme_cls.primary_color
+
+
 With right icon
 ---------------
 
@@ -512,7 +545,9 @@ Builder.load_string(
                 else (0, 0)
             pos:
                 self.x, \
-                self.center[1] - self._lbl_icon_left.texture_size[1] / 2
+                self.center[1] - self._lbl_icon_left.texture_size[1] / 2 + (dp(8) if root.mode != "fill" else 0) \
+                if root.mode != "rectangle" else \
+                self.center[1] - self._lbl_icon_left.texture_size[1] / 2 - dp(4)
 
         # Texture of right Icon.
         Color:
@@ -547,7 +582,10 @@ Builder.load_string(
         Rectangle:
             texture: self._hint_lbl.texture
             size: self._hint_lbl.texture_size
-            pos: self.x + (dp(8) if root.mode == "fill" else 0), self.y + self.height - self._hint_y
+            pos:
+                self.x + ((self._lbl_icon_left.texture_size[1] + dp(20)) if not (self.text or self.focus) or (self.mode == "line" and root.icon_left) else \
+                (dp(8) if root.mode == "fill" else 0)), \
+                self.y + self.height - self._hint_y
 
         Color:
             rgba:

--- a/kivymd/uix/textfield.py
+++ b/kivymd/uix/textfield.py
@@ -1183,7 +1183,7 @@ class MDTextField(ThemableBehavior, TextInput):
             self._anim_current_line_color(self.line_color_focus)
             if self.helper_text_mode == "on_error":
                 self._anim_current_error_color((0, 0, 0, 0))
-                self.on_focus(self, self.focus)
+            self.on_focus(self, self.focus)
 
         if len(self.text) != 0 and not self.focus:
             self._hint_y = dp(14)


### PR DESCRIPTION
### Description of Changes
I was missing a left icon in MDTextField, so I added it

### Screenshot
![MDTextField01](https://user-images.githubusercontent.com/5486125/109828597-127d8f80-7c3d-11eb-87a9-803a49a9937e.png)


### Sample code 
    from kivy.lang import Builder
    from kivy.properties import StringProperty

    from kivymd.app import MDApp
    from kivymd.uix.relativelayout import MDRelativeLayout

    KV = '''
    MDScreen:
        MDBoxLayout:
            orientation: "vertical"
            MDTextField:
                id: normal
                text: "123"
                
            MDTextField:
                id: left
                text: "456"
                icon_left: "clock-outline"
                icon_left_color: app.theme_cls.primary_dark
                
            MDTextField:
                id: right
                text: "789"
                icon_right: "arrow-down-drop-circle-outline"
                icon_right_color: app.theme_cls.primary_color
                
            MDTextField:
                id: leftright
                text:"012"
                icon_left: "clock-outline"
                icon_left_color: app.theme_cls.primary_dark
                icon_right: "arrow-down-drop-circle-outline"
                icon_right_color: app.theme_cls.primary_color
    '''




    class Test(MDApp):
        def build(self):
            return Builder.load_string(KV)


    Test().run()