### PR TITLE
Removed the zeroing of the `md_bg_color` of the `BaseFlatButton` class in the `on_disabled` function, because it resets the custom color

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1029,8 +1029,6 @@ class BaseFlatButton(BaseRectangularButton):
                 if self.md_bg_color_disabled
                 else self.theme_cls.disabled_hint_text_color
             )
-        else:
-            self.md_bg_color = [0.0, 0.0, 0.0, 0.0]
 
     def on_elevation(self, instance, value):
         """

--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1029,6 +1029,9 @@ class BaseFlatButton(BaseRectangularButton):
                 if self.md_bg_color_disabled
                 else self.theme_cls.disabled_hint_text_color
             )
+        else:
+            if self._md_bg_color:
+                self.md_bg_color = self._md_bg_color
 
     def on_elevation(self, instance, value):
         """


### PR DESCRIPTION
Faced with the problem that when the button is locked and unlocked, the color resets to the system.

```python
from kivymd.app import MDApp
from kivy.lang.builder import Builder

KV = """
Screen:
    MDFillRoundFlatButton:
        id: btn
        text: 'Text'
        pos_hint: {'center': (0.5,0.5)}
        text_color: [1,1,1,1]
        md_bg_color: [0,0,0,1]
        on_touch_down: app.disable_btn()
"""


class TestApp(MDApp):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.c = 0

    def build(self):
        return Builder.load_string(KV)

    def disable_btn(self):
        if self.root.ids.btn.disabled:
            self.root.ids.btn.disabled = False
        else:
            self.root.ids.btn.disabled = True

        if self.c == 3:
            self.root.ids.btn.md_bg_color = self.theme_cls.accent_color
            self.c = 0
        else:
            self.c += 1


TestApp().run()
```

https://user-images.githubusercontent.com/40869738/124334337-768a7300-db9f-11eb-89b5-b2d06e952cf2.mp4

