### PR TITLE
Modify Chip.py "Check" icon

### DIFF
--- a/kivymd/uix/chip.py
+++ b/kivymd/uix/chip.py
@@ -296,6 +296,8 @@ class MDChip(ThemableBehavior, ButtonBehavior, BoxLayout):
                             size_hint=(None, None),
                             size=("26dp", "26dp"),
                             font_size=sp(20),
+                            theme_text_color = "Custom",
+                            text_color = self.icon_color
                         )
                     )
                 else:


### PR DESCRIPTION
This modification will allow it to match the set icon color.

### Description of the problem

The "check" icon created in the "on_touch_down" function remains black regardless of what icon color is chosen for the chip.
The example MDChips below should produce a white check rather than a black one.

### Reproducing the problem

```python
MDChip:
    text: 'On Standby?'
    pos_hint: {"center_x":0.5}
    check: True
    icon_color: 1,1,1,1
    text_color: 1,1,1,1

MDChip:
    text: 'On Standby?'
    pos_hint: {"center_x":0.5}
    icon: 'account-clock'
    check: True
    icon_color: 1,1,1,1
    text_color: 1,1,1,1
```

### Screenshot of the problem

![Chip problem](https://user-images.githubusercontent.com/86119212/128078528-63e47e0a-521f-4681-8cc9-9399633cfcbf.jpg)

### Description of Changes

I included the following lines of code to the "Check" widget so that it inherits the icon color and therefore will always match it.
```python
theme_text_color = "Custom",
text_color = self.icon_color
```
### Screenshot of the solution to the problem

![Solution](https://user-images.githubusercontent.com/86119212/128078701-dcbd8584-f62b-4da6-adb4-b6c824a5cce2.jpg)

