### PR TITLE
Added `reset_focus_on_text_empty` to `MDTextField` class

### DIFF
--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -926,6 +926,14 @@ class MDTextField(ThemableBehavior, TextInput):
     and defaults to `'Roboto'`.
     """
 
+    reset_focus_on_text_empty = BooleanProperty(False)
+    """
+    Is the text field unfocused if there are no characters in it.
+
+    :attr:`reset_focus_on_text_empty` is an :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
+
     # The x-axis position of the hint text in the text field.
     _hint_x = NumericProperty(0)
     # The y-axis position of the hint text in the text field.
@@ -1219,8 +1227,9 @@ class MDTextField(ThemableBehavior, TextInput):
                 self.set_notch_rectangle()
 
         if not self.text:
-            self.on_focus(instance_text_field, False)
-            self.focus = False
+            if self.reset_focus_on_text_empty:
+                self.on_focus(instance_text_field, False)
+                self.focus = False
 
     def set_objects_labels(self) -> NoReturn:
         """
@@ -1357,7 +1366,7 @@ class MDTextField(ThemableBehavior, TextInput):
                 self.set_helper_text_color(self.error_color)
         else:
             self.set_max_length_text_color(self.max_length_text_color)
-            self.set_active_underline_color(self._line_color_focus)
+            self.set_active_underline_color(self.line_color_focus)
             if self.hint_text:
                 self.set_hint_text_color(self.focus)
             if self.helper_text:


### PR DESCRIPTION
A new argument `reset_focus_on_text_empty` has been added to give the user more flexibility to control the text field. In most cases, if the user erases the text, then he does not want the text field to be defocused (for example, he enters a password and made a mistake, therefore he presses the backspace, and the field is defocused because of this, which he does not want)

```py
from kivy.lang import Builder

from kivymd.app import MDApp


KV = '''
BoxLayout:
    padding: "10dp"

    MDTextField:
        id: text_field_error
        reset_focus_on_text_empty: False
        hint_text: f'Reset focus on text empty: {self.reset_focus_on_text_empty}'
        pos_hint: {"center_y": .5}
'''


class Test(MDApp):
    def build(self):
        return Builder.load_string(KV)

Test().run()

https://user-images.githubusercontent.com/40869738/153708341-f4d2461a-cb1e-4a01-873e-8d00f44d574e.mp4


```
