### PR TITLE
MDChip: Use icon_color for check mark

### DIFF
--- a/kivymd/uix/chip.py
+++ b/kivymd/uix/chip.py
@@ -286,14 +286,23 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
 
             if self.check:
                 if not len(self.ids.box_check.children):
-                    self.ids.box_check.add_widget(
-                        MDIcon(
+                    if self.icon_color:
+                        icon = MDIcon(
+                            icon="check",
+                            size_hint=(None, None),
+                            size=("26dp", "26dp"),
+                            font_size=sp(20),
+                            theme_text_color="Custom",
+                            text_color=self.icon_color,
+                        )
+                    else:
+                        icon = MDIcon(
                             icon="check",
                             size_hint=(None, None),
                             size=("26dp", "26dp"),
                             font_size=sp(20),
                         )
-                    )
+                    self.ids.box_check.add_widget(icon)
                 else:
                     check = self.ids.box_check.children[0]
                     self.ids.box_check.remove_widget(check)


### PR DESCRIPTION
### Description of Changes
If the check option is set, MDChip currently defaults to the primary text color for the check mark icon. With this PR, if an icon color is set, this is used instead. Another even better solution might be to add a new property to MDChip to make the check mark color customizable independently from either text or icon color.

### Screenshots
#### Before
![before, black check mark, white icon](https://github.com/floi/kivymdchipscreenshots/raw/main/chip-master_green.png) 
#### After
![after, black check mark, white icon](https://github.com/floi/kivymdchipscreenshots/raw/main/chip-check-icon-color_green.png)
