### PR TITLE
Fix typing in `label_check_texture_size` to support old python version

### DIFF
--- a/kivymd/toast/kivytoast/kivytoast.py
+++ b/kivymd/toast/kivytoast/kivytoast.py
@@ -38,7 +38,7 @@ KivyToast
     Test().run()
 """
 
-from typing import NoReturn
+from typing import NoReturn, List
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -87,7 +87,7 @@ class Toast(BaseDialog):
         self.add_widget(self.label_toast)
 
     def label_check_texture_size(
-        self, instance_label: Label, texture_size: list[int, int]
+        self, instance_label: Label, texture_size: List[int]
     ) -> NoReturn:
         """
         Resizes the text if the text texture is larger than the screen size.


### PR DESCRIPTION
Related to: #1063, #1062