### PR TITLE
Fixed `line_color_focus` in `on_error` function `MDTextField` class

### DIFF
--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -1357,7 +1357,7 @@ class MDTextField(ThemableBehavior, TextInput):
                 self.set_helper_text_color(self.error_color)
         else:
             self.set_max_length_text_color(self.max_length_text_color)
-            self.set_active_underline_color(self._line_color_focus)
+            self.set_active_underline_color(self.line_color_focus)
             if self.hint_text:
                 self.set_hint_text_color(self.focus)
             if self.helper_text:


### PR DESCRIPTION
Fixed a bug where the line color did not change
```py
from kivy.lang import Builder

from kivymd.app import MDApp

KV = '''
BoxLayout:
    padding: "10dp"

    MDTextField:
        id: text_field_error
        hint_text: "Helper text on error (press 'Enter')"
        helper_text: "There will always be a mistake"
        helper_text_mode: "on_error"
        pos_hint: {"center_y": .5}
'''


class Test(MDApp):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.screen = Builder.load_string(KV)

    def build(self):
        self.screen.ids.text_field_error.bind(
            on_text_validate=self.set_error_message,
            on_focus=self.set_error_message,
        )
        return self.screen

    def set_error_message(self, instance_textfield):
        self.screen.ids.text_field_error.error = True


Test().run()
```

https://user-images.githubusercontent.com/40869738/153424587-a0690c15-1639-42c4-bd5a-b8e1d7969560.mp4


