### PR TITLE
add pillow to buildozer requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ to save time. If you need full commit history, then remove `--depth 1`.
 ### How to use with [Buildozer](https://github.com/kivy/buildozer)
 
 ```ini
-requirements = kivy==2.0.0, kivymd==0.104.2, sdl2_ttf == 2.0.15
+requirements = kivy==2.0.0, kivymd==0.104.2, sdl2_ttf == 2.0.15, pillow
 ```
 
 This will download latest release version of KivyMD from [PyPI](https://pypi.org/project/kivymd).


### PR DESCRIPTION
It is known that the build will be successful without it. But when running the app, it crashes due to a ModuleNotFoundError.

![image](https://user-images.githubusercontent.com/66187211/123259297-b334db00-d4ca-11eb-86c8-392f45178ca0.png)

