### PR TITLE
Fix wrong "BoxLayout" occurrence in MD colors sample program

### DIFF
--- a/kivymd/color_definitions.py
+++ b/kivymd/color_definitions.py
@@ -396,7 +396,7 @@ To demonstrate the shades of the palette, you can run the following code:
     from kivymd.app import MDApp
 
 
-    class Tab(BoxLayout, MDTabsBase):
+    class Tab(MDBoxLayout, MDTabsBase):
         pass
 
 


### PR DESCRIPTION
### Description of the problem

Simple wrong use of BoxLayout (unimported) breaking the program

### Description of Changes

Replace by properly-imported MDBoxLayout

