### PR TITLE
Add `animation_tooltip_dismiss` function and `on_dismiss` event to `MDTooltip` class

### DIFF
--- a/kivymd/uix/tooltip.py
+++ b/kivymd/uix/tooltip.py
@@ -265,6 +265,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         self.dispatch("on_show")
 
     def animation_tooltip_dismiss(self, interval):
+        """version added: 1.0.0"""
         if not self._tooltip:
             return
         anim = (
@@ -321,7 +322,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         pass
 
     def on_dismiss(self):
-        pass
+        """version added: 1.0.0"""
 
 
 class MDTooltipViewClass(ThemableBehavior, BoxLayout):

--- a/kivymd/uix/tooltip.py
+++ b/kivymd/uix/tooltip.py
@@ -201,6 +201,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.register_event_type("on_show")
+        self.register_event_type("on_dismiss")
 
     def delete_clock(self, widget, touch, *args):
         if self.collide_point(touch.x, touch.y) and touch.grab_current:
@@ -263,6 +264,21 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         ).start(self._tooltip)
         self.dispatch("on_show")
 
+    def animation_tooltip_dismiss(self, interval):
+        if not self._tooltip:
+            return
+        anim = (
+                Animation(_scale_x=0, _scale_y=0, d=0.1)
+                + Animation(opacity=0, d=0.2)
+        )
+        anim.bind(on_complete=self._on_dismiss_anim_complete)
+        anim.start(self._tooltip)
+
+    def _on_dismiss_anim_complete(self, *args):
+        self.dispatch("on_dismiss")
+        self.remove_tooltip()
+        self._tooltip = None
+
     def remove_tooltip(self, *args):
         Window.remove_widget(self._tooltip)
 
@@ -299,10 +315,12 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         """
 
         if self._tooltip:
-            Window.remove_widget(self._tooltip)
-            self._tooltip = None
+            Clock.schedule_once(self.animation_tooltip_dismiss)
 
     def on_show(self):
+        pass
+
+    def on_dismiss(self):
         pass
 
 

--- a/kivymd/uix/tooltip.py
+++ b/kivymd/uix/tooltip.py
@@ -265,7 +265,8 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         self.dispatch("on_show")
 
     def animation_tooltip_dismiss(self, interval):
-        """versionadded:: 1.0.0"""
+        """.. versionadded:: 1.0.0"""
+
         if not self._tooltip:
             return
         anim = (
@@ -322,7 +323,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         pass
 
     def on_dismiss(self):
-        """versionadded:: 1.0.0"""
+        """.. versionadded:: 1.0.0"""
 
 
 class MDTooltipViewClass(ThemableBehavior, BoxLayout):

--- a/kivymd/uix/tooltip.py
+++ b/kivymd/uix/tooltip.py
@@ -265,7 +265,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         self.dispatch("on_show")
 
     def animation_tooltip_dismiss(self, interval):
-        """version added: 1.0.0"""
+        """versionadded:: 1.0.0"""
         if not self._tooltip:
             return
         anim = (
@@ -322,7 +322,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         pass
 
     def on_dismiss(self):
-        """version added: 1.0.0"""
+        """versionadded:: 1.0.0"""
 
 
 class MDTooltipViewClass(ThemableBehavior, BoxLayout):


### PR DESCRIPTION
I added an animation of closing the widget, and then earlier the disappearance looks like something clumsy.

```python
from kivymd.app import MDApp
from kivymd.uix.button import MDFlatButton
from kivymd.uix.tooltip import MDTooltip

from kivy.lang.builder import Builder

KV = """
Screen:
    CustomButton:
        text: 'Text'
        pos_hint: {'center_x': 0.5, 'center_y': 0.5}
        tooltip_text: 'Text'
        on_dismiss: print('Tooltip is closed')
"""


class CustomButton(MDFlatButton, MDTooltip):
    pass


class Example(MDApp):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)

    def build(self):
        return Builder.load_string(KV)


Example().run()
```

https://user-images.githubusercontent.com/40869738/127679065-9349e021-0891-4d03-83ec-5b4bd9ccf713.mp4

