### PR TITLE
Update pickers.py

### DIFF
--- a/demos/kitchen_sink/libs/baseclass/pickers.py
+++ b/demos/kitchen_sink/libs/baseclass/pickers.py
@@ -1,4 +1,4 @@
-from kivymd.uix.pickers import MDDatePicker, MDTimePicker
+from kivymd.uix.picker import MDDatePicker, MDTimePicker
 from kivymd.uix.screen import MDScreen
 
 


### PR DESCRIPTION
### Description of the problem

`from kivymd.uix.pickers import MDDatePicker, MDTimePicker` cause error message:
```
 ModuleNotFoundError: No module named 'kivymd.uix.pickers'

```

### Reproducing the problem

```python
cd KivyMD/demos/kitchen_sink/
python main.py
## Then click "Pickers" will crash the app. 
```
![image](https://user-images.githubusercontent.com/20909751/140594196-47065757-23df-47f5-97f4-4395da8cb99c.png)

### Screenshots of the problem

![image](https://user-images.githubusercontent.com/20909751/140594113-88d26c7a-3f52-40a3-ad76-b83cb5a2d81d.png)


### Description of Changes

Change `from kivymd.uix.pickers import MDDatePicker, MDTimePicker` to `from kivymd.uix.picker import MDDatePicker, MDTimePicker`

### Screenshots of the solution to the problem
Now after clicking "Pickers", it works. 
![image](https://user-images.githubusercontent.com/20909751/140594215-9f723125-e044-4410-bbe9-042bbf2837da.png)

