### PR TITLE
fixes for MDFloatingActionButtonSpeedDial opening stack animation

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1957,7 +1957,8 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         for widget in self.children:
             if isinstance(widget, MDFloatingLabel):
                 Animation.cancel_all(widget)
-
+            elif isinstance(widget, MDFloatingBottomButton):
+                Animation.cancel_all(widget)
         if self.state != "open":
             y = 0
             label_position = dp(56)


### PR DESCRIPTION

### Description of Changes
#954
when clicking multiple times on ActionSpeedDial button while closing animation , floating buttons catch on_touch_up event that leads to activate their animations .
so as in #954 animations still working even the main button closed ..
so i meant to add this elif statement to cancel all animations on_open stack as a reset option , to not merge between opening animations and closeing animations.
Hope it is a good solution .
