### PR TITLE
MDTextField line color code definitions for line mode: to update line…

### DIFF
--- a/kivymd/uix/textfield/textfield.kv
+++ b/kivymd/uix/textfield/textfield.kv
@@ -16,7 +16,7 @@
         # Static underline texture.
         Color:
             rgba:
-                (self.line_color_normal \
+                (self._line_color_normal \
                 if self.line_color_normal else self.theme_cls.divider_color) \
                 if self.mode == "line" else (0, 0, 0, 0)
         Line:
@@ -28,7 +28,7 @@
         # Active underline (on focus) texture.
         Color:
             rgba:
-                self.line_color_focus \
+                self._line_color_focus \
                 if self.mode in ("line", "fill") and self.active_line \
                 else (0, 0, 0, 0)
         Rectangle:

--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -965,8 +965,9 @@ class MDTextField(ThemableBehavior, TextInput):
     _max_length_text_color = ColorProperty([0, 0, 0, 0])
     _icon_right_color = ColorProperty([0, 0, 0, 0])
     _icon_left_color = ColorProperty([0, 0, 0, 0])
+    _line_color_normal = ColorProperty([0, 0, 0, 0])
+    _line_color_focus = ColorProperty([0, 0, 0, 0])
 
-    _cache_colors = DictProperty()
     # List of color attribute names that should be updated when changing the
     # application color palette.
     _colors_to_updated = ListProperty()
@@ -1051,8 +1052,8 @@ class MDTextField(ThemableBehavior, TextInput):
         elif self.helper_text_mode == "persistent":
             self._helper_text_color = self.helper_text_color_normal
 
-        self._cache_colors["line_color_normal"] = self.line_color_normal
-        self._cache_colors["line_color_focus"] = self.line_color_focus
+        self._line_color_normal = self.line_color_normal
+        self._line_color_focus = self.line_color_focus
 
     def set_notch_rectangle(self, joining: bool = False) -> NoReturn:
         """
@@ -1089,7 +1090,7 @@ class MDTextField(ThemableBehavior, TextInput):
         """Animates the color of a static underline line."""
 
         Animation(
-            line_color_normal=color,
+            _line_color_normal=color,
             duration=(0.2 if self.line_anim else 0),
             t="out_quad",
         ).start(self)
@@ -1097,7 +1098,7 @@ class MDTextField(ThemableBehavior, TextInput):
     def set_active_underline_color(self, color: list) -> NoReturn:
         """Animates the fill color for 'fill' mode."""
 
-        Animation(line_color_focus=color, duration=0.2, t="out_quad").start(
+        Animation(_line_color_focus=color, duration=0.2, t="out_quad").start(
             self
         )
 
@@ -1322,10 +1323,7 @@ class MDTextField(ThemableBehavior, TextInput):
             if self.error:
                 self.set_static_underline_color(self.error_color)
             else:
-                # print(self._cache_colors["line_color_normal"])
-                self.set_static_underline_color(
-                    self._cache_colors["line_color_normal"]
-                )
+                self.set_static_underline_color(self.line_color_normal)
 
     def on_icon_left(self, instance_text_field, icon_name: str) -> NoReturn:
         self._icon_left_label.icon = icon_name
@@ -1359,9 +1357,7 @@ class MDTextField(ThemableBehavior, TextInput):
                 self.set_helper_text_color(self.error_color)
         else:
             self.set_max_length_text_color(self.max_length_text_color)
-            self.set_active_underline_color(
-                self._cache_colors["line_color_focus"]
-            )
+            self.set_active_underline_color(self._line_color_focus)
             if self.hint_text:
                 self.set_hint_text_color(self.focus)
             if self.helper_text:
@@ -1400,6 +1396,9 @@ class MDTextField(ThemableBehavior, TextInput):
 
     def on_icon_right_color_normal(self, instance_text_field, color: list):
         self._icon_right_color = color
+
+    def on_line_color_normal(self, instance_text_field, color: list):
+        self._line_color_normal = color
 
     def on_max_length_text_color(self, instance_text_field, color: list):
         self._max_length_text_color = color


### PR DESCRIPTION
### Description of the problem

Proposition to simplify the update of the MDTextField ```line_color_normal``` attribute from python code (#1125).

### Description of Changes

In order not to write two [lines](https://github.com/kivymd/KivyMD/issues/1125#issuecomment-968279510) to update ```line_color_normal``` (with one line calling an hidden attribute: ```_cache_colors``` dictionnary), I first created the following function for the MDTextField class in textfield.py : 
```
    def on_line_color_normal(self, instance_text_field, color: list):
        self._cache_colors["line_color_normal"] = color
```
But this function is triggered when ```line_color_normal``` attribute is updated: entering the textfield, the ```on_focus``` method updates this attribute with the method ```set_static_underline_color([0, 0, 0, 0])``` (L1260) thus setting  ```self._cache_colors["line_color_normal"]``` equal to [0, 0, 0, 0], that leeds to the disappearance of the line when exiting the textfield.

In order to keep the ```line_color_normal``` attribute name, I replicate the method used for other color attributes (L961-L967) that use intern attribute with '_' prefix (e.g. ```_text_color_normal``` with ```text_color_normal```):
- ```self._cache_colors["line_color_normal"]``` is replaced by ```line_color_normal```
- ```line_color_normal``` is replaced by ```_line_color_normal```
Because I propose to delete ```self._cache_colors```, the same update is realized for ```line_color_focus``` attribute.
- ```self._cache_colors["line_color_focus"]``` is replaced by ```line_color_focus```
- ```line_color_focus``` is replaced by ```_line_color_focus```

### Note
In the kivy file, I did not replace ```self.line_color_normal``` by```self.line_color_normal``` (L20) because I did not understand the purpose of this condition.
(First PR ever, if it does not meet the PR guideline or something is badly done, feel free to critize)
