### PR TITLE
Label memory Leakage Fix

### DIFF
--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -823,7 +823,7 @@ class ThemeManager(EventDispatcher):
     def _get_error_color(self):
         return get_color_from_hex(self.colors["Red"]["A700"])
 
-    error_color = AliasProperty(_get_error_color)
+    error_color = AliasProperty(_get_error_color, bind=["theme_style"])
     """
     Color of the error text used
     in the :class:`~kivymd.uix.textfield.MDTextField`.


### PR DESCRIPTION
Possible fix for memory leakage as the widget was binded multiple times. 
Without unbinding the prior element from the event dispatcher.

### Description of Changes
Fix for #723 

### Screenshots
prior behavior.
![TESTING APP- previous](https://user-images.githubusercontent.com/5509325/113802499-76a1e080-9720-11eb-8080-d4e70f47c8c1.png)

After the bugfix.
![WindowsTerminal_ud5pyvUj4z](https://user-images.githubusercontent.com/5509325/113802655-b10b7d80-9720-11eb-9a41-7e2dfd1e25b5.png)
