### PR TITLE
fix(buttons): Icon buttons color initialization from Python broken

### DIFF
--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -55,7 +55,7 @@
     lbl_ic: lbl_ic
     size: "48dp", "48dp"
     padding: "12dp" if root.icon in md_icons else (0, 0, 0, 0)
-    theme_icon_color: root.theme_text_color  # backwards compatibility
+    theme_icon_color: root.theme_icon_color or root.theme_text_color  # backwards compatibility
 
     MDIcon:
         id: lbl_ic


### PR DESCRIPTION
The theme_icon_color property, which should be used instead of theme_text_color for setting the color of an icon in the MDIconButton, MDFloatingActionButton and other button classes, leads to a crash on initialization when set from
Python for MDIconButton and MDFloatingActionButton.

### Description of the problem

For the ButtonContentsIcon class, which is used in the MDIconButton and MDFloatingActionButton classes, there was the line:
```
theme_icon_color: root.theme_text_color  # backwards compatibility
```
This was to allow backwards compatibility, as previously MDIconButton and MDFloatingActionButton theme style was selected using theme_text_color. For consistency with the rectangular buttons with both icons and text, the property theme_icon_color was created for these icons as well. This line was added so that setting theme_text_color would, in turn, set theme_icon_color. Note that, by default, both theme_icon_color and theme_text_color on the *button* are initialized to None (not the theme_text_color property on the label itself, which is initialized as normal to 'Primary').

This works when setting theme_text_color and text_color through Kivy or Python, and it also works when setting theme_icon_color through Kivy. However, due to an oversight on my part, setting theme_icon_color when initializing a button through Python triggers the above Kivy rule, which tries to override the value of theme_icon_color set with the value of theme_text_color, which is None. This is not permitted (setting None) leading to a crash.

### Reproducing the problem

```python
from kivy.lang import Builder
from kivymd.app import MDApp
from kivymd.uix.button import MDIconButton, MDFloatingActionButton


KV = """
BoxLayout:
"""


class Test(MDApp):
    def build(self):
        return Builder.load_string(KV)

    def on_start(self):
        # Works
        self.root.add_widget(
            MDIconButton()
        )
        # Works
        self.root.add_widget(
            MDIconButton(
                theme_text_color='Custom',
                text_color=[1.0, 0.0, 1.0, 1.0]
            )
        )
        # Broken
        self.root.add_widget(
            MDIconButton(
                theme_icon_color='Custom',
                icon_color=[1.0, 0.0, 1.0, 1.0]
            )
        )
        # Works
        self.root.add_widget(
            MDFloatingActionButton(
                theme_text_color='Custom',
                text_color=[1.0, 0.0, 1.0, 1.0]
            )
        )
        # Broken
        self.root.add_widget(
            MDFloatingActionButton(
                theme_icon_color='Custom',
                icon_color=[1.0, 0.0, 1.0, 1.0]
            )
        )


Test().run()
```

### Screenshots of the problem

![image](https://user-images.githubusercontent.com/4930097/146358842-3596ae72-06cc-42d6-a8d2-c821a63f7cef.png)

### Description of Changes

The fix is to change the Kivy rule to:
```
theme_icon_color: root.theme_icon_color or root.theme_text_color  # backwards compatibility
```
This means that setting theme_icon_color will _not_ result in it being overridden by theme_text_color (unless theme_icon_color is Falsy, which is not permitted anyway). This prevents the crash on initialization.
If, however, theme_text_color is set while theme_icon_color is not set, theme_icon_color will be set to theme_text_color, preserving the backwards-compatible behaviour originally desired.
