### PR TITLE
Fix `TypeError: 'int' object is not iterable` in `MDSlider`

### DIFF
--- a/kivymd/uix/slider/slider.py
+++ b/kivymd/uix/slider/slider.py
@@ -128,12 +128,12 @@ class MDSlider(ThemableBehavior, Slider):
     and defaults to `None`.
     """
 
-    hint_radius = NumericProperty(4)
+    hint_radius = ListProperty([dp(4), dp(4), dp(4), dp(4)])
     """
     Hint radius.
 
-    :attr:`hint_radius` is an :class:`~kivy.properties.NumericProperty`
-    and defaults to `4`.
+    :attr:`hint_radius` is an :class:`~kivy.properties.ListProperty`
+    and defaults to `[dp(4), dp(4), dp(4), dp(4)]`.
     """
 
     show_off = BooleanProperty(True)


### PR DESCRIPTION
Fixed a bug
```py
from kivy.lang import Builder

from kivymd.app import MDApp

KV = '''
MDScreen

    MDSlider:
        min: 0
        max: 100
        value: 40
'''


class Test(MDApp):
    def build(self):
        return Builder.load_string(KV)


Test().run()
```