### PR TITLE
Fixed MDDropdownmenu position

### DIFF
--- a/kivymd/uix/menu/menu.py
+++ b/kivymd/uix/menu/menu.py
@@ -798,7 +798,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
         if self._move_menu and self.position == "auto":
             self.on_shift()
 
-    # Shift effect for MDDropdownMenu when window resizing only in 'default' and 'auto' position.
+    # Shift effect for MDDropdownMenu when Window resizing only in 'default' and 'auto' position.
     def on_shift(self):
 
         if self._ver_growth == "down" and self._hor_growth == "left":

--- a/kivymd/uix/menu/menu.py
+++ b/kivymd/uix/menu/menu.py
@@ -468,6 +468,7 @@ from typing import NoReturn, Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
+from kivy.core import window
 from kivy.core.window import Window
 from kivy.core.window.window_sdl2 import WindowSDL
 from kivy.lang import Builder
@@ -643,6 +644,10 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
     _start_coords = []
     _calculate_complete = False
     _calculate_process = False
+    _move_menu = False
+    _ver_growth = None
+    _hor_growth = None
+    _header_cls = False
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -652,6 +657,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
         self.register_event_type("on_dismiss")
         self.menu = self.ids.md_menu
         self.target_height = 0
+        self.h_cls = 0
 
     def check_position_caller(
         self, instance_window: WindowSDL, width: int, height: int
@@ -667,11 +673,10 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
 
         if self.caller:
             self.ids.md_menu.data = self.items
+
             # We need to pick a starting point, see how big we need to be,
             # and where to grow to.
-            self._start_coords = self.caller.to_window(
-                self.caller.center_x, self.caller.center_y
-            )
+            self.coordinates(0, 0)
             self.target_width = self.width_mult * m_res.STANDARD_INCREMENT
 
             # If we're wider than the Window...
@@ -681,12 +686,21 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
                     int(Window.width / m_res.STANDARD_INCREMENT)
                     * m_res.STANDARD_INCREMENT
                 )
+            # When MenuHeader added to MDDropdownMenu we add 55 to the list
+            # target_height to get a correct target position otherwise carry on.
+            # Header_cls size on y axis. Dropping menu down minus header size.
+            if self._header_cls:
+                self.h_cls = dp(self.header_size)
+            else:
+                self.h_cls = 0
+                self._header_cls = False
+
+            self.target_height = 0 - dp(self.h_cls)
 
             # Set the target_height of the menu depending on the size of
             # each MDMenuItem or MDMenuItemIcon.
-            self.target_height = 0
             for item in self.ids.md_menu.data:
-                self.target_height += item.get("height", dp(72))
+                self.target_height += item.get("height", dp(48))
 
             # If we're over max_height...
             if 0 < self.max_height < self.target_height:
@@ -698,13 +712,13 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
             else:
                 # If there's enough space below us:
                 if (
-                    self.target_height
+                    self.target_height + dp(self.h_cls)
                     <= self._start_coords[1] - self.border_margin
                 ):
                     ver_growth = "down"
                 # if there's enough space above us:
                 elif (
-                    self.target_height
+                    self.target_height + dp(self.h_cls)
                     < Window.height - self._start_coords[1] - self.border_margin
                 ):
                     ver_growth = "up"
@@ -717,7 +731,9 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
                     ):
                         ver_growth = "down"
                         self.target_height = (
-                            self._start_coords[1] - self.border_margin
+                            self._start_coords[1]
+                            - self.border_margin
+                            - dp(self.h_cls)
                         )
                     # If there's more space above us:
                     else:
@@ -764,7 +780,9 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
                         )
 
             if ver_growth == "down":
-                self.tar_y = self._start_coords[1] - self.target_height
+                self.tar_y = (
+                    self._start_coords[1] - self.target_height - dp(self.h_cls)
+                )
             else:  # should always be "up"
                 self.tar_y = self._start_coords[1]
 
@@ -772,7 +790,41 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
                 self.tar_x = self._start_coords[0]
             else:  # should always be "left"
                 self.tar_x = self._start_coords[0] - self.target_width
+
             self._calculate_complete = True
+            self._ver_growth = ver_growth
+            self._hor_growth = hor_growth
+
+        if self._move_menu and self.position == "auto":
+            self.on_shift()
+
+    # Shift effect for MDDropdownMenu when window resizing only in 'default' and 'auto' position.
+    def on_shift(self):
+
+        if self._ver_growth == "down" and self._hor_growth == "left":
+            self.menu.pos = self.coordinates(
+                self.target_width, self.target_height + dp(self.h_cls)
+            )
+
+        elif self._ver_growth == "up" and self._hor_growth == "right":
+            self.menu.pos = self.coordinates(0, 0)
+
+        elif self._ver_growth == "down" and self._hor_growth == "right":
+            self.menu.pos = self.coordinates(
+                0, self.target_height + dp(self.h_cls)
+            )
+        # Move top left.
+        else:
+            self.menu.pos = self.coordinates(self.target_width, 0)
+
+        self._calculate_process = False
+
+    # Window starting and follow up coordinates for repositioning DropdownMenu.
+    def coordinates(self, *args):
+        self._start_coords = self.caller.to_window(
+            self.caller.center_x - args[0], self.caller.center_y - args[1]
+        )
+        return self._start_coords
 
     def open(self) -> NoReturn:
         """Animate the opening of a menu window."""
@@ -819,11 +871,12 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
             Window.add_widget(self)
             Clock.unschedule(open)
             self._calculate_process = False
+            self._move_menu = True
 
-        self.set_menu_properties()
         if not self._calculate_process:
             self._calculate_process = True
             Clock.schedule_interval(open, 0)
+        self.set_menu_properties()
 
     def on_header_cls(
         self, instance_dropdown_menu, instance_user_menu_header
@@ -833,6 +886,8 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
             self.ids.content_header.add_widget(instance_user_menu_header)
 
         Clock.schedule_once(add_content_header_cls, 1)
+        self._header_cls = True
+        self.header_size = self.size[0] / 2
 
     def on_touch_down(self, touch):
         if not self.menu.collide_point(*touch.pos):


### PR DESCRIPTION
Fix #1108 Header Menu not working with MDToolbar bug.

### Description of the problem

Drop down menu takes the window y axis which is 0 but the action item is lower on y than that. Because of this issue left and right drop down menu ends up in different position in window. When  right_action_items called in MDToolBar the  dropdown menu position not same.

#Reproducing issue
 Left icon clicked drop down menu get correct pos but when right icon called drop down menu ends up in right up corner

Minimal code example that reproduces the problem:

          from kivy.lang import Builder
          from kivy.metrics import dp
          
          from kivymd.app import MDApp
          from kivymd.uix.menu import MDDropdownMenu
          from kivymd.uix.snackbar import Snackbar
          from kivymd.uix.boxlayout import MDBoxLayout
          
          KV = '''
          <MenuHeader>
              orientation: "vertical"
              adaptive_size: True
              padding: "4dp"
          
              MDBoxLayout:
                  spacing: "120dp"
                  adaptive_size: True
          
                  MDIconButton:
                      icon: "gesture-tap-button"
                      pos_hint: {"center_y": .5}
          
                  MDLabel:
                      text: "Actions"
                      adaptive_size: True
                      pos_hint: {"center_y": .5}
                      
          MDBoxLayout:
              orientation: "vertical"
          
              MDToolbar:
                  title: "MDToolbar"
                  left_action_items: [["menu", lambda x: app.callback(x)]]
                  right_action_items: [["dots-vertical", lambda x: app.callback(x)]]
          
              MDLabel:
                  text: "Content"
                  halign: "center"
              MDBottomAppBar:
          
                  MDToolbar:
                      title: "Title"
                      icon: "git"
                      type: "bottom"
                      left_action_items: [["menu", lambda x: app.callback(x)]]
                      right_action_items: [["dots-vertical", lambda x: app.callback(x)]]
          '''
          
          class MenuHeader(MDBoxLayout):
              '''An instance of the class that will be added to the menu header.'''
          
          class Test(MDApp):
              def __init__(self, **kwargs):
                  super().__init__(**kwargs)
                  self.screen = Builder.load_string(KV)
                  menu_items = [
                      {
                          "viewclass": "OneLineListItem",
                          "text": f"Item {i}",
                          "height": dp(56),
                          "on_release": lambda x=f"Item {i}": self.menu_callback(x),
                       } for i in range(5)
                  ]
                  self.menu = MDDropdownMenu(
                      header_cls=MenuHeader(),
                      items=menu_items,
                      width_mult=4,
                  )
                  
              def build(self):
                  return self.screen
          
              def callback(self, button):
                  self.menu.caller = button
                  self.menu.open()
          
              def menu_callback(self, text_item):
                  self.menu.dismiss()
                  Snackbar(text=text_item).open()
          
       Test().run()


Screenshots of the problem

![mdtoolpic](https://user-images.githubusercontent.com/74240451/139326755-a7083714-babb-48a7-9343-5edb000baf1e.png)
 
Describe what changes you create to solve the problem.

Took the window starting point and drop down the menu position from top - 50 also repositioned dropdown menu in window.
Position parameter only work in default (auto) any other position (center, top , bottom ) works as it was working before.
This includes  BottomAppBar.  Added shift effect to improve experience.

### Screenshots of the solution to the problem


https://user-images.githubusercontent.com/74240451/139330145-c7c4947a-934f-4cc6-aedd-4b8eae0fd394.mp4


