### PR TITLE
Added reload method to FitImage class

### DIFF
--- a/kivymd/utils/fitimage.py
+++ b/kivymd/utils/fitimage.py
@@ -122,6 +122,9 @@ class FitImage(BoxLayout):
         self.bind(source=self.container.setter("source"))
         self.add_widget(self.container)
 
+    def reload(self):
+        self.container.image.reload()
+
 
 class Container(Widget):
     source = ObjectProperty()


### PR DESCRIPTION
Added a standard function for images - `reload`

Function reload image from disk. This facilitates re-loading of images from disk in case the image content changes.
If we change the image to another one with the same name after loading it, we will need to clear the cache, and this will be done by `reload`
```python
from kivymd.app import MDApp
from kivy.lang.builder import Builder

KV = '''
Screen:
    FitImage:
        id: image
        source: 'Image.jpg'
        
    FloatLayout:
        MDIconButton:
            icon: 'reload'
            pos: root.width - self.width, root.height - self.height
            theme_text_color: "Custom"
            text_color: app.theme_cls.primary_color
            on_release: image.container.image.reload()
'''


class TestApp(MDApp):
    def build(self):
        return Builder.load_string(KV)


TestApp().run()

```

https://user-images.githubusercontent.com/40869738/112895474-d88d9500-90e5-11eb-9c99-eb096d0e401a.mov

[kivy image reload](https://kivy.org/doc/stable/api-kivy.uix.image.html?highlight=asyncimage#kivy.uix.image.Image.reload)