### PR TITLE
README.MD | Added missing requirement for buildozer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ to save time. If you need full commit history, then remove `--depth 1`.
 ### How to use with [Buildozer](https://github.com/kivy/buildozer)
 
 ```ini
-requirements = kivy==2.0.0, kivymd==0.104.1
+requirements = kivy==2.0.0, kivymd==0.104.1, sdl2_ttf == 2.0.15
 ```
 
 This will download latest release version of KivyMD from [PyPI](https://pypi.org/project/kivymd).


### PR DESCRIPTION
Added missing requirement to the "how to use with buildozer" example line
sdl2_ttf is required to show icons on android devices.

### Description of Changes
* added missing requirement on how to use with buildozer example line in README.md
* fix for #257 
* fix #918 