### PR TITLE
Fixed margins on the edges of the first and last element in the `MDSwiper` class of the `_reset_size` function

### DIFF
--- a/kivymd/uix/swiper.py
+++ b/kivymd/uix/swiper.py
@@ -454,9 +454,17 @@ class MDSwiper(ScrollView, EventDispatcher):
         children = list(reversed(self.ids.anchor_scroll.children))
         if not children:
             return
+
         child = children[self._selected]
         total_width = self.ids.anchor_scroll.width - Window.width
-        view_x = child.x - self.items_spacing * self.width_mult
+
+        if self.get_current_index() == 0:
+            view_x = child.x - self.items_spacing
+        elif self.get_current_index() == len(children) - 1:
+            view_x = child.x - self.items_spacing * self.width_mult - self.items_spacing * 2
+        else:
+            view_x = child.x - self.items_spacing * self.width_mult
+
         anim = Animation(
             scroll_x=view_x / total_width,
             d=self.transition_duration,
@@ -467,6 +475,7 @@ class MDSwiper(ScrollView, EventDispatcher):
         for widget in children:
             widget.children[0]._dismiss_size()
             widget.children[0]._selected = False
+
         child.children[0]._selected_size()
         child.children[0]._selected = True
 


### PR DESCRIPTION
Previously, there were problems with the margins of the image from the edges, instead of the set value of the margins, they were larger and only after clicking on the images or swiping became normal


https://user-images.githubusercontent.com/40869738/113695196-45ea8880-96d9-11eb-8040-0084d5f4875c.mp4

