### PR TITLE
Fixed scrolling issue of header and made scrolling easier

### DIFF
--- a/kivymd/uix/datatables/datatables.kv
+++ b/kivymd/uix/datatables/datatables.kv
@@ -100,7 +100,7 @@
 
 <TableHeader>
     bar_width: 0
-    do_scroll: False
+    do_scroll: True
     size_hint: 1, None
     height: header.height
 

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -701,12 +701,14 @@ class TableData(RecycleView):
 
     def on_mouse_select(self, instance_cell_row) -> NoReturn:
         """Called on the ``on_enter`` event of the :class:`~CellRow` class."""
-
+        """
         if not self.pagination_menu_open:
             if self.ids.row_controller.selected_row != instance_cell_row.index:
                 self.ids.row_controller.selected_row = instance_cell_row.index
                 self.ids.row_controller.select_current(self)
-
+        """
+        pass
+    
     def on_rows_num(self, instance_table_date, value_rows_num: int) -> NoReturn:
         if not self._to_value:
             self._to_value = value_rows_num

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -1444,17 +1444,20 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
             rows_num=self.rows_num,
             _parent=self,
         )
+        self.table_data.bar_width = 3
+        self.table_data.scroll_type = ['bars', 'content']
         self.register_event_type("on_row_press")
         self.register_event_type("on_check_press")
         self.pagination = TablePagination(table_data=self.table_data)
         self.table_data.pagination = self.pagination
         self.header.table_data = self.table_data
-        self.table_data.fbind("scroll_x", self._scroll_with_header)
+        #self.table_data.fbind("scroll_x", self._scroll_with_header)
         self.ids.container.add_widget(self.header)
         self.ids.container.add_widget(self.table_data)
         if self.use_pagination:
             self.ids.container.add_widget(self.pagination)
         Clock.schedule_once(self.create_pagination_menu, 0.5)
+        Clock.schedule_interval(lambda dt: self.update_header_scroll_x(), 0.01) # update scroll bar of header
         self.bind(row_data=self.update_row_data)
 
     def update_row_data(self, instance_data_table, data: list) -> NoReturn:
@@ -1482,6 +1485,9 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
         self.table_data.set_next_row_data_parts("")
         self.pagination.ids.button_back.disabled = True
         Clock.schedule_once(self.create_pagination_menu, 0.5)
+
+    def update_header_scroll_x(self):
+        self.header.scroll_x = self.table_data.scroll_x
 
     def add_row(self, data: Union[list, tuple]) -> NoReturn:
         """

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -488,7 +488,7 @@ class TableData(RecycleView):
         self.cols_minimum = table_header.cols_minimum
         self.set_row_data()
         self.effect_cls = self._parent.effect_cls
-        Clock.schedule_once(self.set_default_first_row, 0)
+        #Clock.schedule_once(self.set_default_first_row, 0)
 
     def get_select_row(self, index: int) -> NoReturn:
         """Returns the current row with all elements."""


### PR DESCRIPTION
### Description of the problem

1. Scrolling was happening only when content is dragged and not when the scroll bar is dragged.
2. Header of the table was not scrolling

### Reproducing the problem

```python
# Minimal code example that reproduces the problem:
```

### Screenshots of the problem

Attach screenshots that demonstrate the problem.

### Description of Changes
1. Changed option to scroll when both content or scroll bar is dragged.
2. Added a function to update scroll value of header along with table rows

Describe what changes you create to solve the problem.

### Screenshots of the solution to the problem

Attach screenshots that demonstrate that your changes solved the problem.
