### PR TITLE
Fixed a non-retractable background in the `on_touch_up` method in the `BasePressedButton` class

### DIFF
--- a/kivymd/uix/button.py
+++ b/kivymd/uix/button.py
@@ -976,11 +976,11 @@ class BasePressedButton(BaseButton):
 
     def on_touch_up(self, touch):
         if (
-            self.collide_point(touch.x, touch.y)
+            not self.disabled
             and self.animation_fade_bg
-            and not self.disabled
         ):
             self.animation_fade_bg.stop_property(self, "md_bg_color")
+            self.animation_fade_bg = None
             Animation(
                 duration=0.05, md_bg_color=self.current_md_bg_color
             ).start(self)


### PR DESCRIPTION
If you hold down the button and move the cursor/finger away from the button, the button background will remain gray, since the animation of its removal will not work due to `self.collide_point(touch. x, touch. y)`.

https://user-images.githubusercontent.com/40869738/127784896-719168f4-ae6a-4dd3-9053-5f405266183e.mp4

