### PR TITLE
WIP - Do Not Merge - BackgroundColorBehavior Layer fix

### DIFF
--- a/demos/kitchen_sink/libs/kv/start_screen.kv
+++ b/demos/kitchen_sink/libs/kv/start_screen.kv
@@ -27,6 +27,7 @@ MDBoxLayout:
         Home:
             id: home
             name: "home"
+            BoxLayout:
 
             MDBackdrop:
                 id: backdrop
@@ -79,6 +80,7 @@ MDBoxLayout:
 
 
     ScrollView:
+        y:root.y
 
         MDGridLayout:
             adaptive_height: True
@@ -103,12 +105,17 @@ MDBoxLayout:
                     spacing: "30dp"
 
                     KitchenSinkThemeStyleCheckbox:
+                        state: "down"
+                        on_release:
+                            app.theme_cls.theme_style = 'Light'
 
                     Label:
                         text: "Light"
                         color: app.theme_cls.text_color
 
                     KitchenSinkThemeStyleCheckbox:
+                        on_release:
+                            app.theme_cls.theme_style = 'Dark'
 
                     Label:
                         text: "Dark"
@@ -127,7 +134,8 @@ MDBoxLayout:
                 text: "Change Theme"
                 icon: "palette-outline"
                 divider: None
-                on_release: app.show_dialog_change_theme()
+                on_release:
+                    app.show_dialog_change_theme()
 
             MDSeparator:
 
@@ -142,13 +150,15 @@ MDBoxLayout:
                 text: "Developers"
                 icon: "dev-to"
                 divider: None
-                on_release: KitchenSinkDialogDev().open()
+                on_release:
+                    KitchenSinkDialogDev().open()
 
             KitchenSinkOneLineIconListItem:
                 text: "License"
                 icon: "license"
                 divider: None
-                on_release: KitchenSinkDialogLicense().open()
+                on_release:
+                    KitchenSinkDialogLicense().open()
 
             Widget:
                 size_hint_y: None
@@ -159,4 +169,6 @@ MDBoxLayout:
     group: "style"
     size_hint: None, None
     size: "48dp", "48dp"
-    on_active: if self.active: app.switch_theme_style()
+
+    on_release:
+        self.active = True

--- a/demos/kitchen_sink/main.py
+++ b/demos/kitchen_sink/main.py
@@ -129,7 +129,7 @@ class KitchenSinkApp(MDApp):
         self.theme_cls.theme_style = (
             "Light" if self.theme_cls.theme_style == "Dark" else "Dark"
         )
-        self.root.ids.backdrop.ids._front_layer.md_bg_color = [0, 0, 0, 0]
+        # self.root.ids.backdrop.ids._front_layer.md_bg_color = [0, 0, 0, 0]
 
     def show_code(self):
         if self.theme_cls.device_orientation == "landscape":

--- a/kivymd/uix/backdrop/backdrop.kv
+++ b/kivymd/uix/backdrop/backdrop.kv
@@ -1,8 +1,10 @@
 <MDBackdrop>
-    md_bg_color:
-        root.theme_cls.primary_color \
-        if not root.back_layer_color \
-        else root.back_layer_color
+    canvas.before:
+        Color:
+            rgba: self._md_bg_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
 
     MDBackdropToolbar:
         id: toolbar
@@ -11,30 +13,26 @@
         left_action_items: root.left_action_items
         right_action_items: root.right_action_items
         pos_hint: {"top": 1}
-        md_bg_color:
-            root.theme_cls.primary_color \
-            if not root.back_layer_color \
-            else root.back_layer_color
+        md_bg_color: root._md_bg_color
 
     _BackLayer:
         id: back_layer
-        y: -toolbar.height
-        padding: 0, 0, 0, toolbar.height + dp(10)
+        cols: 1
+        top: toolbar.y
+        height: root.height-toolbar.height
+        size_hint_y: None
+        padding: 0, 0, 0, header_button.height + dp(8)
 
     _FrontLayer:
         id: _front_layer
-        md_bg_color: 0, 0, 0, 0
         orientation: "vertical"
         size_hint_y: None
         height: root.height - toolbar.height
         padding: root.padding
-        md_bg_color:
-            root.theme_cls.bg_normal \
-            if not root.front_layer_color \
-            else root.front_layer_color
+        elevation: root.elevation
         radius:
             [root.radius_left, root.radius_left,
-            root.radius_right, root.radius_right]
+            0, 0]
 
         OneLineListItem:
             id: header_button

--- a/kivymd/uix/behaviors/__init__.py
+++ b/kivymd/uix/behaviors/__init__.py
@@ -10,6 +10,9 @@ from .hover_behavior import HoverBehavior  # isort:skip
 from .backgroundcolor_behavior import (
     BackgroundColorBehavior,
     SpecificBackgroundColorBehavior,
+    RoundedRectangularColorBehavior,
+    RectangularColorBehavior,
+    EllipseColorBehavior,
 )
 from .elevation import (
     CircularElevationBehavior,

--- a/kivymd/uix/behaviors/backgroundcolor_behavior.py
+++ b/kivymd/uix/behaviors/backgroundcolor_behavior.py
@@ -9,6 +9,7 @@ __all__ = ("BackgroundColorBehavior", "SpecificBackgroundColorBehavior")
 
 from typing import List, NoReturn
 
+from kivy.clock import Clock
 from kivy.lang import Builder
 from kivy.properties import (
     BoundedNumericProperty,
@@ -282,6 +283,7 @@ class BackgroundColorBehavior(CommonElevationBehavior):
         super().__init__(**kwarg)
         self.bind(pos=self.update_background_origin)
         self.bind(md_bg_color=self.update_bg_color)
+        Clock.schedule_once(lambda *x: self.update_bg_color(self, self.md_bg_color))
 
     def update_bg_color(self, instance, value: list) -> NoReturn:
         """

--- a/kivymd/uix/behaviors/backgroundcolor_behavior.py
+++ b/kivymd/uix/behaviors/backgroundcolor_behavior.py
@@ -283,7 +283,7 @@ class BackgroundColorBehavior(CommonElevationBehavior):
         self.bind(pos=self.update_background_origin)
         self.bind(md_bg_color=self.update_bg_color)
 
-    def update_bg_color(self, instance, value):
+    def update_bg_color(self, instance, value: list) -> NoReturn:
         """
         This method updates the background color in a standard way.
         rememebr _md_bg_color is the current background color.
@@ -299,7 +299,9 @@ class BackgroundColorBehavior(CommonElevationBehavior):
         if self.disabled is True:
             self.on_disabled(self, self.disabled)
             return
-        self._md_bg_color = self.md_bg_color
+
+        if self.md_bg_color:
+            self._md_bg_color = self.md_bg_color
 
     def update_background_origin(
         self, instance_md_widget, pos: List[float]

--- a/kivymd/uix/behaviors/backgroundcolor_behavior.py
+++ b/kivymd/uix/behaviors/backgroundcolor_behavior.py
@@ -33,7 +33,7 @@ Builder.load_string(
 
 
 <BackgroundColorBehavior>
-    canvas:
+    canvas.before:
         PushMatrix
         Rotate:
             angle: self.angle

--- a/kivymd/uix/behaviors/backgroundcolor_behavior.py
+++ b/kivymd/uix/behaviors/backgroundcolor_behavior.py
@@ -5,7 +5,13 @@ Behaviors/Background Color
 .. note:: The following classes are intended for in-house use of the library.
 """
 
-__all__ = ("BackgroundColorBehavior", "SpecificBackgroundColorBehavior")
+__all__ = (
+    "BackgroundColorBehavior",
+    "SpecificBackgroundColorBehavior",
+    "RoundedRectangularColorBehavior",
+    "RectangularColorBehavior",
+    "EllipseColorBehavior",
+)
 
 from typing import List, NoReturn
 

--- a/kivymd/uix/boxlayout.py
+++ b/kivymd/uix/boxlayout.py
@@ -86,8 +86,22 @@ Equivalent
 __all__ = ("MDBoxLayout",)
 
 from kivy.uix.boxlayout import BoxLayout
+from kivy.lang.builder import Builder
 
 from kivymd.uix import MDAdaptiveWidget
+from kivy.lang.builder import Builder
+
+kv = """
+<MDBoxLayout>:
+    canvas.before:
+        Color:
+            rgba: self._md_bg_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
+"""
+
+Builder.load_string(kv, filename="MDBoxLayout.kv")
 
 
 class MDBoxLayout(BoxLayout, MDAdaptiveWidget):

--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -1,5 +1,5 @@
 <BaseButton>
-    canvas:
+    canvas.before:
         Clear
         Color:
             rgba:
@@ -32,7 +32,7 @@
 
 
 <BaseRoundButton>
-    canvas:
+    canvas.before:
         Clear
         Color:
             rgba:

--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -1,9 +1,9 @@
 <BaseButton>
-    canvas.before:
+    canvas:
         Clear
         Color:
             rgba:
-                self.md_bg_color if not self.disabled else \
+                self._md_bg_color if not self.disabled else \
                 (root.md_bg_color_disabled if root.md_bg_color_disabled \
                 else root.theme_cls.disabled_hint_text_color)
         RoundedRectangle:
@@ -32,11 +32,11 @@
 
 
 <BaseRoundButton>
-    canvas.before:
+    canvas:
         Clear
         Color:
             rgba:
-                (self.md_bg_color if root.icon in md_icons else (0, 0, 0, 0)) \
+                (self._md_bg_color if root.icon in md_icons else (0, 0, 0, 0)) \
                 if not root.disabled else \
                 (root.md_bg_color_disabled if root.md_bg_color_disabled \
                 else root.theme_cls.disabled_hint_text_color)
@@ -87,8 +87,8 @@
     canvas.before:
         Color:
             rgba:
-                (root.theme_cls.primary_color if root.md_bg_color == [0.0, 0.0, 0.0, 0.0] \
-                else root.md_bg_color) if not root.disabled else \
+                (root.theme_cls.primary_color if root._md_bg_color == [0.0, 0.0, 0.0, 0.0] \
+                else root._md_bg_color) if not root.disabled else \
                 (root.md_bg_color_disabled if root.md_bg_color_disabled \
                 else root.theme_cls.disabled_hint_text_color)
         RoundedRectangle:
@@ -104,8 +104,8 @@
     canvas.before:
         Color:
             rgba:
-                (root.theme_cls.primary_color if root.md_bg_color == [0.0, 0.0, 0.0, 0.0] \
-                else root.md_bg_color) if not root.disabled else \
+                (root.theme_cls.primary_color if root._md_bg_color == [0.0, 0.0, 0.0, 0.0] \
+                else root._md_bg_color) if not root.disabled else \
                 (root.md_bg_color_disabled if root.md_bg_color_disabled \
                 else root.theme_cls.disabled_hint_text_color)
         RoundedRectangle:

--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -466,6 +466,8 @@ from kivymd.font_definitions import theme_font_styles
 from kivymd.theming import ThemableBehavior, ThemeManager
 from kivymd.uix.behaviors import (
     BackgroundColorBehavior,
+    RectangularColorBehavior,
+    EllipseColorBehavior,
     CircularElevationBehavior,
     CircularRippleBehavior,
     CommonElevationBehavior,
@@ -481,7 +483,7 @@ with open(
     Builder.load_string(kv_file.read())
 
 
-class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
+class BaseButton(BackgroundColorBehavior, ThemableBehavior, ButtonBehavior, AnchorLayout):
     """Base class for all buttons."""
 
     text = StringProperty(" ")
@@ -572,7 +574,7 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
     """
 
     _radius = NumericProperty(0)
-    _md_bg_color = ColorProperty(None)  # last current button color
+    # _md_bg_color = ColorProperty(None)  # last current button color
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -631,12 +633,12 @@ class BaseButton(ThemableBehavior, ButtonBehavior, AnchorLayout):
                 self.md_bg_color_disabled = (
                     self.theme_cls.disabled_hint_text_color
                 )
-            self.md_bg_color = self.md_bg_color_disabled
+            self._md_bg_color = self.md_bg_color_disabled
         # Sets last current button background color.
         else:
-            self.md_bg_color = (
-                self._md_bg_color
-                if self._md_bg_color
+            self._md_bg_color = (
+                self.md_bg_color
+                if self.md_bg_color
                 else self.theme_cls.primary_color
             )
 
@@ -689,7 +691,7 @@ class BasePressedButton(BaseButton):
 class BaseRectangularButton(
     RectangularRippleBehavior,
     FakeRectangularElevationBehavior,
-    BackgroundColorBehavior,
+    # RectangularColorBehavior,
     BasePressedButton,
     BaseButton,
 ):
@@ -737,8 +739,8 @@ class BaseFlatButton(BaseRectangularButton):
                 else self.theme_cls.disabled_hint_text_color
             )
         else:
-            if self._md_bg_color:
-                self.md_bg_color = self._md_bg_color
+            if self.md_bg_color:
+                self._md_bg_color = self.md_bg_color
 
     def on_elevation(self, instance_button, elevation_value: int) -> NoReturn:
         """
@@ -751,7 +753,7 @@ class BaseFlatButton(BaseRectangularButton):
         super().on_elevation(instance_button, elevation_value)
 
 
-class BaseElevationButton(CommonElevationBehavior, BaseButton):
+class BaseElevationButton(BaseButton, CommonElevationBehavior):
     """
     Base class for raised buttons.
     Implements elevation behavior as well as the recommended down/disabled
@@ -1135,8 +1137,8 @@ class MDFillRoundFlatIconButton(MDRoundFlatIconButton):
                 )
             self.md_bg_color = self.md_bg_color_disabled
         else:
-            if self._md_bg_color:
-                self.md_bg_color = self._md_bg_color
+            if self.md_bg_color:
+                self._md_bg_color = self.md_bg_color
 
     def set_icon_color(self, interval):
         pass

--- a/kivymd/uix/card/card.kv
+++ b/kivymd/uix/card/card.kv
@@ -3,9 +3,10 @@
 
 
 <MDCard>
+    # md_bg_color: app.theme_cls.
     canvas.before:
         Color:
-            rgba: self.md_bg_color
+            rgba: self._md_bg_color
         RoundedRectangle:
             size: self.size
             pos: self.pos

--- a/kivymd/uix/card/card.py
+++ b/kivymd/uix/card/card.py
@@ -646,8 +646,11 @@ class MDCard(
     def update_md_bg_color(
         self, instance_card_swipe_front_box, theme_style: str
     ) -> NoReturn:
-        if self.md_bg_color in self._bg_color_map:
-            self.md_bg_color = get_color_from_hex(
+        if self.md_bg_color:
+            self._md_bg_color = self.md_bg_color
+            return
+        if self._md_bg_color in self._bg_color_map:
+            self._md_bg_color = get_color_from_hex(
                 colors[theme_style]["CardsDialogs"]
             )
 

--- a/kivymd/uix/chip/chip.kv
+++ b/kivymd/uix/chip/chip.kv
@@ -14,7 +14,8 @@
         self.minimum_width - (dp(10) if DEVICE_TYPE == "desktop" else dp(20)) \
         if root.icon != 'checkbox-blank-circle' else self.minimum_width
 
-    canvas:
+    canvas.before:
+        Clear
         Color:
             rgba: root.theme_cls.primary_color if not root.color else root.color
         RoundedRectangle:

--- a/kivymd/uix/floatlayout.py
+++ b/kivymd/uix/floatlayout.py
@@ -48,7 +48,7 @@ kv = """
             size: self.size
 """
 
-Builder.load_string(kv, filename="MDBoxLayout.kv")
+Builder.load_string(kv, filename="MDFloatLayout.kv")
 
 
 class MDFloatLayout(FloatLayout, MDAdaptiveWidget):

--- a/kivymd/uix/floatlayout.py
+++ b/kivymd/uix/floatlayout.py
@@ -47,7 +47,6 @@ kv = """
             pos: self.pos
             size: self.size
 """
-
 Builder.load_string(kv, filename="MDFloatLayout.kv")
 
 

--- a/kivymd/uix/floatlayout.py
+++ b/kivymd/uix/floatlayout.py
@@ -34,8 +34,21 @@ MDFloatLayout
 """
 
 from kivy.uix.floatlayout import FloatLayout
+from kivy.lang.builder import Builder
 
 from kivymd.uix import MDAdaptiveWidget
+
+kv = """
+<MDFloatLayout>:
+    canvas.before:
+        Color:
+            rgba: self._md_bg_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
+"""
+
+Builder.load_string(kv, filename="MDBoxLayout.kv")
 
 
 class MDFloatLayout(FloatLayout, MDAdaptiveWidget):

--- a/kivymd/uix/gridlayout.py
+++ b/kivymd/uix/gridlayout.py
@@ -84,9 +84,22 @@ Equivalent
 """
 
 from kivy.uix.gridlayout import GridLayout
+from kivy.lang.builder import Builder
 
 from kivymd.uix import MDAdaptiveWidget
 
+
+kv = """
+<MDGridLayout>:
+    canvas.before:
+        Color:
+            rgba: self._md_bg_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
+"""
+
+Builder.load_string(kv, filename="MDBoxLayout.kv")
 
 class MDGridLayout(GridLayout, MDAdaptiveWidget):
     pass

--- a/kivymd/uix/gridlayout.py
+++ b/kivymd/uix/gridlayout.py
@@ -99,7 +99,7 @@ kv = """
             size: self.size
 """
 
-Builder.load_string(kv, filename="MDBoxLayout.kv")
+Builder.load_string(kv, filename="MDGridLayout.kv")
 
 class MDGridLayout(GridLayout, MDAdaptiveWidget):
     pass

--- a/kivymd/uix/gridlayout.py
+++ b/kivymd/uix/gridlayout.py
@@ -98,8 +98,8 @@ kv = """
             pos: self.pos
             size: self.size
 """
-
 Builder.load_string(kv, filename="MDGridLayout.kv")
+
 
 class MDGridLayout(GridLayout, MDAdaptiveWidget):
     pass

--- a/kivymd/uix/label/label.kv
+++ b/kivymd/uix/label/label.kv
@@ -2,6 +2,13 @@
 
 
 <MDLabel>
+    canvas.before:
+        Color:
+            rgba: self._md_bg_color
+        RoundedRectangle:
+            pos: self.pos
+            size: self.size
+            radius: self.radius
     disabled_color: self.theme_cls.disabled_hint_text_color
     # FIXME: Overriding the values of this property greatly affects application
     #  performance. Especially when the application window is resized and a

--- a/kivymd/uix/navigationdrawer/navigationdrawer.kv
+++ b/kivymd/uix/navigationdrawer/navigationdrawer.kv
@@ -12,7 +12,7 @@
     canvas:
         Clear
         Color:
-            rgba: self.md_bg_color
+            rgba: self._md_bg_color
         RoundedRectangle:
             size: self.size
             pos: self.pos

--- a/kivymd/uix/navigationrail/navigationrail.kv
+++ b/kivymd/uix/navigationrail/navigationrail.kv
@@ -37,7 +37,7 @@
 
     canvas.before:
         Color:
-            rgba: root.md_bg_color
+            rgba: root._md_bg_color
         RoundedRectangle:
             pos: dp(8), self.y - self._padding_right / 2 + dp(1.5)
             size:

--- a/kivymd/uix/pickers/timepicker/timepicker.kv
+++ b/kivymd/uix/pickers/timepicker/timepicker.kv
@@ -98,6 +98,7 @@
     # line_color_normal: 0, 0, 0, 0
     on_text: root.on_text
     radius: [dp(10), ]
+    -disabled_foreground_color: self.text_color
 
 
 <TimeInput>

--- a/kivymd/uix/pickers/timepicker/timepicker.py
+++ b/kivymd/uix/pickers/timepicker/timepicker.py
@@ -170,7 +170,7 @@ class TimeInputTextField(MDTextField):
         super().__init__(**kwargs)
         Clock.schedule_once(self.on_text)
         self.register_event_type("on_select")
-        self.bind(text_color=self.setter("_current_hint_text_color"))
+        # self.bind(text_color=self.setter("_current_hint_text_color"))
         self.bind(text_color=self.setter("current_hint_text_color"))
 
     def validate_time(self, s):

--- a/kivymd/uix/relativelayout.py
+++ b/kivymd/uix/relativelayout.py
@@ -30,8 +30,20 @@ MDRelativeLayout
 """
 
 from kivy.uix.relativelayout import RelativeLayout
+from kivy.lang.builder import Builder
 
 from kivymd.uix import MDAdaptiveWidget
+
+kv = """
+<MDRelativeLayout>:
+    canvas.before:
+        Color:
+            rgba: self._md_bg_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
+"""
+Builder.load_string(kv, filename="MDRelativeLayout.kv")
 
 
 class MDRelativeLayout(RelativeLayout, MDAdaptiveWidget):

--- a/kivymd/uix/screen.py
+++ b/kivymd/uix/screen.py
@@ -30,9 +30,20 @@ MDScreen
 """
 
 from kivy.uix.screenmanager import Screen
+from kivy.lang.builder import Builder
 
 from kivymd.uix import MDAdaptiveWidget
 
+kv = """
+<MDScreen>:
+    canvas.before:
+        Color:
+            rgba: self._md_bg_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
+"""
+Builder.load_string(kv, filename="MDScreen.kv")
 
 class MDScreen(Screen, MDAdaptiveWidget):
     pass

--- a/kivymd/uix/snackbar/snackbar.kv
+++ b/kivymd/uix/snackbar/snackbar.kv
@@ -13,7 +13,7 @@
 
     canvas:
         Color:
-            rgba: self.md_bg_color
+            rgba: self._md_bg_color
         RoundedRectangle:
             size: self.size
             pos: self.pos

--- a/kivymd/uix/stacklayout.py
+++ b/kivymd/uix/stacklayout.py
@@ -84,8 +84,20 @@ Equivalent
 """
 
 from kivy.uix.stacklayout import StackLayout
+from kivy.lang.builder import Builder
 
 from kivymd.uix import MDAdaptiveWidget
+
+kv = """
+<MDStackLayout>:
+    canvas.before:
+        Color:
+            rgba: self._md_bg_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
+"""
+Builder.load_string(kv, filename="MDStackLayout.kv")
 
 
 class MDStackLayout(StackLayout, MDAdaptiveWidget):

--- a/kivymd/uix/toolbar/toolbar.kv
+++ b/kivymd/uix/toolbar/toolbar.kv
@@ -24,16 +24,20 @@
     canvas:
         Color:
             rgba:
+                # ( \
+                # root.theme_cls.primary_color \
+                # if root._md_bg_color == [0, 0, 0, 0] \
+                # else root._md_bg_color \
+                # ) \
+                # if root.type == "top" else \
+                # ( \
+                # root.theme_cls.primary_color \
+                # if root.parent._md_bg_color == [0, 0, 0, 0] \
+                # else root.parent._md_bg_color \
+                # )
                 ( \
-                root.theme_cls.primary_color \
-                if root.md_bg_color == [0, 0, 0, 0] \
-                else root.md_bg_color \
-                ) \
-                if root.type == "top" else \
-                ( \
-                root.theme_cls.primary_color \
-                if root.parent.md_bg_color == [0, 0, 0, 0] \
-                else root.parent.md_bg_color \
+                root._md_bg_color if root.type == "top" \
+                else root.parent._md_bg_color \
                 )
         Mesh:
             vertices: root._vertices_left

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -322,6 +322,7 @@ from kivymd import uix_path
 from kivymd.color_definitions import text_colors
 from kivymd.theming import ThemableBehavior
 from kivymd.uix.behaviors import (
+    BackgroundColorBehavior,
     FakeRectangularElevationBehavior,
     SpecificBackgroundColorBehavior,
 )
@@ -617,14 +618,14 @@ class MDToolbar(NotchedBox):
         Window.bind(on_resize=self._on_resize)
         self.bind(specific_text_color=self.update_action_bar_text_colors)
         # self.bind(opposite_colors=self.update_opposite_colors)
-        self.theme_cls.bind(primary_palette=self.update_md_bg_color)
+        self.theme_cls.bind(primary_palette=self.update_bg_color)
         Clock.schedule_once(
             lambda x: self.on_left_action_items(0, self.left_action_items)
         )
         Clock.schedule_once(
             lambda x: self.on_right_action_items(0, self.right_action_items)
         )
-        Clock.schedule_once(lambda x: self.set_md_bg_color(0, self.md_bg_color))
+        Clock.schedule_once(lambda x: self.update_bg_color(0, self.md_bg_color))
 
     def on_type(self, instance, value):
         if value == "bottom":
@@ -647,7 +648,7 @@ class MDToolbar(NotchedBox):
 
     def on_md_bg_color(self, instance, value):
         if self.type == "bottom":
-            self.md_bg_color = [0, 0, 0, 0]
+            self._md_bg_color = [0, 0, 0, 0]
 
     def on_left_action_items(self, instance, value):
         self.update_action_bar(self.ids["left_actions"], value)
@@ -655,9 +656,16 @@ class MDToolbar(NotchedBox):
     def on_right_action_items(self, instance, value):
         self.update_action_bar(self.ids["right_actions"], value)
 
-    def set_md_bg_color(self, instance, value):
-        if value == [1.0, 1.0, 1.0, 0.0]:
-            self.md_bg_color = self.theme_cls.primary_color
+    def update_bg_color(self, instance, value):
+        if self.disabled is True:
+            self.on_disabled(self, self.disabled)
+            return
+        if not self.md_bg_color:
+            self._md_bg_color = self.theme_cls._get_primary_color()
+            # self._md_bg_color = self.theme_cls.primary_color
+            return
+        self._md_bg_color = self.md_bg_color
+
 
     def update_action_bar(self, action_bar, action_bar_items):
         action_bar.clear_widgets()
@@ -687,8 +695,8 @@ class MDToolbar(NotchedBox):
             )
         action_bar.width = new_width
 
-    def update_md_bg_color(self, *args):
-        self.md_bg_color = self.theme_cls._get_primary_color()
+    # def update_md_bg_color(self, *args):
+    #     self.md_bg_color = self.theme_cls._get_primary_color()
 
     def update_opposite_colors(self, instance, value):
         if value:
@@ -787,8 +795,8 @@ class MDToolbar(NotchedBox):
             ][self.theme_cls.primary_hue]
 
 
-class MDBottomAppBar(FloatLayout):
-    md_bg_color = ColorProperty([0, 0, 0, 0])
+class MDBottomAppBar(BackgroundColorBehavior, FloatLayout):
+    md_bg_color = ColorProperty(None)
     """
     Color toolbar.
 

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -601,7 +601,7 @@ class MDToolbar(NotchedBox):
     type = OptionProperty("top", options=["top", "bottom"])
     """
     When using the :class:`~MDBottomAppBar` class, the parameter ``type``
-    must be set to `'bottom'`:
+    must be set to `"bottom"`:
 
     .. code-block:: kv
 
@@ -610,7 +610,7 @@ class MDToolbar(NotchedBox):
             MDToolbar:
                 type: "bottom"
 
-    Available options are: `'top'`, `'bottom'`.
+    Available options are: `"top"`, `"bottom"`.
 
     :attr:`type` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'top'`.
@@ -636,7 +636,7 @@ class MDToolbar(NotchedBox):
         Clock.schedule_once(
             lambda x: self.on_right_action_items(0, self.right_action_items)
         )
-        Clock.schedule_once(lambda x: self.update_bg_color(0, self.md_bg_color))
+        Clock.schedule_once(lambda x: self.update_bg_color(0, self._md_bg_color))
 
     def on_type(self, instance, value):
         if value == "bottom":
@@ -807,19 +807,34 @@ class MDToolbar(NotchedBox):
 
 
 class MDBottomAppBar(BackgroundColorBehavior, FloatLayout):
-    md_bg_color = ColorProperty(None)
-    """
-    Color toolbar.
-
-    :attr:`md_bg_color` is an :class:`~kivy.properties.ColorProperty`
-    and defaults to `[0, 0, 0, 0]`.
-    """
+    # md_bg_color = ColorProperty(None)
+    # """
+    # Color toolbar.
+    #
+    # :attr:`md_bg_color` is an :class:`~kivy.properties.ColorProperty`
+    # and defaults to `[0, 0, 0, 0]`.
+    # """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        App.get_running_app().theme_cls.bind(primary_color=self.update_bg_color)
         self.size_hint_y = None
+        # Clock.schedule_once(lambda *x: self.update_bg_color)
 
     def add_widget(self, widget, index=0, canvas=None):
         if isinstance(widget, MDToolbar):
             super().add_widget(widget)
             return super().add_widget(widget.action_button)
+
+    def update_bg_color(self, instance, value: list) -> NoReturn:
+        """
+        updates the background collor of the bottom toolbar widget.
+        """
+        # if self.disabled is True:
+        #     self.on_disabled(self, self.disabled)
+        #     return
+
+        if self.md_bg_color:
+            self._md_bg_color = self.md_bg_color
+            return
+        self._md_bg_color = App.get_running_app().theme_cls._get_primary_color()

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -301,6 +301,7 @@ __all__ = ("MDToolbar", "MDBottomAppBar", "MDActionTopAppBarButton")
 
 import os
 from math import cos, radians, sin
+from typing import List, NoReturn
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -328,6 +329,7 @@ from kivymd.uix.behaviors import (
 )
 from kivymd.uix.button import MDFloatingActionButton, MDIconButton
 from kivymd.uix.tooltip import MDTooltip
+from kivy.app import App
 
 with open(
     os.path.join(uix_path, "toolbar", "toolbar.kv"), encoding="utf-8"
@@ -497,6 +499,15 @@ class NotchedBox(
             points.append([x, y])
 
         return points
+
+    def update_bg_color(self, instance, value: List) -> NoReturn:
+        if self.disabled is True:
+            self.on_disabled(self, self.disabled)
+            return
+        if self.md_bg_color:
+            self._md_bg_color = self.md_bg_color
+        else:
+            self._md_bg_color = App.get_running_app().theme_cls._get_primary_color()
 
 
 class MDToolbar(NotchedBox):


### PR DESCRIPTION
Fix for specific background behavior.

This fix ensures that the background layer is drawn before the active 
content of the widget..

### Description of the problem
At some point during development, the background color layer was moved from the bottom layer to the middle layer, where most widgets with texture draw their data, since this behavior is stackable, it will be drawn after the previous behavior, in the case of the MDLabel, the background layer is drawn over the text texture layer.

### Reproducing the problem

```python
from kivy.lang.builder import Builder
from kivymd.app import MDApp


kv="""
FloatLayout:
    MDLabel:
        halign: "center"
        valign: "center"
        md_bg_color: (1,0,0,0.5)
        size: 120,64
        size_hint: None,None
        pos_hint: {"center": [0.5, 0.5]}
        text: "this is visible text"
        text_size: self.size
"""

class app(MDApp):
    def build(self, *dt):
        return Builder.load_string(kv)

app().run()
```

### Screenshots of the problem
![image](https://user-images.githubusercontent.com/5509325/135308877-5e69a92b-7212-424d-8166-ad217cb33d3d.png)
here, we can se that the background color is drawn over the text layer, which means that the text will be hidden behind the texture if the alpha channel is 1.

### Description of Changes
changed the layer where the background color is drawn, moved from canvas to canvas,before.
Describe what changes you create to solve the problem.

### Screenshots of the solution to the problem
![image](https://user-images.githubusercontent.com/5509325/135309319-cb6f8847-42c0-4f44-8f9d-da76246d060e.png)
in this image, we set the alpha channel of the md_bg_color to 1 instead of the 0.5 that is on the example code.

Attach screenshots that demonstrate that your changes solved the problem.
