### PR TITLE
fix button press fade behaviour when switching screen

### DIFF
--- a/kivymd/app.py
+++ b/kivymd/app.py
@@ -89,3 +89,12 @@ class MDApp(App, FpsMonitoring):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.theme_cls = ThemeManager()
+
+    """
+    :attr:`get_screen_manager` find the screen manager of the application. If no one exists return None
+    """
+    def get_screen_manager(self):
+        for key, item in self.__dict__.items():
+            if isinstance(item, ScreenManager):
+                return item
+        return None

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -949,6 +949,7 @@ class BasePressedButton(BaseButton):
 
     animation_fade_bg = None
     current_md_bg_color = ColorProperty(None)
+    current_screen = None
 
     def on_touch_down(self, touch):
         if touch.is_mouse_scrolling:
@@ -961,6 +962,9 @@ class BasePressedButton(BaseButton):
             return False
         else:
             if self.md_bg_color == [0.0, 0.0, 0.0, 0.0]:
+                screen_manager = MDApp.get_running_app().get_screen_manager()
+                if screen_manager:
+                    self.current_screen = screen_manager.current
                 self.current_md_bg_color = self.md_bg_color
                 self.animation_fade_bg = Animation(
                     duration=0.5, md_bg_color=[0.0, 0.0, 0.0, 0.1]
@@ -975,9 +979,13 @@ class BasePressedButton(BaseButton):
             and not self.disabled
         ):
             self.animation_fade_bg.stop_property(self, "md_bg_color")
-            Animation(
-                duration=0.05, md_bg_color=self.current_md_bg_color
-            ).start(self)
+            screen_manager = MDApp.get_running_app().get_screen_manager()
+            if screen_manager and self.current_screen != screen_manager.current:
+                self.md_bg_color = self.current_md_bg_color
+            else:
+                Animation(
+                    duration=0.05, md_bg_color=self.current_md_bg_color
+                ).start(self)
         return super().on_touch_up(touch)
 
 


### PR DESCRIPTION
### Description of Changes

These changes fix the bug with the button on press fade transition.

Steps to reproduce:
1. Create MDFlatButton(for example)
2. Bind the changing screen callback to this button
3. Click on the button
4. On the new screen you also should have a button to navigate back. So click on it *quickly* and return to the first screen
5. The button on the first screen has bugged fade

Here is my solution to fix this bug. I am not sure this is the best solution, but I will be thankful if you answered my pr.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/60746298/123642092-95010f00-d82b-11eb-910c-5ea2d3d94e46.png)

After:
![image](https://user-images.githubusercontent.com/60746298/123641855-608d5300-d82b-11eb-9091-e68d3f7d80e6.png)