### PR TITLE
Fix typo in gridlayout.py

### DIFF
--- a/kivymd/uix/gridlayout.py
+++ b/kivymd/uix/gridlayout.py
@@ -65,7 +65,7 @@ Equivalent
 .. code-block:: kv
 
     size_hint_x: None
-    height: self.minimum_width
+    width: self.minimum_width
 
 .. adaptive_size:
 adaptive_size


### PR DESCRIPTION
"height" and "width" were mixed in adaptive_width equivalence doc
