### PR TITLE
Fixed BoundedNumericProperty error in BaseRectangularButton #995

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -445,7 +445,6 @@ from kivy.lang import Builder
 from kivy.metrics import dp
 from kivy.properties import (
     BooleanProperty,
-    BoundedNumericProperty,
     ColorProperty,
     DictProperty,
     NumericProperty,
@@ -991,9 +990,9 @@ class BaseRectangularButton(
 ):
     """Base class for all rectangular buttons."""
 
-    width = BoundedNumericProperty(
-        88, min=88, max=None, errorhandler=lambda x: 88
-    )
+    def on_width(self, *args):
+        if self.width < 88:
+            self.width = 88
 
 
 class BaseFlatButton(BaseRectangularButton):


### PR DESCRIPTION
### Description of Changes
Will fix `TypeError: Cannot convert kivy.properties.BoundedNumericPropertyStorage to kivy.properties.NumericPropertyStorage` when using kivy `v2.1.0.dev0` . 

The idea is to check the `width` value of  `BaseRectangularButton` inside `on_width` event and then resize it if the value is less than `88`. So we don't need to `BoundedNumericProperty` to check the minimum value.