### PR TITLE
Fixed the `_radius` argument for the `MDRoundFlatButton` class

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -1240,7 +1240,7 @@ class MDRoundFlatButton(MDFlatButton):
     and defaults to `None`.
     """
 
-    _radius = NumericProperty(18)
+    _radius = NumericProperty("18dp")
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
I found that for some reason all the buttons (`MDRoundFlatButton`, `MDFillRoundFlatIconButton`, etc) that should have rounded edges are similar to ordinary rectangular buttons. Fix issue #1040 
![FixedRoundButtons](https://user-images.githubusercontent.com/40869738/126047076-28576ad6-4693-455c-ab6b-45f681ff2a0b.jpg)
