### PR TITLE
Datatable bugfixes and features

### DIFF
--- a/kivymd/uix/datatables.py
+++ b/kivymd/uix/datatables.py
@@ -22,6 +22,9 @@ Components/DataTables
 
 __all__ = ("MDDataTable",)
 
+from collections import defaultdict
+from math import ceil
+
 from kivy.clock import Clock
 from kivy.lang import Builder
 from kivy.metrics import dp
@@ -50,8 +53,6 @@ from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.button import MDIconButton
 from kivymd.uix.menu import MDDropdownMenu
 from kivymd.uix.tooltip import MDTooltip
-from collections import defaultdict
-from math import ceil
 
 Builder.load_string(
     """
@@ -428,12 +429,12 @@ class CellRow(
                     ]
                 ):
                     self.change_check_state_no_notif("down")
-                    #self.ids.check.state = "down"
+                    # self.ids.check.state = "down"
                 else:
-                    #self.ids.check.state = "normal"
+                    # self.ids.check.state = "normal"
                     self.change_check_state_no_notif("normal")
         else:
-            #self.ids.check.state = "normal"
+            # self.ids.check.state = "normal"
             self.change_check_state_no_notif("normal")
 
     def change_check_state_no_notif(self, new_state):
@@ -541,8 +542,8 @@ class CellHeader(MDTooltip, BoxLayout):
                 each.bind(on_leave=each.set_sort_btn)
 
         if self.sort_action:
-            if not self.table_data:	
-                th = self.parent.parent	
+            if not self.table_data:
+                th = self.parent.parent
                 self.table_data = th.table_data
 
             indices, sorted_data = self.sort_action(self.table_data.row_data)
@@ -556,7 +557,7 @@ class CellHeader(MDTooltip, BoxLayout):
 
             self.table_data.row_data = sorted_data
             self.table_data.on_rows_num(self, self.table_data.rows_num)
-            self.restore_checks(dict(zip(indices,range(len(indices)))))
+            self.restore_checks(dict(zip(indices, range(len(indices)))))
             self.table_data.set_next_row_data_parts("reset")
             self.table_data.cell_row_obj_dict = {}
             self.table_data.table_header.ids.check.state = "normal"
@@ -570,8 +571,10 @@ class CellHeader(MDTooltip, BoxLayout):
         new_checks = defaultdict(list)
         for i, x in enumerate(curr_checks):
             for j, y in enumerate(curr_checks[x]):
-                new_page = (indices[y // columns + x * rows_num])// rows_num
-                new_indice = ((indices[y // columns + x * rows_num]) % rows_num) * columns
+                new_page = (indices[y // columns + x * rows_num]) // rows_num
+                new_indice = (
+                    (indices[y // columns + x * rows_num]) % rows_num
+                ) * columns
                 new_checks[new_page].append(new_indice)
 
         self.table_data.current_selection_check = dict(new_checks)
@@ -786,26 +789,22 @@ class TableData(RecycleView):
         """Sets the checkboxes of all rows to the active/inactive position."""
 
         for i in range(0, len(self.recycle_data), self.total_col_headings):
-            cell_row_obj = (	
-                cell_row_obj	
-            ) = self.view_adapter.get_visible_view(i)	
-            self.cell_row_obj_dict[i] = cell_row_obj	
-            self.on_mouse_select(cell_row_obj)	
+            cell_row_obj = cell_row_obj = self.view_adapter.get_visible_view(i)
+            self.cell_row_obj_dict[i] = cell_row_obj
+            self.on_mouse_select(cell_row_obj)
             cell_row_obj.ids.check.state = state
 
-        if state == 'down':
+        if state == "down":
             # select all checks on all pages
 
             rows_num = self.rows_num
             columns = self.total_col_headings
-            full_pages  = len(self.row_data) // self.rows_num
+            full_pages = len(self.row_data) // self.rows_num
             left_over_rows = len(self.row_data) % self.rows_num
 
             new_checks = {}
             for page in range(full_pages):
-                new_checks[page] = list(
-                    range(0, rows_num * columns, columns)
-                )
+                new_checks[page] = list(range(0, rows_num * columns, columns))
 
             if left_over_rows:
                 new_checks[full_pages] = list(
@@ -814,7 +813,7 @@ class TableData(RecycleView):
 
             self.current_selection_check = new_checks
             return
-        
+
         # resets all checks on all pages
         self.current_selection_check = {}
 

--- a/kivymd/uix/datatables.py
+++ b/kivymd/uix/datatables.py
@@ -84,8 +84,6 @@ Builder.load_string(
             size_hint: None, None
             size: 0, 0
             opacity: 0
-            #on_active: root.select_check(self, self.active)
-            #on_release: root._check_all(self.state)
 
         MDBoxLayout:
             id: inner_box
@@ -428,12 +426,9 @@ class CellRow(
                     ]
                 ):
                     self.change_check_state_no_notif("down")
-                    # self.ids.check.state = "down"
                 else:
-                    # self.ids.check.state = "normal"
                     self.change_check_state_no_notif("normal")
         else:
-            # self.ids.check.state = "normal"
             self.change_check_state_no_notif("normal")
 
     def change_check_state_no_notif(self, new_state):

--- a/kivymd/uix/datatables.py
+++ b/kivymd/uix/datatables.py
@@ -22,6 +22,8 @@ Components/DataTables
 
 __all__ = ("MDDataTable",)
 
+from collections import defaultdict
+
 from kivy.clock import Clock
 from kivy.lang import Builder
 from kivy.metrics import dp
@@ -50,8 +52,6 @@ from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.button import MDIconButton
 from kivymd.uix.menu import MDDropdownMenu
 from kivymd.uix.tooltip import MDTooltip
-from collections import defaultdict
-from math import ceil
 
 Builder.load_string(
     """


### PR DESCRIPTION
### Description of Changes

- Page pagination now displays the correct data after sorting a column
- Checkboxes will now persist even after sorting a column
- - **This requires a change of the user-provided sort function! See sample code below.**
- (Un)checking all rows now (un)checks every row on every page
- Datatable no longer crashes when using the page pagination after sorting a column
- on_check_press no longer gets called when changing pages

### Known issues
- When (un)checking all rows only the displayed rows receive the on_check_press event

### Sample code

```python
from kivy.metrics import dp
from kivy.uix.anchorlayout import AnchorLayout

from kivymd.app import MDApp
from kivymd.uix.datatables import MDDataTable


class Example(MDApp):
    def build(self):
        layout = AnchorLayout()
        self.data_tables = MDDataTable(
            size_hint=(0.7, 0.6),
            use_pagination=True,
            check=True,
            column_data=[
                ("No.", dp(30)),
                ("Status", dp(30)),
                ("Signal Name", dp(60), self.sort_on_signal),
                ("Severity", dp(30)),
                ("Stage", dp(30)),
                ("Schedule", dp(30)),
                ("Team Lead", dp(30))
            ],
            row_data=[
                (1,) * 7,
                (2,) * 7,
                (3,) * 7,
                (4,) * 7,
                (5,) * 7,
                (6,) * 7,
                (7,) * 7,
                (8,) * 7,
                (9,) * 7,

            ],
            sorted_on="Schedule",
            sorted_order="ASC",
            elevation=2
        )

        self.data_tables.bind(on_check_press=self.on_check_press)
        layout.add_widget(self.data_tables)
        return layout

    def on_check_press(self, instance_table, current_row):
        '''Called when the check box in the table row is checked.'''

        print(instance_table, current_row)

    def sort_on_signal(self, data):
        ''' 
        Returns a
             - Tuple of indices (the permutation to sort the data in ascending order)
             - Tuple of the ascending ordered data
        '''
        return zip(*sorted(enumerate(data), key=lambda l: int(l[1][3])))

Example().run()
```



