### PR TITLE
Fix MDBottomNavigation to change color.

### DIFF
--- a/kivymd/uix/bottomnavigation/bottomnavigation.py
+++ b/kivymd/uix/bottomnavigation/bottomnavigation.py
@@ -272,11 +272,10 @@ class MDBottomNavigationHeader(
         self.panel = panel
         self.tab = tab
         super().__init__()
-        # Change text_color if it is not default [1.1.1.1]
         self._text_color_normal = (
             self.theme_cls.disabled_hint_text_color
-            if MDColorHolder.on_normal_color == None
-            else MDColorHolder.on_normal_color
+            if self.text_color_normal == [1, 1, 1, 1]
+            else self.text_color_normal
         )
         self._label = self.ids._label
         self._label_font_size = sp(12)
@@ -296,8 +295,8 @@ class MDBottomNavigationHeader(
             ).start(self)
         Animation(
             _text_color_normal=self.theme_cls.primary_color
-            if MDColorHolder.on_active_color == None
-            else MDColorHolder.on_active_color,
+            if self.text_color_active == [1, 1, 1, 1]
+            else self.text_color_active,
             d=0.1,
         ).start(self)
 
@@ -551,6 +550,8 @@ class MDBottomNavigation(TabbedPanelBase):
     :attr:`tab_header` is an :class:`~MDBottomNavigationHeader`
     and defaults to `None`.
     """
+    # Text active color if it is selected.
+    _active_color = ColorProperty([1, 1, 1, 1])
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -584,21 +585,21 @@ class MDBottomNavigation(TabbedPanelBase):
 
     def refresh_tabs(self, *args) -> NoReturn:
         """Refresh all tabs."""
-        # Use primary_color if default color used otherwise use on_active_color.
-        color_active = self.theme_cls.primary_color
-        if MDColorHolder.on_active_color != None:
-            color_active = MDColorHolder.on_active_color
+
         if self.ids:
             tab_bar = self.ids.tab_bar
             tab_bar.clear_widgets()
             tab_manager = self.ids.tab_manager
+            self._active_color = self.theme_cls.primary_color
+            if self.text_color_active != [1, 1, 1, 1]:
+                self._active_color = self.text_color_active
             for tab in tab_manager.screens:
                 self.tab_header = MDBottomNavigationHeader(tab=tab, panel=self)
                 tab.header = self.tab_header
                 tab_bar.add_widget(self.tab_header)
                 if tab is self.first_widget:
                     self.tab_header._text_color_normal = (
-                        color_active
+                        self._active_color
                     )
                     self.tab_header._label_font_size = sp(14)
                     self.tab_header.active = True
@@ -639,17 +640,16 @@ class MDBottomNavigation(TabbedPanelBase):
     def on_text_color_normal(
         self, instance_bottom_navigation, color: list
     ) -> NoReturn:
-        # Getting text_normal_color and store value in MCColorHolder class.
-        MDColorHolder.on_normal_color = color
+        MDBottomNavigationHeader.text_color_normal = (color)
         for tab in self.ids.tab_bar.children:
             if not tab.active:
                 tab._text_color_normal = color
-
+        
     def on_text_color_active(
         self, instance_bottom_navigation, color: list
     ) -> NoReturn:
-        # Getting text_active_color and store value in MCColorHolder class.
-        MDColorHolder.on_active_color = color
+        MDBottomNavigationHeader.text_color_active = (color)
+        self.text_color_active = (color)
         for tab in self.ids.tab_bar.children:
             tab.text_color_active = color
             if tab.active:
@@ -714,8 +714,3 @@ class MDBottomNavigationBar(
     MDFloatLayout,
 ):
     pass
-
-#  Store active color and normal color and use it for text color and icon color.
-class MDColorHolder:
-    on_normal_color = None
-    on_active_color = None

--- a/kivymd/uix/bottomnavigation/bottomnavigation.py
+++ b/kivymd/uix/bottomnavigation/bottomnavigation.py
@@ -272,10 +272,11 @@ class MDBottomNavigationHeader(
         self.panel = panel
         self.tab = tab
         super().__init__()
+        # Change text_color if it is not default [1.1.1.1]
         self._text_color_normal = (
             self.theme_cls.disabled_hint_text_color
-            if self.text_color_normal == [1, 1, 1, 1]
-            else self.text_color_normal
+            if MDColorHolder.on_normal_color == None
+            else MDColorHolder.on_normal_color
         )
         self._label = self.ids._label
         self._label_font_size = sp(12)
@@ -295,8 +296,8 @@ class MDBottomNavigationHeader(
             ).start(self)
         Animation(
             _text_color_normal=self.theme_cls.primary_color
-            if self.text_color_active == [1, 1, 1, 1]
-            else self.text_color_active,
+            if MDColorHolder.on_active_color == None
+            else MDColorHolder.on_active_color,
             d=0.1,
         ).start(self)
 
@@ -583,7 +584,10 @@ class MDBottomNavigation(TabbedPanelBase):
 
     def refresh_tabs(self, *args) -> NoReturn:
         """Refresh all tabs."""
-
+        # Use primary_color if default color used otherwise use on_active_color.
+        color_active = self.theme_cls.primary_color
+        if MDColorHolder.on_active_color != None:
+            color_active = MDColorHolder.on_active_color
         if self.ids:
             tab_bar = self.ids.tab_bar
             tab_bar.clear_widgets()
@@ -594,7 +598,7 @@ class MDBottomNavigation(TabbedPanelBase):
                 tab_bar.add_widget(self.tab_header)
                 if tab is self.first_widget:
                     self.tab_header._text_color_normal = (
-                        self.theme_cls.primary_color
+                        color_active
                     )
                     self.tab_header._label_font_size = sp(14)
                     self.tab_header.active = True
@@ -635,6 +639,8 @@ class MDBottomNavigation(TabbedPanelBase):
     def on_text_color_normal(
         self, instance_bottom_navigation, color: list
     ) -> NoReturn:
+        # Getting text_normal_color and store value in MCColorHolder class.
+        MDColorHolder.on_normal_color = color
         for tab in self.ids.tab_bar.children:
             if not tab.active:
                 tab._text_color_normal = color
@@ -642,6 +648,8 @@ class MDBottomNavigation(TabbedPanelBase):
     def on_text_color_active(
         self, instance_bottom_navigation, color: list
     ) -> NoReturn:
+        # Getting text_active_color and store value in MCColorHolder class.
+        MDColorHolder.on_active_color = color
         for tab in self.ids.tab_bar.children:
             tab.text_color_active = color
             if tab.active:
@@ -706,3 +714,8 @@ class MDBottomNavigationBar(
     MDFloatLayout,
 ):
     pass
+
+#  Store active color and normal color and use it for text color and icon color.
+class MDColorHolder:
+    on_normal_color = None
+    on_active_color = None


### PR DESCRIPTION
Fix #1111  No effects when using  text_color_active and text_color_normal. It is suppose to change text and icon color.

When app starts left first icon remained default color even given color value and behaved incorrectly. 

### Reproducing the problem

        from kivy.uix.boxlayout import BoxLayout
        from kivy.uix.screenmanager import Screen
        from kivymd.app import MDApp
        from kivymd.uix.bottomnavigation import MDBottomNavigation, MDBottomNavigationItem
        
        
        class Test(MDApp):
            def build(self):
                return Screen()
        
            def on_start(self):
                nav = MDBottomNavigation()
                self.root.add_widget(nav)
                child_1 = MDBottomNavigationItem(name='compare screen', icon='swap-vertical-bold')
                content_1 = BoxLayout()
                child_1.add_widget(content_1)
        
                child_2 = MDBottomNavigationItem(name='rank screen', icon='google-analytics')
                content_2 = BoxLayout()
                child_2.add_widget(content_2)
        
                child_3 = MDBottomNavigationItem(name='profile screen', icon='account-circle')
                content_3 = BoxLayout()
                child_3.add_widget(content_3)
                nav.text_color_active = 0, 1, 0, 1 # this was not working correctly.
                nav.text_color_normal = 0, 0, 1, 1 # this has not given any effect.
        
                nav.add_widget(child_1)
                nav.add_widget(child_2)
                nav.add_widget(child_3)
        
        
        Test().run()
    

### Screenshots of the problem


![before pic1](https://user-images.githubusercontent.com/74240451/142073706-d5aca369-91b3-4049-9705-46b7b0133fe2.png)

![before pic2](https://user-images.githubusercontent.com/74240451/142073764-d64cad2e-fe1e-408b-9917-74f6f5385276.png)

### Description of Changes

Resolved issue by passing color values to objects (Widgets) when deployed.

### Screenshots of the solution to the problem
![after fix](https://user-images.githubusercontent.com/74240451/142074671-8c6391cd-2067-4177-8c0a-82d794782610.png)

