### PR TITLE
Change MDSwitch to use Accent color when ON.

### DIFF
--- a/kivymd/uix/selectioncontrol/selectioncontrol.py
+++ b/kivymd/uix/selectioncontrol/selectioncontrol.py
@@ -451,22 +451,22 @@ class MDSwitch(ThemableBehavior, ButtonBehavior, FloatLayout):
     and property is readonly.
     """
 
-    theme_thumb_color = OptionProperty("Primary", options=["Primary", "Custom"])
+    theme_thumb_color = OptionProperty("Accent", options=["Accent", "Custom"])
     """
     Thumb color scheme name
 
     :attr:`theme_thumb_color` is an :class:`~kivy.properties.OptionProperty`
-    and defaults to `Primary`.
+    and defaults to `Accent`.
     """
 
     theme_thumb_down_color = OptionProperty(
-        "Primary", options=["Primary", "Custom"]
+        "Accent", options=["Accent", "Custom"]
     )
     """
     Thumb Down color scheme name
 
     :attr:`theme_thumb_down_color` is an :class:`~kivy.properties.OptionProperty`
-    and defaults to `Primary`.
+    and defaults to `Accent`.
     """
 
     _track_color_active = ColorProperty([0, 0, 0, 0])
@@ -478,8 +478,8 @@ class MDSwitch(ThemableBehavior, ButtonBehavior, FloatLayout):
         super().__init__(**kwargs)
         self.theme_cls.bind(
             theme_style=self._set_colors,
-            primary_color=self._set_colors,
-            primary_palette=self._set_colors,
+            accent_color=self._set_colors,
+            accent_palette=self._set_colors,
         )
         self.bind(active=self._update_thumb_pos)
         Clock.schedule_once(self._set_colors)
@@ -490,8 +490,8 @@ class MDSwitch(ThemableBehavior, ButtonBehavior, FloatLayout):
         self._track_color_normal = self.theme_cls.disabled_hint_text_color
         if self.theme_cls.theme_style == "Dark":
 
-            if self.theme_thumb_down_color == "Primary":
-                self._track_color_active = self.theme_cls.primary_color
+            if self.theme_thumb_down_color == "Accent":
+                self._track_color_active = self.theme_cls.accent_color
             else:
                 self._track_color_active = self.thumb_color_down
 
@@ -499,17 +499,17 @@ class MDSwitch(ThemableBehavior, ButtonBehavior, FloatLayout):
             self._track_color_disabled = get_color_from_hex("FFFFFF")
             self._track_color_disabled[3] = 0.1
 
-            if self.theme_thumb_color == "Primary":
+            if self.theme_thumb_color == "Accent":
                 self.thumb_color = get_color_from_hex(colors["Gray"]["400"])
 
-            if self.theme_thumb_down_color == "Primary":
+            if self.theme_thumb_down_color == "Accent":
                 self.thumb_color_down = get_color_from_hex(
-                    colors[self.theme_cls.primary_palette]["200"]
+                    colors[self.theme_cls.accent_palette]["200"]
                 )
         else:
-            if self.theme_thumb_down_color == "Primary":
+            if self.theme_thumb_down_color == "Accent":
                 self._track_color_active = get_color_from_hex(
-                    colors[self.theme_cls.primary_palette]["200"]
+                    colors[self.theme_cls.accent_palette]["200"]
                 )
             else:
                 self._track_color_active = self.thumb_color_down
@@ -517,10 +517,10 @@ class MDSwitch(ThemableBehavior, ButtonBehavior, FloatLayout):
             self._track_color_active[3] = 0.5
             self._track_color_disabled = self.theme_cls.disabled_hint_text_color
 
-            if self.theme_thumb_down_color == "Primary":
-                self.thumb_color_down = self.theme_cls.primary_color
+            if self.theme_thumb_down_color == "Accent":
+                self.thumb_color_down = self.theme_cls.accent_color
 
-            if self.theme_thumb_color == "Primary":
+            if self.theme_thumb_color == "Accent":
                 self.thumb_color = get_color_from_hex(colors["Gray"]["50"])
 
     def _update_thumb_pos(self, *args, animation=True):


### PR DESCRIPTION
Resolves #1101 

### Description of the Bug

MDSwitch uses the primary color of the theme when switched on.  Typically, color themes use a muted color for the primary color, and a brighter color for the accent color.

Using the Primary color for ON has the effect of making it difficult to see the color contrast between OFF and ON.

Example: with BlueGrey primary color / Cyan accent color

OFF:
![image](https://user-images.githubusercontent.com/3267533/137265480-ade5ae21-7a47-4e87-906d-e4c56d654423.png)

ON:
![image](https://user-images.githubusercontent.com/3267533/137265515-62e7c98f-696d-40a8-9a04-9d2f4460eb71.png)

Proposed change: Change the "ON" color to use the accent color.  This has much higher contrast for typical color schemes.

OFF:
![image](https://user-images.githubusercontent.com/3267533/137265661-80a20558-904f-45e3-8ae7-8678354de69b.png)

ON:
![image](https://user-images.githubusercontent.com/3267533/137265692-8b332d94-3e44-4d6b-a7b8-232c2b37e581.png)

### Code and Logs

```
import kivy
from kivy.lang import Builder
from kivymd.app import MDApp


class TestApp(MDApp):
    
    def build(self):
        self.theme_cls.theme_style = "Dark" #light
        self.theme_cls.primary_palette = "BlueGray"
        self.theme_cls.accent_palette = "Cyan"
        return Builder.load_string("""
AnchorLayout:
    MDSwitch:
        size_hint: (None, None)
        size: (40,40)        
""")


TestApp().run()
```




### Versions

* OS:  Linux
* Python: 3.8.9
* Kivy: 2.0.0
* KivyMD: master
