### PR TITLE
Double and triple touch validation moved to the `delete_clock` function of the `on_touch_down` event

### DIFF
--- a/kivymd/uix/behaviors/touch_behavior.py
+++ b/kivymd/uix/behaviors/touch_behavior.py
@@ -1,51 +1,34 @@
 """
 Behaviors/Touch
 ===============
-
 .. rubric:: Provides easy access to events.
-
 The following events are available:
-
 - on_long_touch
 - on_double_tap
 - on_triple_tap
-
 Usage
 -----
-
 .. code-block:: python
-
     from kivy.lang import Builder
-
     from kivymd.app import MDApp
     from kivymd.uix.behaviors import TouchBehavior
     from kivymd.uix.button import MDRaisedButton
-
     KV = '''
     Screen:
-
         MyButton:
             text: "PRESS ME"
             pos_hint: {"center_x": .5, "center_y": .5}
     '''
-
-
     class MyButton(MDRaisedButton, TouchBehavior):
         def on_long_touch(self, *args):
             print("<on_long_touch> event")
-
         def on_double_tap(self, *args):
             print("<on_double_tap> event")
-
         def on_triple_tap(self, *args):
             print("<on_triple_tap> event")
-
-
     class MainApp(MDApp):
         def build(self):
             return Builder.load_string(KV)
-
-
     MainApp().run()
 """
 
@@ -61,16 +44,13 @@ class TouchBehavior:
     duration_long_touch = NumericProperty(0.4)
     """
     Time for a long touch.
-
     :attr:`duration_long_touch` is an :class:`~kivy.properties.NumericProperty`
     and defaults to `0.4`.
     """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.bind(
-            on_touch_down=self.create_clock, on_touch_up=self.delete_clock
-        )
+        self.bind(on_touch_down=self.create_clock, on_touch_up=self.delete_clock)
 
     def create_clock(self, widget, touch, *args):
         if self.collide_point(touch.x, touch.y):
@@ -78,17 +58,17 @@ class TouchBehavior:
             Clock.schedule_once(callback, self.duration_long_touch)
             touch.ud["event"] = callback
 
+        if touch.is_double_tap:
+            self.on_double_tap(touch, *args)
+        if touch.is_triple_tap:
+            self.on_triple_tap(touch, *args)
+
     def delete_clock(self, widget, touch, *args):
         if self.collide_point(touch.x, touch.y):
             try:
                 Clock.unschedule(touch.ud["event"])
             except KeyError:
                 pass
-
-            if touch.is_double_tap:
-                self.on_double_tap(touch, *args)
-            if touch.is_triple_tap:
-                self.on_triple_tap(touch, *args)
 
     def on_long_touch(self, touch, *args):
         """Called when the widget is pressed for a long time."""


### PR DESCRIPTION
Double and triple click checks must occur when the `on_touch_down` method is triggered, otherwise the functions : `on_double_tap`, `on_triple_tap` - will trigger twice.
[Code example](https://kivymd.readthedocs.io/en/latest/behaviors/touch/index.html#usage)