### PR TITLE
Replace MDRectangleFlatButton with MDRectangleFlatIconButton

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -210,7 +210,7 @@ MDRectangleFlatIconButton
 .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/md-rectangle-flat-icon-button.png
     :align: center
 
-Button parameters :class:`~MDRectangleFlatButton` are the same as
+Button parameters :class:`~MDRectangleFlatIconButton` are the same as
 button :class:`~MDRectangleFlatButton`:
 
 .. code-block:: kv


### PR DESCRIPTION
### Description of Changes
* Replaced `MDRectangleFlatButton` with `MDRectangleFlatIconButton` on [line 213](https://github.com/kivymd/KivyMD/blob/master/kivymd/uix/button.py#L213-L214).
* There is this line under the section [Components > Button > MDRectangleFlatIconButton](https://kivymd.readthedocs.io/en/latest/components/button/#mdrectangleflaticonbutton):
    > Button parameters `MDRectangleFlatButton` are the same as button `MDRectangleFlatButton`:

    Instead of the first `MDRectangleFlatButton` there should be `MDRectangleFlatIconButton` since this description is of the button `MDRectangleFlatIconButton`, and implies that the button parameters of `MDRectangleFlatIconButton` are the same as of `MDRectangleFlatButton`. The corrected description is:
    > Button parameters `MDRectangleFlatIconButton` are the same as button `MDRectangleFlatButton`:

## Screenshots
Without change:
![MDRectangleFlatIconButton](https://user-images.githubusercontent.com/57973356/115109259-65fd3000-9f94-11eb-8b3a-bad76ea4026f.png)
