### PR TITLE
Fix Identical Icons MDFloatingActionButtonSpeedDial

### DIFF
--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,10 +15,11 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
-            button_speed_dial.data = {'Python':'language-python' ,
-                                      'PHP':'language-php' ,
-                                      'C++':'language-cpp' ,
-                                     }
+            button_speed_dial.data = {
+                "Python": "language-python",
+                "PHP": "language-php",
+                "C++": "language-cpp",
+            }
             button_speed_dial.callback = callback
             self.add_widget(button_speed_dial)
             self.already_create_buttons = True

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,7 +15,6 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
-            # {"Text to be displayed" : "Icon name"}
             button_speed_dial.data = {'Python':'language-python' ,
                                       'PHP':'language-php' ,
                                       'C++':'language-cpp' ,

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,11 +15,10 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
-            button_speed_dial.data = {
-                "language-python": "Python",
-                "language-php": "PHP",
-                "language-cpp": "C++",
-            }
+            button_speed_dial.data = {'Python':'plus' ,
+                                      'PHP':'plus' ,
+                                      'C++':'plus' ,
+                                     }
             button_speed_dial.callback = callback
             self.add_widget(button_speed_dial)
             self.already_create_buttons = True

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,6 +15,7 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
+            # {"Text to be displayed" : "Icon name"}
             button_speed_dial.data = {'Python':'language-python' ,
                                       'PHP':'language-php' ,
                                       'C++':'language-cpp' ,

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,9 +15,9 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
-            button_speed_dial.data = {'Python':'plus' ,
-                                      'PHP':'plus' ,
-                                      'C++':'plus' ,
+            button_speed_dial.data = {'Python':'language-python' ,
+                                      'PHP':'language-php' ,
+                                      'C++':'language-cpp' ,
                                      }
             button_speed_dial.callback = callback
             self.add_widget(button_speed_dial)

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -374,9 +374,9 @@ Or without KV Language:
 
     class Example(MDApp):
         data = {
-            'language-python': 'Python',
-            'language-php': 'PHP',
-            'language-cpp': 'C++',
+            'Python': 'language-python',
+            'PHP': 'language-php',
+            'C++': 'language-cpp',
         }
 
         def build(self):

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,6 +1872,9 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
+        # Added New format for data of speed dial for identical icons
+        # {"Text to be displayed":"icon name"}
+        
         for name,name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,7 +1872,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        for name,name_icon in value.items():
+        for name, name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,
                 on_enter=self.on_enter,

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,9 +1872,6 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        # Added New format for data of speed dial for identical icons
-        # {"Text to be displayed":"icon name"}
-        
         for name,name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -349,9 +349,9 @@ MDFloatingActionButtonSpeedDial
 
     class Example(MDApp):
         data = {
-            'language-python': 'Python',
-            'language-php': 'PHP',
-            'language-cpp': 'C++',
+            'Python': 'language-python',
+            'PHP': 'language-php',
+            'C++': 'language-cpp',
         }
 
         def build(self):
@@ -1872,7 +1872,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        for name_icon in value.keys():
+        for name,name_icon in zip(value.keys(),value.values):
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,
                 on_enter=self.on_enter,
@@ -1885,7 +1885,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
             self.set_pos_bottom_buttons(bottom_button)
             self.add_widget(bottom_button)
             # Labels.
-            floating_text = value[name_icon]
+            floating_text = name
             if floating_text:
                 label = MDFloatingLabel(text=floating_text, opacity=0)
                 label.text_color = self.label_text_color

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,7 +1872,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        for name,name_icon in zip(value.keys(),value.values):
+        for name,name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,
                 on_enter=self.on_enter,


### PR DESCRIPTION
### Description of Changes
Checked with KitchenSink and everything works as expected and it allows users/dev to use identical icons in speed dials

data provided should be as follows,

### Examples

```
data = {'Python':'language-python' ,
            'PHP':'language-php' ,
            'C++':'language-cpp' ,
           }
```
![Screenshot_3](https://user-images.githubusercontent.com/45727291/111903744-c5d1eb00-8a69-11eb-8e81-90704a90abf7.jpg)
```
data = {'Python':'plus' ,
            'PHP':'plus' ,
            'C++':'plus' ,
           }
```
![Screenshot_2](https://user-images.githubusercontent.com/45727291/111903701-91f6c580-8a69-11eb-82b0-b45b9d67958e.jpg)

