### PR TITLE
Fix bug where visible attribute is checked on wrong object type

### DIFF
--- a/kivymd/uix/navigationrail.py
+++ b/kivymd/uix/navigationrail.py
@@ -678,7 +678,7 @@ class MDNavigationRail(MDCard):
             t=self.color_transition,
             d=self.color_change_duration,
         ).start(item)
-        if item.visible == "Selected":
+        if self.visible == "Selected":
             Animation(
                 text_color=(0, 0, 0, 0),
                 t=self.color_transition,
@@ -696,7 +696,7 @@ class MDNavigationRail(MDCard):
             t=self.color_transition,
             d=self.color_change_duration,
         ).start(item)
-        if item.visible == "Selected":
+        if self.visible == "Selected":
             item.ids.lbl_text.text_color = item._color_normal
             Animation(
                 text_color=color,


### PR DESCRIPTION
When function anim_color_normal or anim_color_active is called on MDNavigationRail, the visible property is checked on MDNavigationRailItem causing attribute error

### Description of Changes
* changed item.visible to self.visible in anim_color_normal and  anim_color_active functions

