### PR TITLE
Dismiss on clicking out of focus on MDFloatingActionButtonSpeedDial

### DIFF
--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,6 +15,8 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
+            button_speed_dial.auto_dismiss = True
+            button_speed_dial.dismiss_on_option_touch = False
             button_speed_dial.data = {
                 "Python": "language-python",
                 "PHP": "language-php",

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,10 +15,11 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
-            button_speed_dial.data = {'Python':'language-python' ,
-                                      'PHP':'language-php' ,
-                                      'C++':'language-cpp' ,
-                                     }
+            button_speed_dial.data = {
+                "Python": "language-python",
+                "PHP": "language-php",
+                "C++": "language-cpp",
+            }
             button_speed_dial.callback = callback
             self.add_widget(button_speed_dial)
             self.already_create_buttons = True

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,7 +15,6 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
-            # {"Text to be displayed" : "Icon name"}
             button_speed_dial.data = {'Python':'language-python' ,
                                       'PHP':'language-php' ,
                                       'C++':'language-cpp' ,

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,11 +15,10 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
-            button_speed_dial.data = {
-                "language-python": "Python",
-                "language-php": "PHP",
-                "language-cpp": "C++",
-            }
+            button_speed_dial.data = {'Python':'plus' ,
+                                      'PHP':'plus' ,
+                                      'C++':'plus' ,
+                                     }
             button_speed_dial.callback = callback
             self.add_widget(button_speed_dial)
             self.already_create_buttons = True

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,6 +15,7 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
+            # {"Text to be displayed" : "Icon name"}
             button_speed_dial.data = {'Python':'language-python' ,
                                       'PHP':'language-php' ,
                                       'C++':'language-cpp' ,

--- a/demos/kitchen_sink/libs/baseclass/stack_buttons.py
+++ b/demos/kitchen_sink/libs/baseclass/stack_buttons.py
@@ -15,9 +15,9 @@ class KitchenSinkStackButtons(Screen):
 
             button_speed_dial = MDFloatingActionButtonSpeedDial()
             button_speed_dial.root_button_anim = True
-            button_speed_dial.data = {'Python':'plus' ,
-                                      'PHP':'plus' ,
-                                      'C++':'plus' ,
+            button_speed_dial.data = {'Python':'language-python' ,
+                                      'PHP':'language-php' ,
+                                      'C++':'language-cpp' ,
                                      }
             button_speed_dial.callback = callback
             self.add_widget(button_speed_dial)

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1793,6 +1793,22 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
     and defaults to `False`.
     """
 
+    auto_dismiss = BooleanProperty(False)
+    """
+    Whether to dismiss stack when clicked out of focus of widget.
+
+    :attr:`auto_dismiss` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
+
+    dismiss_on_option_touch = BooleanProperty(False)
+    """
+    Whether to dismiss stack when clicked on one of the options.
+
+    :attr:`dismiss_on_option_touch` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
+
     _label_pos_y_set = False
     _anim_buttons_data = {}
     _anim_labels_data = {}
@@ -1802,6 +1818,23 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self.register_event_type("on_open")
         self.register_event_type("on_close")
         Window.bind(on_resize=self._update_pos_buttons)
+
+    def on_touch_up(self, touch):
+        pos = touch.pos
+        touch_root = None
+        touch_stack = None
+        if self.auto_dismiss:
+            for widget in self.children:
+                if isinstance(widget, MDFloatingRootButton):
+                    if widget.collide_point(*pos):
+                        touch_root = widget.collide_point(*pos)
+                if isinstance(widget, MDFloatingBottomButton) or isinstance(widget, MDFloatingLabel):
+                    if widget.collide_point(*pos) and not self.dismiss_on_option_touch:
+                        if self.state == 'open':
+                            touch_stack = widget.collide_point(*pos)
+            else:
+                if self.collide_point(*pos) and not touch_root and not touch_stack:
+                    self.close_stack()
 
     def on_open(self, *args):
         """Called when a stack is opened."""

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -374,9 +374,9 @@ Or without KV Language:
 
     class Example(MDApp):
         data = {
-            'language-python': 'Python',
-            'language-php': 'PHP',
-            'language-cpp': 'C++',
+            'Python': 'language-python',
+            'PHP': 'language-php',
+            'C++': 'language-cpp',
         }
 
         def build(self):

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -413,6 +413,14 @@ You can set your color values ​​for background, text of buttons etc:
 .. seealso::
 
     `See full example <https://github.com/kivymd/KivyMD/wiki/Components-Button>`_
+
+You can use various types of dismissal on the stack:
+
+.. code-block:: kv
+
+    MDFloatingActionButtonSpeedDial:
+        auto_dismiss: True              #dismisses when clicked out of widget
+        dismiss_on_option_touch: True   #dismisses even when clicked on options
 """
 
 __all__ = (
@@ -1820,6 +1828,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         Window.bind(on_resize=self._update_pos_buttons)
 
     def on_touch_up(self, touch):
+        """Dismisses stack when clicked out of focus or clicked on options"""
         pos = touch.pos
         touch_root = None
         touch_stack = None
@@ -1828,12 +1837,21 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
                 if isinstance(widget, MDFloatingRootButton):
                     if widget.collide_point(*pos):
                         touch_root = widget.collide_point(*pos)
-                if isinstance(widget, MDFloatingBottomButton) or isinstance(widget, MDFloatingLabel):
-                    if widget.collide_point(*pos) and not self.dismiss_on_option_touch:
-                        if self.state == 'open':
+                if isinstance(widget, MDFloatingBottomButton) or isinstance(
+                    widget, MDFloatingLabel
+                ):
+                    if (
+                        widget.collide_point(*pos)
+                        and not self.dismiss_on_option_touch
+                    ):
+                        if self.state == "open":
                             touch_stack = widget.collide_point(*pos)
             else:
-                if self.collide_point(*pos) and not touch_root and not touch_stack:
+                if (
+                    self.collide_point(*pos)
+                    and not touch_root
+                    and not touch_stack
+                ):
                     self.close_stack()
 
     def on_open(self, *args):

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,6 +1872,9 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
+        # Added New format for data of speed dial for identical icons
+        # {"Text to be displayed":"icon name"}
+        
         for name,name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,7 +1872,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        for name,name_icon in value.items():
+        for name, name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,
                 on_enter=self.on_enter,

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,9 +1872,6 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        # Added New format for data of speed dial for identical icons
-        # {"Text to be displayed":"icon name"}
-        
         for name,name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -349,9 +349,9 @@ MDFloatingActionButtonSpeedDial
 
     class Example(MDApp):
         data = {
-            'language-python': 'Python',
-            'language-php': 'PHP',
-            'language-cpp': 'C++',
+            'Python': 'language-python',
+            'PHP': 'language-php',
+            'C++': 'language-cpp',
         }
 
         def build(self):
@@ -1872,7 +1872,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        for name_icon in value.keys():
+        for name,name_icon in zip(value.keys(),value.values):
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,
                 on_enter=self.on_enter,
@@ -1885,7 +1885,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
             self.set_pos_bottom_buttons(bottom_button)
             self.add_widget(bottom_button)
             # Labels.
-            floating_text = value[name_icon]
+            floating_text = name
             if floating_text:
                 label = MDFloatingLabel(text=floating_text, opacity=0)
                 label.text_color = self.label_text_color

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1872,7 +1872,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self._label_pos_y_set = False
 
         # Bottom buttons.
-        for name,name_icon in zip(value.keys(),value.values):
+        for name,name_icon in value.items():
             bottom_button = MDFloatingBottomButton(
                 icon=name_icon,
                 on_enter=self.on_enter,


### PR DESCRIPTION
### Description of Changes

- This commit adds 2 new options
```
MDFloatingActionButtonSpeedDial:
    auto_dismiss: True              #dismisses when clicked out of widget
    dismiss_on_option_touch: True   #dismisses even when clicked on options
```

- The commit has been tested with KitchenSink and works as intended
- the below video is captured while testing but will showcase the feature perfectly
- If any changes in names auto_dismiss or dismiss_on_option_touch please kindly request for changes and suggest a name or nomenclature to be followed for naming



### Video

https://user-images.githubusercontent.com/45727291/111988969-31ce5500-8b37-11eb-847f-e9e100dab88b.mp4


