### PR TITLE
Solving hint_animation on MDFloatingActionButtonSpeedDial

### DIFF
--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -1684,13 +1684,11 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
                                 _padding_right=0,
                                 d=self.opening_time,
                                 t=self.opening_transition,
+                                _elevation=0
                             ).start(instance_button)
-                            if self.hint_animation:
-                                Animation(
-                                    opacity=0, d=0.1, t=self.opening_transition
-                                ).start(widget)
-                            break
-                    break
+                            Animation(
+                                opacity=0, d=0.1, t=self.opening_transition
+                            ).start(widget)
 
     def on_enter(self, instance_button: MDFloatingBottomButton) -> NoReturn:
         """Called when the mouse cursor is over a button from the stack."""
@@ -1699,6 +1697,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
             for widget in self.children:
                 if isinstance(widget, MDFloatingLabel) and self.hint_animation:
                     widget._elevation = 0
+                    Animation.cancel_all(widget)
                     for item in self.data.items():
                         if widget.text in item:
                             Animation(
@@ -1707,14 +1706,16 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
                                 d=self.opening_time,
                                 t=self.opening_transition,
                             ).start(instance_button)
-                            if self.hint_animation:
+                            if instance_button.icon == self.data[f"{widget.text}"]:
                                 Animation(
                                     opacity=1,
                                     d=self.opening_time,
-                                    t=self.opening_transition,
+                                    t=self.opening_transition
                                 ).start(widget)
-                            break
-                    break
+                            else:
+                                Animation(
+                                    opacity=0, d=0.1, t=self.opening_transition
+                                ).start(widget)
 
     def on_data(self, instance_speed_dial, data: dict) -> NoReturn:
         """Creates a stack of buttons."""


### PR DESCRIPTION
Solving the hint animation of MDFloatingActionButtonSpeedDial to correctly show each label and its text.

### Description of the problem

When hint_animation = True, only the first button's text displays when cursor rolls over any of the other icons. I thought it was a problem with a part of my program. So, I used the example code in the kivymd button section and had the same problem.

### Reproducing the problem

```python
# Minimal code example that reproduces the problem:
```

### Screenshots of the problem

![20220107_161340](https://user-images.githubusercontent.com/93722960/148566693-7a316f23-743a-46b8-b89c-afc661f0fb38.gif)

### Description of Changes

Removing the breaks from the For Loops to avoid having all the labels at the same place and added a validation to match the icon of the stack button to its label and display the animation for both if hint_animation is True.

### Screenshots of the solution to the problem

![20220107_161517](https://user-images.githubusercontent.com/93722960/148567179-6be3e05b-6cfc-45f2-a92a-33a28606a4b1.gif)

