### PR TITLE
fix(buttons): Fix infinite loop for buttons with minimum width

### DIFF
--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -32,7 +32,7 @@
 
 <ButtonContentsText>
     lbl_txt: lbl_txt
-    width: lbl_txt.texture_size[0] + dp(24)
+    width: max(root._min_width, lbl_txt.texture_size[0] + dp(24))
     height: dp(20) + lbl_txt.texture_size[1]
 
     MDLabel:
@@ -74,7 +74,7 @@
 <ButtonContentsIconText>
     lbl_txt: lbl_txt
     lbl_ic: lbl_ic
-    width: lbl_txt.width + lbl_ic.width * 2 + box.spacing
+    width: max(root._min_width, lbl_txt.width + lbl_ic.width * 2 + box.spacing)
     height: lbl_ic.texture_size[1] + dp(12)
 
     MDBoxLayout:

--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -33,6 +33,7 @@
 <ButtonContentsText>
     lbl_txt: lbl_txt
     width: max(root._min_width, lbl_txt.texture_size[0] + dp(24))
+    size_hint_min_x: max(root._min_width, lbl_txt.texture_size[0] + dp(24))
     height: dp(20) + lbl_txt.texture_size[1]
 
     MDLabel:
@@ -75,6 +76,7 @@
     lbl_txt: lbl_txt
     lbl_ic: lbl_ic
     width: max(root._min_width, lbl_txt.width + lbl_ic.width * 2 + box.spacing)
+    size_hint_min_x: max(root._min_width, lbl_txt.texture_size[0] + dp(24))
     height: lbl_ic.texture_size[1] + dp(12)
 
     MDBoxLayout:

--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -699,13 +699,6 @@ class BaseButton(
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # To prevent infinite loop for partially-initialized button width
-        # between AnchorLayout and on_width, set size_hint_min_x to match
-        # (at least) _min_width.
-        if self._min_width:
-            self.size_hint_min_x = max(
-                self._min_width, self.size_hint_min_x or 0
-            )
         self.theme_cls.bind(
             primary_palette=self.set_button_colors,
             theme_style=self.set_button_colors,
@@ -787,14 +780,6 @@ class BaseButton(
         else:
             default_text_color = self.theme_cls.text_color
         self._text_color = self.text_color or default_text_color
-
-    def on_width(self, instance_button, width: float) -> NoReturn:
-        """
-        If the button style has a minimum width set, enforce it here.
-        """
-
-        if self._min_width and (self.width < self._min_width):
-            self.width = self._min_width
 
     # Touch events that cause transparent buttons to fade to background
     def on_touch_down(self, touch):
@@ -931,7 +916,7 @@ class ButtonContentsIcon(ButtonIconMixin):
     Contents for a round BaseButton consisting of an MDIcon.
     """
 
-    _min_width = None
+    _min_width = 0
 
     def on_text_color(self, instance_button, color: list) -> NoReturn:
         """
@@ -1167,7 +1152,7 @@ class MDIconButton(ButtonContentsIcon, BaseButton):
     and defaults to `None` (set by button class).
     """
 
-    _min_width = None
+    _min_width = 0
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -699,6 +699,13 @@ class BaseButton(
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        # To prevent infinite loop for partially-initialized button width
+        # between AnchorLayout and on_width, set size_hint_min_x to match
+        # (at least) _min_width.
+        if self._min_width:
+            self.size_hint_min_x = max(
+                self._min_width, self.size_hint_min_x or 0
+            )
         self.theme_cls.bind(
             primary_palette=self.set_button_colors,
             theme_style=self.set_button_colors,


### PR DESCRIPTION
### Description of the problem

As described in #1116 , creating a button that:
- has a minimum width set (any rectangular button),
- has a non-zero size_hint_x,
- is created in a BoxLayout with a non-zero padding, and
- is on a Screen that is not yet displayed,
causes an immediate infinite loop.

The on_width of BaseButton sets the width to 88. However, AnchorLayout then sets this width to a different value; this may also trigger updates in BoxLayout and/or the width binding in ButtonContentsText (Kivy language). The set width (for a button on a screen that has not yet been shown) is less than 88, triggering on_width again hence the infinite loop.

### Reproducing the problem

Adapted from #1116

```python
from kivy.lang import Builder
from kivymd.app import MDApp
from kivymd.uix.screen import MDScreen


class ScreenA(MDScreen):
    pass


class ScreenB(MDScreen):
    pass


KV = """
<ScreenA>:

<ScreenB>:
    BoxLayout:
        padding: 10
        MDFlatButton:
            size_hint_x: 1.0

Screen:
    ScreenManager:
        ScreenA:
            name: "ScreenA"
        ScreenB:
            name: "ScreenB"
"""


class MyMDApp(MDApp):
    def build(self):
        return Builder.load_string(KV)


if __name__ == "__main__":
    MyMDApp().run()
```

### Screenshots of the problem

![image](https://user-images.githubusercontent.com/4930097/145989488-ae3e6d20-b6e9-40bb-8693-b5bfac96ddc5.png)

### Description of Changes

In BaseButton __init__(), check if _min_width is set. If it is, then set size_hint_min_x to the larger of _min_width and size_hint_min_x (if set). This will normally just set size_hint_min_x to _min_width, but in the event a user sets size_hint_min_x to a larger value then this will be preserved.

The layout code in AnchorLayout now keeps the size of the button above _min_width, preventing the infinite loop.