### PR TITLE
Fix same icon MDFloatingActionButtonSpeedDial

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -349,9 +349,9 @@ MDFloatingActionButtonSpeedDial
 
     class Example(MDApp):
         data = {
-            'language-python': 'Python',
-            'language-php': 'PHP',
-            'language-cpp': 'C++',
+            'Python': 'language-python',
+            'PHP': 'language-php',
+            'C++': 'language-cpp',
         }
 
         def build(self):
@@ -1872,7 +1872,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        for name_icon in value.keys():
+        for name,name_icon in zip(value.keys(),value.values):
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,
                 on_enter=self.on_enter,
@@ -1885,7 +1885,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
             self.set_pos_bottom_buttons(bottom_button)
             self.add_widget(bottom_button)
             # Labels.
-            floating_text = value[name_icon]
+            floating_text = name
             if floating_text:
                 label = MDFloatingLabel(text=floating_text, opacity=0)
                 label.text_color = self.label_text_color

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,7 +1872,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        for name,name_icon in zip(value.keys(),value.values):
+        for name,name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,
                 on_enter=self.on_enter,


### PR DESCRIPTION
### Description of Changes
This fix allows user to use same icon for multiple speed dials in MDFloatingActionButtonSpeedDial
but data need to be changed as follows, 
{'icon_name': 'name to be displayed'}
```
data = {
            'Python':'plus' ,
            'PHP':'plus' ,
            'C++':'plus' ,
        }
```


### Screenshots
![Screenshot_1](https://user-images.githubusercontent.com/45727291/111900907-1a219e80-8a5b-11eb-91cc-f09520ed4593.jpg)

