### PR TITLE
Changed the value of the `size_hint` parameter in the `_ItemsBox` rul…

### DIFF
--- a/kivymd/uix/swiper.py
+++ b/kivymd/uix/swiper.py
@@ -231,7 +231,7 @@ Builder.load_string(
 
 
 <_ItemsBox>
-    size_hint: None, None
+    size_hint_x: None
     anchor_x: "center"
     anchor_y: "center"
 """


### PR DESCRIPTION
I made this change because I was faced with the problem of scaling the image in height. My change concerns the `_ItemsBox` class, if you change the value of `size_hint: None, None` to `size_hint_x: None`, then the problem is solved.
For the test, the [code from the documentation](https://kivymd.readthedocs.io/en/latest/components/mdswiper/#example) was used

https://user-images.githubusercontent.com/40869738/113522206-4be04c80-95a7-11eb-8165-fbb2918932bc.mp4

