### PR TITLE
Add `dp` to `radius` in `BaseDialog` class

### DIFF
--- a/kivymd/uix/dialog.py
+++ b/kivymd/uix/dialog.py
@@ -175,7 +175,7 @@ Builder.load_string(
 
 
 class BaseDialog(ThemableBehavior, ModalView):
-    radius = ListProperty([7, 7, 7, 7])
+    radius = ListProperty([dp(7), dp(7), dp(7), dp(7)])
     """
     Dialog corners rounding value.
 


### PR DESCRIPTION
Such values should be wrapped in the `dp` function, otherwise there will be no effect on mobile devices.