### PR TITLE
Added `loader_clock` to the `Container` class, which updates the canvas every `image.anim_delay` for the correct operation of the preloader

### DIFF
--- a/kivymd/utils/fitimage.py
+++ b/kivymd/utils/fitimage.py
@@ -166,7 +166,8 @@ class Container(Widget):
     def __init__(self, source, mipmap, **kwargs):
         super().__init__(**kwargs)
         self.image = AsyncImage(mipmap=mipmap)
-        self.image.bind(on_load=self.adjust_size)
+        self.loader_clock = Clock.schedule_interval(self.adjust_size, self.image.anim_delay)
+        self.image.bind(on_load=lambda inst: (self.adjust_size(), self.loader_clock.cancel()))
         self.source = source
         self.bind(size=self.adjust_size, pos=self.adjust_size)
 


### PR DESCRIPTION
Previously, the preloader did not rotate, since the `texture` of the image was not updated, I solved this problem by adding `Clock.schedule_interval`

```python
from kivymd.app import MDApp

from kivy.lang.builder import Builder

KV = """
FitImage:
    source: 'https://wallpapershome.com/images/pages/pic_h/23346.jpg'
"""


class TestApp(MDApp):
    def build(self):
        return Builder.load_string(KV)


TestApp().run()
```

https://user-images.githubusercontent.com/40869738/124310924-94db7900-db75-11eb-83bf-d0c3dfd2eda8.mp4

