### PR TITLE
Fix `TypeError` in `label_check_texture_size` method

### DIFF
--- a/kivymd/toast/kivytoast/kivytoast.py
+++ b/kivymd/toast/kivytoast/kivytoast.py
@@ -38,7 +38,7 @@ KivyToast
     Test().run()
 """
 
-from typing import NoReturn
+from typing import NoReturn, Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -87,7 +87,7 @@ class Toast(BaseDialog):
         self.add_widget(self.label_toast)
 
     def label_check_texture_size(
-        self, instance_label: Label, texture_size: list[int, int]
+        self, instance_label: Label, texture_size: Union[int, int]
     ) -> NoReturn:
         """
         Resizes the text if the text texture is larger than the screen size.


### PR DESCRIPTION
To indicate that the argument can be of different types, you must use `Union`