### PR TITLE
Corrected import for screen

### DIFF
--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -479,7 +479,7 @@ class ThemeManager(EventDispatcher):
     .. code-block:: python
 
         from kivymd.app import MDApp
-        from kivymd.screen import MDScreen
+        from kivymd.uix.screen import MDScreen
         from kivymd.uix.button import MDRectangleFlatButton
 
 


### PR DESCRIPTION
Existing import statement results in `ModuleNotFoundError: No module named 'kivymd.screen'`

### Description of the problem

Incorrect import statement

### Reproducing the problem

```python
from kivymd.screen import MDScreen
```

### Description of Changes

Changed import statement to

```python
from kivymd.uix.screen import MDScreen
```
