### PR TITLE
Wrong use of return type "NoReturn"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ temp
 .pytest_cache
 .coverage
 .DS_Store
+.dccache
 
 /kivymd/tools/release/*.zip
 /kivymd/tools/release/temp

--- a/kivymd/app.py
+++ b/kivymd/app.py
@@ -41,7 +41,6 @@ the current ``FPS`` value in your application:
 __all__ = ("MDApp",)
 
 import os
-from typing import NoReturn
 
 from kivy.app import App
 from kivy.lang import Builder
@@ -53,7 +52,7 @@ from kivymd.theming import ThemeManager
 class FpsMonitoring:
     """Implements a monitor to display the current FPS in the toolbar."""
 
-    def fps_monitor_start(self) -> NoReturn:
+    def fps_monitor_start(self) -> None:
         """Adds a monitor to the main application window."""
 
         from kivy.core.window import Window
@@ -100,7 +99,7 @@ class MDApp(App, FpsMonitoring):
         super().__init__(**kwargs)
         self.theme_cls = ThemeManager()
 
-    def load_all_kv_files(self, path_to_directory: str) -> NoReturn:
+    def load_all_kv_files(self, path_to_directory: str) -> None:
         """
         Recursively loads KV files from the selected directory.
 

--- a/kivymd/effects/fadingedge/fadingedge.py
+++ b/kivymd/effects/fadingedge/fadingedge.py
@@ -51,7 +51,7 @@ The `FadingEdgeEffect` class implements a fade effect for `KivyMD` widgets:
     parent widget.
 """
 
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.clock import Clock
 from kivy.graphics.context_instructions import Color
@@ -111,7 +111,7 @@ class FadingEdgeEffect(ThemableBehavior):
 
     # TODO: Perhaps it would be better if we used a Shader for the fade effect.
     #  But, I think the canvas instructions shouldn't affect performance
-    def set_fade(self, interval: Union[int, float]) -> NoReturn:
+    def set_fade(self, interval: Union[int, float]) -> None:
         """Draws a bottom and top fade border on the canvas."""
 
         fade_color = (
@@ -172,7 +172,7 @@ class FadingEdgeEffect(ThemableBehavior):
         rectangle_top: Rectangle,
         rectangle_bottom: Rectangle,
         index: int,
-    ) -> NoReturn:
+    ) -> None:
         """
         Updates the position and size of the fade border on the canvas.
         Called when the application screen is resized.

--- a/kivymd/tests/pyinstaller/test_pyinstaller_packaging.py
+++ b/kivymd/tests/pyinstaller/test_pyinstaller_packaging.py
@@ -6,12 +6,12 @@ PyInstaller must package KivyMD apps correctly.
 """
 
 import subprocess
-from typing import NoReturn
+
 
 from PyInstaller import __main__ as pyi_main
 
 
-def test_datas(tmp_path) -> NoReturn:
+def test_datas(tmp_path) -> None:
     """Test fonts and images."""
 
     app_name = "userapp"
@@ -54,7 +54,7 @@ assert "rec_shadow.atlas" in images
     subprocess.run([str(distpath / app_name / app_name)], check=True)
 
 
-def test_widgets(tmp_path) -> NoReturn:
+def test_widgets(tmp_path) -> None:
     """Test that all widgets are accesible."""
 
     app_name = "userapp"

--- a/kivymd/tests/pyinstaller/test_pyinstaller_packaging.py
+++ b/kivymd/tests/pyinstaller/test_pyinstaller_packaging.py
@@ -7,7 +7,6 @@ PyInstaller must package KivyMD apps correctly.
 
 import subprocess
 
-
 from PyInstaller import __main__ as pyi_main
 
 

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -169,7 +169,6 @@ respects, the theming stays as documented.
     dictionary ``colors``.
 """
 
-from typing import NoReturn
 
 from kivy.app import App
 from kivy.atlas import Atlas
@@ -907,7 +906,7 @@ class ThemeManager(EventDispatcher):
     def _get_ripple_color(self) -> list:
         return self._ripple_color
 
-    def _set_ripple_color(self, value) -> NoReturn:
+    def _set_ripple_color(self, value) -> None:
         self._ripple_color = value
 
     _ripple_color = ColorProperty(get_color_from_hex(colors["Gray"]["400"]))
@@ -924,7 +923,7 @@ class ThemeManager(EventDispatcher):
     property is readonly.
     """
 
-    def _determine_device_orientation(self, _, window_size) -> NoReturn:
+    def _determine_device_orientation(self, _, window_size) -> None:
         if window_size[0] > window_size[1]:
             self.device_orientation = "landscape"
         elif window_size[1] >= window_size[0]:
@@ -972,7 +971,7 @@ class ThemeManager(EventDispatcher):
     property is readonly.
     """
 
-    def on_theme_style(self, interval: int, theme_style: str) -> NoReturn:
+    def on_theme_style(self, interval: int, theme_style: str) -> None:
         if (
             hasattr(App.get_running_app(), "theme_cls")
             and App.get_running_app().theme_cls == self
@@ -1063,7 +1062,7 @@ class ThemeManager(EventDispatcher):
         accent_hue: str,
         accent_light_hue: str,
         accent_dark_hue: str,
-    ) -> NoReturn:
+    ) -> None:
         """
         Courtesy method to allow all of the theme color attributes to be set in one call.
 
@@ -1128,7 +1127,7 @@ class ThemeManager(EventDispatcher):
         self.colors = colors
         Clock.schedule_once(self.sync_theme_styles)
 
-    def sync_theme_styles(self, *args) -> NoReturn:
+    def sync_theme_styles(self, *args) -> None:
         # Syncs the values from self.font_styles to theme_font_styles
         # this will ensure continuity when someone registers a new font_style.
         for num, style in enumerate(theme_font_styles):

--- a/kivymd/toast/kivytoast/kivytoast.py
+++ b/kivymd/toast/kivytoast/kivytoast.py
@@ -38,7 +38,7 @@ KivyToast
     Test().run()
 """
 
-from typing import List, NoReturn
+from typing import List, None
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -88,7 +88,7 @@ class Toast(BaseDialog):
 
     def label_check_texture_size(
         self, instance_label: Label, texture_size: List[int]
-    ) -> NoReturn:
+    ) -> None:
         """
         Resizes the text if the text texture is larger than the screen size.
         Sets the size of the toast according to the texture size of the toast
@@ -102,26 +102,26 @@ class Toast(BaseDialog):
             texture_width, texture_height = instance_label.texture_size
         self.size = (texture_width + 25, texture_height + 25)
 
-    def toast(self, text_toast: str) -> NoReturn:
+    def toast(self, text_toast: str) -> None:
         """Displays a toast."""
 
         self.label_toast.text = text_toast
         self.open()
 
-    def on_open(self) -> NoReturn:
+    def on_open(self) -> None:
         """Default open event handler."""
 
         self.fade_in()
         Clock.schedule_once(self.fade_out, self.duration)
 
-    def fade_in(self) -> NoReturn:
+    def fade_in(self) -> None:
         """Animation of opening toast on the screen."""
 
         anim = Animation(opacity=1, duration=0.4)
         anim.start(self.label_toast)
         anim.start(self)
 
-    def fade_out(self, *args) -> NoReturn:
+    def fade_out(self, *args) -> None:
         """Animation of hiding toast on the screen."""
 
         anim = Animation(opacity=0, duration=0.4)
@@ -140,7 +140,7 @@ class Toast(BaseDialog):
 
 def toast(
     text: str = "", background: list = None, duration: float = 2.5
-) -> NoReturn:
+) -> None:
     """
     Displays a toast.
 

--- a/kivymd/toast/kivytoast/kivytoast.py
+++ b/kivymd/toast/kivytoast/kivytoast.py
@@ -38,7 +38,7 @@ KivyToast
     Test().run()
 """
 
-from typing import List, None
+from typing import List
 
 from kivy.animation import Animation
 from kivy.clock import Clock

--- a/kivymd/tools/hotreload/app.py
+++ b/kivymd/tools/hotreload/app.py
@@ -224,7 +224,7 @@ class MDApp(BaseApp):
         that the application is built. Act according to it.
         """
 
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def unload_app_dependencies(self):
         """
@@ -488,7 +488,7 @@ class MDApp(BaseApp):
         try:
             mod = sys.modules[self.__class__.__module__]
             mod_filename = realpath(mod.__file__)
-        except Exception as e:
+        except Exception:
             mod_filename = None
 
         # Detect if it's the application class // main.

--- a/kivymd/tools/patterns/create_project.py
+++ b/kivymd/tools/patterns/create_project.py
@@ -466,7 +466,7 @@ def main():
             ) as requirements:
                 requirements.write("watchdog")
         if use_localization == "yes":
-            Logger.info(f"KivyMD: Create localization files...")
+            Logger.info("KivyMD: Create localization files...")
             create_makefile(
                 path_to_project, project_name, module_name, name_screen
             )

--- a/kivymd/tools/patterns/create_project.py
+++ b/kivymd/tools/patterns/create_project.py
@@ -104,7 +104,7 @@ Optional arguments
 import os
 import re
 import shutil
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy import Logger, platform
 
@@ -179,7 +179,7 @@ class {name_screen}Model(BaseScreenModel):
     :class:`~View.{module_name}.{name_screen}.{name_screen}View` class.
     """'''
 
-_firebase_controller = '''from typing import NoReturn
+_firebase_controller = '''
 {import_module}
 
 
@@ -197,22 +197,22 @@ class {name_screen}Controller:
             controller=self, model=self.model
         )
 
-    def set_user_data(self, key, value) -> NoReturn:
+    def set_user_data(self, key, value) -> None:
         """Called every time the user enters text into the text fields."""
 
         self.model.set_user_data(key, value)
 
-    def on_tap_button_login(self) -> NoReturn:
+    def on_tap_button_login(self) -> None:
         """Called when the `LOGIN` button is pressed."""
 
         self.view.show_dialog_wait()
         self.model.chek_data()
 
-    def reset_data_validation_status(self, *args) -> NoReturn:
+    def reset_data_validation_status(self, *args) -> None:
         self.model.reset_data_validation_status()
 '''
 
-_without_firebase_controller = '''from typing import NoReturn
+_without_firebase_controller = '''
 {import_module}
 
 
@@ -228,14 +228,14 @@ class {name_screen}Controller:
         self.model = model  # Model.{module_name}.{name_screen}Model
         self.view = {name_view}(controller=self, model=self.model)
 
-    def on_tap_button_login(self) -> NoReturn:
+    def on_tap_button_login(self) -> None:
         """Called when the `LOGIN` button is pressed."""
 
-    def set_user_data(self, key, value) -> NoReturn:
+    def set_user_data(self, key, value) -> None:
         """Called every time the user enters text into the text fields."""
 '''
 
-_firebase_view_import = """from typing import Union, NoReturn
+_firebase_view_import = """from typing import Union, None
 
 from kivy.clock import Clock
 
@@ -243,7 +243,7 @@ from kivymd.uix.dialog import MDDialog
 from kivymd.uix.snackbar import Snackbar
 """
 
-_without_firebase_view_import = """from typing import NoReturn
+_without_firebase_view_import = """
 """
 
 _firebase_view_methods = '''    def __init__(self, **kwargs):
@@ -251,14 +251,14 @@ _firebase_view_methods = '''    def __init__(self, **kwargs):
         self.dialog = MDDialog()
         self.dialog.bind(on_dismiss=self.controller.reset_data_validation_status)
 
-    def show_dialog_wait(self) -> NoReturn:
+    def show_dialog_wait(self) -> None:
         """Displays a wait dialog while the model is processing data."""
 
         self.dialog.auto_dismiss = False
         self.dialog.text = "Data validation..."
         self.dialog.open()
 
-    def show_toast(self, interval: Union[int, float]) -> NoReturn:
+    def show_toast(self, interval: Union[int, float]) -> None:
         Snackbar(
             text="You have passed the verification successfully!",
             snackbar_x="10dp",
@@ -305,7 +305,7 @@ DEBUG=1 python main.py
 
 import importlib
 import os
-from typing import NoReturn
+
 
 from kivy import Config
 from kivy.uix.screenmanager import ScreenManager
@@ -362,7 +362,7 @@ class %s(MDApp):
 
         return self.manager_screens
 
-    def on_keyboard_down(self, window, keyboard, keycode, text, modifiers) -> NoReturn:
+    def on_keyboard_down(self, window, keyboard, keycode, text, modifiers) -> None:
         """
         The method handles keyboard events.
 
@@ -496,7 +496,7 @@ def create_main_with_hotreload(
     module_name: str,
     use_firebase: str,
     use_localization: str,
-) -> NoReturn:
+) -> None:
     with open(
         os.path.join(path_to_project, "main.py"), encoding="utf-8"
     ) as main_file:
@@ -531,11 +531,11 @@ def create_main_with_hotreload(
             if use_localization == "yes"
             else "",
             "self.base" if use_firebase == "yes" else "",
-            "\n\n    def on_lang(self, instance_app, lang_value: str) -> NoReturn:\n"
+            "\n\n    def on_lang(self, instance_app, lang_value: str) -> None:\n"
             "        self.translation.switch_lang(lang_value)\n"
             if use_localization == "yes"
             else "",
-            "\n    def switch_lang(self) -> NoReturn:\n"
+            "\n    def switch_lang(self) -> None:\n"
             '        """Switch lang."""\n\n'
             '        self.lang = "ru" if self.lang == "en" else "en"'
             if use_localization == "yes"
@@ -550,7 +550,7 @@ def create_main(
     use_localization: str,
     path_to_project: str,
     project_name: str,
-) -> NoReturn:
+) -> None:
     replace_in_file(
         os.path.join(path_to_project, "main.py_tmp"),
         (
@@ -572,11 +572,11 @@ def create_main(
             else "",
             "self.base = Base()\n" if use_firebase == "yes" else "",
             "self.base" if use_firebase == "yes" else "",
-            "\n    def on_lang(self, instance_app, lang_value: str) -> NoReturn:\n"
+            "\n    def on_lang(self, instance_app, lang_value: str) -> None:\n"
             "        self.translation.switch_lang(lang_value)\n"
             if use_localization == "yes"
             else "",
-            "\n    def switch_lang(self) -> NoReturn:\n"
+            "\n    def switch_lang(self) -> None:\n"
             '        """Switch lang."""\n\n'
             '        self.lang = "ru" if self.lang == "en" else "en"\n'
             if use_localization == "yes"
@@ -588,7 +588,7 @@ def create_main(
 
 def create_model(
     use_firebase: str, name_screen: str, module_name: str, path_to_project: str
-) -> NoReturn:
+) -> None:
     if use_firebase == "yes":
         firebase_model = _firebase_model.format(
             name_screen=name_screen, module_name=module_name
@@ -618,7 +618,7 @@ def create_controller(
     name_screen: str,
     module_name: str,
     path_to_project: str,
-) -> NoReturn:
+) -> None:
     if use_firebase == "yes":
         firebase_controller = _firebase_controller
     else:
@@ -658,7 +658,7 @@ def create_view(
     name_screen: str,
     module_name: str,
     path_to_project: str,
-) -> NoReturn:
+) -> None:
     replace_in_file(
         os.path.join(path_to_project, "View", "screens.py_tmp"),
         (
@@ -741,7 +741,7 @@ def create_view(
     )
 
 
-def create_requirements(use_firebase: str, path_to_project: str) -> NoReturn:
+def create_requirements(use_firebase: str, path_to_project: str) -> None:
     with open(
         os.path.join(path_to_project, "requirements.txt"), "w", encoding="utf-8"
     ) as requirements:
@@ -754,7 +754,7 @@ def create_requirements(use_firebase: str, path_to_project: str) -> NoReturn:
 
 def create_makefile(
     path_to_project: str, project_name: str, module_name: str, name_screen: str
-) -> NoReturn:
+) -> None:
     replace_in_file(
         os.path.join(path_to_project, "Makefile"),
         (
@@ -770,21 +770,21 @@ def create_makefile(
     os.system("make po")
 
 
-def create_mofile(path_to_project: str) -> NoReturn:
+def create_mofile(path_to_project: str) -> None:
     os.chdir(path_to_project)
     os.system("make mo")
 
 
 def create_virtual_environment(
     python_version: str, path_to_project: str
-) -> NoReturn:
+) -> None:
     os.system(f"{python_version} -m pip install virtualenv")
     os.system(
         f"virtualenv -p {python_version} {os.path.join(path_to_project, 'venv')}"
     )
 
 
-def localization_po_file(path_to_project: str) -> NoReturn:
+def localization_po_file(path_to_project: str) -> None:
     path_to_file_po = os.path.join(
         path_to_project, "data", "locales", "po", "ru.po"
     )
@@ -812,7 +812,7 @@ def localization_po_file(path_to_project: str) -> NoReturn:
 
 def install_requirements(
     path_to_project: str, kivy_version: str, use_firebase: str
-) -> NoReturn:
+) -> None:
     python = os.path.join(path_to_project, "venv", "bin", "python3")
     if kivy_version == "master":
         if platform == "macosx":
@@ -848,7 +848,7 @@ def install_requirements(
     )
 
 
-def rename_ext_py_tmp_to_py(path_to_project: str) -> NoReturn:
+def rename_ext_py_tmp_to_py(path_to_project: str) -> None:
     for path_to_dir, dirs, files in os.walk(path_to_project):
         for name_file in files:
             if os.path.splitext(name_file)[1] == ".py_tmp":
@@ -860,7 +860,7 @@ def rename_ext_py_tmp_to_py(path_to_project: str) -> NoReturn:
                 )
 
 
-def move_init(path_to_project: str, name_screen: str) -> NoReturn:
+def move_init(path_to_project: str, name_screen: str) -> None:
     path_to_init_file = __file__.replace("create_project", "__init__")
     for name_dir in ("Controller", "Model", "Utility", "View"):
         shutil.copy(
@@ -887,7 +887,7 @@ def chek_camel_case_name_project(name_project) -> Union[bool, list]:
     return result
 
 
-def replace_in_file(path_to_file: str, args) -> NoReturn:
+def replace_in_file(path_to_file: str, args) -> None:
     with open(path_to_file, "rt", encoding="utf-8") as file_content:
         new_file_content = file_content.read() % (args)
         with open(path_to_file, "wt", encoding="utf-8") as original_file:

--- a/kivymd/tools/patterns/create_project.py
+++ b/kivymd/tools/patterns/create_project.py
@@ -235,7 +235,7 @@ class {name_screen}Controller:
         """Called every time the user enters text into the text fields."""
 '''
 
-_firebase_view_import = """from typing import Union, None
+_firebase_view_import = """from typing import Union
 
 from kivy.clock import Clock
 

--- a/kivymd/tools/patterns/create_project.py
+++ b/kivymd/tools/patterns/create_project.py
@@ -306,7 +306,6 @@ DEBUG=1 python main.py
 import importlib
 import os
 
-
 from kivy import Config
 from kivy.uix.screenmanager import ScreenManager
 

--- a/kivymd/uix/__init__.py
+++ b/kivymd/uix/__init__.py
@@ -1,6 +1,5 @@
 __all__ = ("MDAdaptiveWidget",)
 
-from typing import NoReturn
 
 from kivy.properties import BooleanProperty
 from kivy.uix.floatlayout import FloatLayout
@@ -50,7 +49,7 @@ class MDAdaptiveWidget(SpecificBackgroundColorBehavior):
     and defaults to `False`.
     """
 
-    def on_adaptive_height(self, md_widget, value: bool) -> NoReturn:
+    def on_adaptive_height(self, md_widget, value: bool) -> None:
         self.size_hint_y = None
         if issubclass(self.__class__, Label):
             self.bind(
@@ -62,7 +61,7 @@ class MDAdaptiveWidget(SpecificBackgroundColorBehavior):
             if not isinstance(self, (FloatLayout, Screen)):
                 self.bind(minimum_height=self.setter("height"))
 
-    def on_adaptive_width(self, md_widget, value: bool) -> NoReturn:
+    def on_adaptive_width(self, md_widget, value: bool) -> None:
         self.size_hint_x = None
         if issubclass(self.__class__, Label):
             self.bind(
@@ -74,7 +73,7 @@ class MDAdaptiveWidget(SpecificBackgroundColorBehavior):
             if not isinstance(self, (FloatLayout, Screen)):
                 self.bind(minimum_width=self.setter("width"))
 
-    def on_adaptive_size(self, md_widget, value: bool) -> NoReturn:
+    def on_adaptive_size(self, md_widget, value: bool) -> None:
         self.size_hint = (None, None)
         if issubclass(self.__class__, Label):
             self.text_size = (None, None)

--- a/kivymd/uix/__init__.py
+++ b/kivymd/uix/__init__.py
@@ -1,6 +1,5 @@
 __all__ = ("MDAdaptiveWidget",)
 
-
 from kivy.properties import BooleanProperty
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.label import Label

--- a/kivymd/uix/backdrop/backdrop.py
+++ b/kivymd/uix/backdrop/backdrop.py
@@ -122,7 +122,7 @@ __all__ = (
 )
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -306,24 +306,24 @@ class MDBackdrop(ThemableBehavior, MDFloatLayout):
             lambda x: self.on_left_action_items(self, self.left_action_items)
         )
 
-    def on_open(self) -> NoReturn:
+    def on_open(self) -> None:
         """When the front layer drops."""
 
-    def on_close(self) -> NoReturn:
+    def on_close(self) -> None:
         """When the front layer rises."""
 
-    def on_left_action_items(self, instance_backdrop, menu: list) -> NoReturn:
+    def on_left_action_items(self, instance_backdrop, menu: list) -> None:
         if menu:
             self.left_action_items = [menu[0]]
         else:
             self.left_action_items = [["menu", lambda x: self.open()]]
         self._open_icon = self.left_action_items[0][0]
 
-    def on_header(self, instance_backdrop, value: bool) -> NoReturn:
+    def on_header(self, instance_backdrop, value: bool) -> None:
         if not value:
             self.ids._front_layer.remove_widget(self.ids.header_button)
 
-    def open(self, open_up_to: int = 0) -> NoReturn:
+    def open(self, open_up_to: int = 0) -> None:
         """
         Opens the front layer.
 
@@ -355,7 +355,7 @@ class MDBackdrop(ThemableBehavior, MDFloatLayout):
         self._front_layer_open = True
         self.dispatch("on_open")
 
-    def close(self) -> NoReturn:
+    def close(self) -> None:
         """Opens the front layer."""
 
         Animation(y=0, d=self.closing_time, t=self.closing_transition).start(
@@ -369,7 +369,7 @@ class MDBackdrop(ThemableBehavior, MDFloatLayout):
         instance_icon_menu: Union[MDActionTopAppBarButton, None] = None,
         opacity_value: int = 0,
         call_set_new_icon: bool = True,
-    ) -> NoReturn:
+    ) -> None:
         """Starts the opacity animation of the icon."""
 
         if not instance_icon_menu:
@@ -387,7 +387,7 @@ class MDBackdrop(ThemableBehavior, MDFloatLayout):
         self,
         instance_animation: Animation,
         instance_icon_menu: MDActionTopAppBarButton,
-    ) -> NoReturn:
+    ) -> None:
         """
         Sets the icon of the button depending on the state of the backdrop.
         """

--- a/kivymd/uix/banner/banner.py
+++ b/kivymd/uix/banner/banner.py
@@ -140,7 +140,7 @@ add the prefix `'-icon'` to the banner type:
 __all__ = ("MDBanner",)
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -296,7 +296,7 @@ class MDBanner(MDCard, FakeRectangularElevationBehavior):
 
     def add_actions_buttons(
         self, instance_box: MDBoxLayout, data: list
-    ) -> NoReturn:
+    ) -> None:
         """
         Adds buttons to the banner.
 
@@ -314,7 +314,7 @@ class MDBanner(MDCard, FakeRectangularElevationBehavior):
             action_button.markup = True
             instance_box.add_widget(action_button)
 
-    def show(self) -> NoReturn:
+    def show(self) -> None:
         """Displays a banner on the screen."""
 
         def show(interval: Union[int, float]):
@@ -332,7 +332,7 @@ class MDBanner(MDCard, FakeRectangularElevationBehavior):
                 self.hide()
             Clock.schedule_once(show, self.opening_timeout)
 
-    def hide(self) -> NoReturn:
+    def hide(self) -> None:
         """Hides the banner from the screen."""
 
         def hide(interval: Union[int, float]):
@@ -347,7 +347,7 @@ class MDBanner(MDCard, FakeRectangularElevationBehavior):
             self._progress = True
             Clock.schedule_once(hide, 0.5)
 
-    def set_type_banner(self) -> NoReturn:
+    def set_type_banner(self) -> None:
         self._type_message = {
             "three-line-icon": ThreeLineIconBanner,
             "two-line-icon": TwoLineIconBanner,
@@ -357,7 +357,7 @@ class MDBanner(MDCard, FakeRectangularElevationBehavior):
             "one-line": OneLineBanner,
         }[self.type]
 
-    def animation_display_banner(self, interval: Union[int, float]) -> NoReturn:
+    def animation_display_banner(self, interval: Union[int, float]) -> None:
         Animation(
             banner_y=self.height + self.vertical_pad,
             d=self.opening_time,
@@ -380,7 +380,7 @@ class MDBanner(MDCard, FakeRectangularElevationBehavior):
     def _reset_progress(self, *args):
         self._progress = False
 
-    def _add_banner_to_container(self) -> NoReturn:
+    def _add_banner_to_container(self) -> None:
         self.ids.container_message.add_widget(
             self._type_message(text_message=self.text, icon=self.icon)
         )

--- a/kivymd/uix/behaviors/backgroundcolor_behavior.py
+++ b/kivymd/uix/behaviors/backgroundcolor_behavior.py
@@ -7,7 +7,7 @@ Behaviors/Background Color
 
 __all__ = ("BackgroundColorBehavior", "SpecificBackgroundColorBehavior")
 
-from typing import List, None
+from typing import List
 
 from kivy.lang import Builder
 from kivy.properties import (

--- a/kivymd/uix/behaviors/backgroundcolor_behavior.py
+++ b/kivymd/uix/behaviors/backgroundcolor_behavior.py
@@ -7,7 +7,7 @@ Behaviors/Background Color
 
 __all__ = ("BackgroundColorBehavior", "SpecificBackgroundColorBehavior")
 
-from typing import List, NoReturn
+from typing import List, None
 
 from kivy.lang import Builder
 from kivy.properties import (
@@ -194,7 +194,7 @@ class BackgroundColorBehavior(CommonElevationBehavior):
 
     def update_background_origin(
         self, instance_md_widget, pos: List[float]
-    ) -> NoReturn:
+    ) -> None:
         if self.background_origin:
             self._background_origin = self.background_origin
         else:
@@ -246,7 +246,7 @@ class SpecificBackgroundColorBehavior(BackgroundColorBehavior):
 
     def _update_specific_text_color(
         self, instance_theme_manager: ThemeManager, theme_style: str
-    ) -> NoReturn:
+    ) -> None:
         if hasattr(self, "theme_cls"):
             palette = {
                 "Primary": self.theme_cls.primary_palette,

--- a/kivymd/uix/behaviors/magic_behavior.py
+++ b/kivymd/uix/behaviors/magic_behavior.py
@@ -86,7 +86,6 @@ Example:
 
 __all__ = ("MagicBehavior",)
 
-from typing import NoReturn
 
 from kivy.animation import Animation
 from kivy.lang import Builder
@@ -129,7 +128,7 @@ class MagicBehavior:
     and defaults to `1`.
     """
 
-    def grow(self) -> NoReturn:
+    def grow(self) -> None:
         """Grow effect animation."""
 
         (
@@ -144,7 +143,7 @@ class MagicBehavior:
             )
         ).start(self)
 
-    def shake(self) -> NoReturn:
+    def shake(self) -> None:
         """Shake effect animation."""
 
         (
@@ -154,7 +153,7 @@ class MagicBehavior:
             )
         ).start(self)
 
-    def wobble(self) -> NoReturn:
+    def wobble(self) -> None:
         """Wobble effect animation."""
 
         (
@@ -172,7 +171,7 @@ class MagicBehavior:
             )
         ).start(self)
 
-    def twist(self) -> NoReturn:
+    def twist(self) -> None:
         """Twist effect animation."""
 
         (
@@ -180,7 +179,7 @@ class MagicBehavior:
             + Animation(rotate=0, t="out_elastic", d=0.5 / self.magic_speed)
         ).start(self)
 
-    def shrink(self) -> NoReturn:
+    def shrink(self) -> None:
         """Shrink effect animation."""
 
         Animation(

--- a/kivymd/uix/behaviors/magic_behavior.py
+++ b/kivymd/uix/behaviors/magic_behavior.py
@@ -86,7 +86,6 @@ Example:
 
 __all__ = ("MagicBehavior",)
 
-
 from kivy.animation import Animation
 from kivy.lang import Builder
 from kivy.properties import NumericProperty

--- a/kivymd/uix/bottomnavigation/bottomnavigation.py
+++ b/kivymd/uix/bottomnavigation/bottomnavigation.py
@@ -164,7 +164,7 @@ __all__ = (
 )
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -282,7 +282,7 @@ class MDBottomNavigationHeader(
         self.theme_cls.bind(disabled_hint_text_color=self._update_theme_style)
         self.active = False
 
-    def on_press(self) -> NoReturn:
+    def on_press(self) -> None:
         """Called when clicking on a panel item."""
 
         if self.theme_cls.material_style == "M2":
@@ -397,7 +397,7 @@ class MDBottomNavigationItem(MDTab):
     and defaults to `None`.
     """
 
-    def on_tab_press(self, *args) -> NoReturn:
+    def on_tab_press(self, *args) -> None:
         """Called when clicking on a panel item."""
 
         bottom_navigation_object = self.parent_widget
@@ -563,10 +563,10 @@ class MDBottomNavigation(TabbedPanelBase):
         Clock.schedule_once(lambda x: self.on_resize())
         Clock.schedule_once(self.set_status_bar_color)
 
-    def set_status_bar_color(self, interval: Union[int, float]) -> NoReturn:
+    def set_status_bar_color(self, interval: Union[int, float]) -> None:
         set_bars_colors(self.panel_color, None, self.theme_cls.theme_style)
 
-    def switch_tab(self, name_tab) -> NoReturn:
+    def switch_tab(self, name_tab) -> None:
         """Switching the tab by name."""
 
         if not self.ids.tab_manager.has_screen(name_tab):
@@ -583,7 +583,7 @@ class MDBottomNavigation(TabbedPanelBase):
             numbers_screens.index(count_index_screen)
         ].dispatch("on_press")
 
-    def refresh_tabs(self, *args) -> NoReturn:
+    def refresh_tabs(self, *args) -> None:
         """Refresh all tabs."""
 
         if self.ids:
@@ -607,13 +607,13 @@ class MDBottomNavigation(TabbedPanelBase):
 
     def on_selected_color_background(
         self, instance_bottom_navigation, color: list
-    ) -> NoReturn:
+    ) -> None:
         for tab in self.ids.tab_bar.children:
             tab.selected_color_background = color
 
     def on_use_text(
         self, instance_bottom_navigation, use_text_value: bool
-    ) -> NoReturn:
+    ) -> None:
         if not use_text_value:
             for instance_bottom_navigation_header in self.ids.tab_bar.children:
                 instance_bottom_navigation_header.ids.item_container.remove_widget(
@@ -637,7 +637,7 @@ class MDBottomNavigation(TabbedPanelBase):
 
     def on_text_color_normal(
         self, instance_bottom_navigation, color: list
-    ) -> NoReturn:
+    ) -> None:
         MDBottomNavigationHeader.text_color_normal = color
         for tab in self.ids.tab_bar.children:
             if not tab.active:
@@ -645,7 +645,7 @@ class MDBottomNavigation(TabbedPanelBase):
 
     def on_text_color_active(
         self, instance_bottom_navigation, color: list
-    ) -> NoReturn:
+    ) -> None:
         MDBottomNavigationHeader.text_color_active = color
         self.text_color_active = color
         for tab in self.ids.tab_bar.children:
@@ -653,12 +653,12 @@ class MDBottomNavigation(TabbedPanelBase):
             if tab.active:
                 tab._text_color_normal = color
 
-    def on_switch_tabs(self, bottom_navigation_item, name_tab: str) -> NoReturn:
+    def on_switch_tabs(self, bottom_navigation_item, name_tab: str) -> None:
         """
         Called when switching tabs. Returns the object of the tab to be opened.
         """
 
-    def on_size(self, *args) -> NoReturn:
+    def on_size(self, *args) -> None:
         self.on_resize()
 
     def on_resize(
@@ -666,7 +666,7 @@ class MDBottomNavigation(TabbedPanelBase):
         instance: Union[WindowSDL, None] = None,
         width: Union[int, None] = None,
         do_again: bool = True,
-    ) -> NoReturn:
+    ) -> None:
         """Called when the application window is resized."""
 
         full_width = 0

--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -481,7 +481,7 @@ __all__ = (
 )
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -809,14 +809,14 @@ class BaseButton(
         else:
             self._disabled_color = self._line_color
 
-    def set_all_colors(self, *args) -> NoReturn:
+    def set_all_colors(self, *args) -> None:
         """Set all button colours."""
 
         self.set_button_colors()
         self.set_text_color()
         self.set_icon_color()
 
-    def set_button_colors(self, *args) -> NoReturn:
+    def set_button_colors(self, *args) -> None:
         """Set all button colours (except text/icons)."""
 
         # Set main color
@@ -859,7 +859,7 @@ class BaseButton(
             or self.theme_cls.disabled_primary_color
         )
 
-    def set_text_color(self, *args) -> NoReturn:
+    def set_text_color(self, *args) -> None:
         """
         Set _theme_text_color and _text_color based on defaults and options.
         """
@@ -877,7 +877,7 @@ class BaseButton(
             default_text_color = self.theme_cls.text_color
         self._text_color = self.text_color or default_text_color
 
-    def set_icon_color(self, *args) -> NoReturn:
+    def set_icon_color(self, *args) -> None:
         """
         Set _theme_icon_color and _icon_color based on defaults and options.
         """
@@ -895,7 +895,7 @@ class BaseButton(
             default_icon_color = self.theme_cls.text_color
         self._icon_color = self.icon_color or default_icon_color
 
-    def set_radius(self, *args) -> NoReturn:
+    def set_radius(self, *args) -> None:
         """
         Set the radius, if we are a rounded button, based on the
         current height.
@@ -941,7 +941,7 @@ class BaseButton(
             Animation(duration=0.05, _md_bg_color=md_bg_color).start(self)
         return super().on_touch_up(touch)
 
-    def on_disabled(self, instance_button, disabled_value: bool) -> NoReturn:
+    def on_disabled(self, instance_button, disabled_value: bool) -> None:
         Clock.schedule_once(self.set_disabled_color)
 
 
@@ -968,18 +968,18 @@ class ButtonElevationBehaviour(CommonElevationBehavior):
         self.bind(_radius=self.setter("radius"))
         self.on_elevation(self, self.elevation)
 
-    def on_elevation(self, instance_button, elevation_value: int) -> NoReturn:
+    def on_elevation(self, instance_button, elevation_value: int) -> None:
         super().on_elevation(instance_button, elevation_value)
         self._elevation_raised = self.elevation + 6
         self.on_disabled(self, self.disabled)
 
     def on__elevation_raised(
         self, instance_button, elevation_value: int
-    ) -> NoReturn:
+    ) -> None:
         Animation.cancel_all(self, "_elevation")
         self._anim_raised = Animation(_elevation=self._elevation_raised, d=0.15)
 
-    def on_disabled(self, instance_button, disabled_value: bool) -> NoReturn:
+    def on_disabled(self, instance_button, disabled_value: bool) -> None:
         if self.disabled is True:
             Animation.cancel_all(self, "_elevation")
         super().on_disabled(instance_button, disabled_value)
@@ -1026,7 +1026,7 @@ class ButtonContentsIcon:
             self.icon_size = self.user_font_size
         self.bind(user_font_size=self.setter("icon_size"))
 
-    def on_text_color(self, instance_button, color: list) -> NoReturn:
+    def on_text_color(self, instance_button, color: list) -> None:
         """
         Set icon_color equal to text_color.
         For backwards compatibility - can use text_color instead
@@ -1066,7 +1066,7 @@ class OldButtonIconMixin:
 
     icon = StringProperty("android")
 
-    def on_icon_color(self, instance_button, color: list) -> NoReturn:
+    def on_icon_color(self, instance_button, color: list) -> None:
         """
         If we are setting an icon color, set theme_icon_color to Custom.
         For backwards compatibility (before theme_icon_color existed).
@@ -1268,7 +1268,7 @@ class MDIconButton(OldButtonIconMixin, ButtonContentsIcon, BaseButton):
         self.line_width = 0.001
         Clock.schedule_once(self.set_size)
 
-    def set_size(self, interval: Union[int, float]) -> NoReturn:
+    def set_size(self, interval: Union[int, float]) -> None:
         """
         Sets the custom icon size if the value of the `icon_size`
         attribute is not zero. Otherwise, the icon size is set to `(48, 48)`.
@@ -1321,14 +1321,14 @@ class MDFloatingActionButton(
         Clock.schedule_once(self.set__radius)
         Clock.schedule_once(self.set_font_size)
 
-    def set_font_size(self, *args) -> NoReturn:
+    def set_font_size(self, *args) -> None:
         if self.theme_cls.material_style == "M3":
             if self.type == "large":
                 self.icon_size = "36sp"
             else:
                 self.icon_size = 0
 
-    def set__radius(self, *args) -> NoReturn:
+    def set__radius(self, *args) -> None:
         if self.theme_cls.material_style == "M2":
             self.rounded_button = True
         else:
@@ -1340,7 +1340,7 @@ class MDFloatingActionButton(
             elif self.type == "large":
                 self._radius = dp(28)
 
-    def set_size(self, *args) -> NoReturn:
+    def set_size(self, *args) -> None:
         if self.theme_cls.material_style == "M2":
             self.size = dp(56), dp(56)
         else:
@@ -1351,9 +1351,7 @@ class MDFloatingActionButton(
             elif self.type == "large":
                 self.size = dp(96), dp(96)
 
-    def on_type(
-        self, instance_md_floating_action_button, type: str
-    ) -> NoReturn:
+    def on_type(self, instance_md_floating_action_button, type: str) -> None:
         self.set_size()
         self.set_font_size()
 
@@ -1377,7 +1375,7 @@ class MDTextButton(ButtonBehavior, MDLabel):
 
     _color = ColorProperty(None)  # last current button text color
 
-    def animation_label(self) -> NoReturn:
+    def animation_label(self) -> None:
         def set_default_state_label(*args):
             Animation(opacity=1, d=0.1, t="in_out_cubic").start(self)
 
@@ -1389,7 +1387,7 @@ class MDTextButton(ButtonBehavior, MDLabel):
         self.animation_label()
         return super().on_press(*args)
 
-    def on_disabled(self, instance_button, disabled_value) -> NoReturn:
+    def on_disabled(self, instance_button, disabled_value) -> None:
         if disabled_value:
             if not self.color_disabled:
                 self.color_disabled = self.theme_cls.disabled_hint_text_color
@@ -1415,7 +1413,7 @@ class BaseFloatingBottomButton(MDFloatingActionButton, MDTooltip):
     _padding_right = NumericProperty(0)
     _bg_color = ColorProperty(None)
 
-    def set_size(self, interval: Union[int, float]) -> NoReturn:
+    def set_size(self, interval: Union[int, float]) -> None:
         self.width = "46dp"
         self.height = "46dp"
 
@@ -1676,7 +1674,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
     def on_close(self, *args):
         """Called when a stack is closed."""
 
-    def on_leave(self, instance_button: MDFloatingBottomButton) -> NoReturn:
+    def on_leave(self, instance_button: MDFloatingBottomButton) -> None:
         """Called when the mouse cursor goes outside the button of stack."""
 
         if self.state == "open":
@@ -1696,7 +1694,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
                                 opacity=0, d=0.1, t=self.opening_transition
                             ).start(widget)
 
-    def on_enter(self, instance_button: MDFloatingBottomButton) -> NoReturn:
+    def on_enter(self, instance_button: MDFloatingBottomButton) -> None:
         """Called when the mouse cursor is over a button from the stack."""
 
         if self.state == "open":
@@ -1726,7 +1724,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
                                     opacity=0, d=0.1, t=self.opening_transition
                                 ).start(widget)
 
-    def on_data(self, instance_speed_dial, data: dict) -> NoReturn:
+    def on_data(self, instance_speed_dial, data: dict) -> None:
         """Creates a stack of buttons."""
 
         # FIXME: Don't know how to fix AttributeError error:
@@ -1770,51 +1768,47 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         self.set_pos_root_button(root_button)
         self.add_widget(root_button)
 
-    def on_icon(self, instance_speed_dial, name_icon: str) -> NoReturn:
+    def on_icon(self, instance_speed_dial, name_icon: str) -> None:
         self._get_count_widget(MDFloatingRootButton).icon = name_icon
 
-    def on_label_text_color(self, instance_speed_dial, color: list) -> NoReturn:
+    def on_label_text_color(self, instance_speed_dial, color: list) -> None:
         for widget in self.children:
             if isinstance(widget, MDFloatingLabel):
                 widget.text_color = color
 
     def on_color_icon_stack_button(
         self, instance_speed_dial, color: list
-    ) -> NoReturn:
+    ) -> None:
         for widget in self.children:
             if isinstance(widget, MDFloatingBottomButton):
                 widget.text_color = color
 
-    def on_hint_animation(self, instance_speed_dial, value: bool) -> NoReturn:
+    def on_hint_animation(self, instance_speed_dial, value: bool) -> None:
         for widget in self.children:
             if isinstance(widget, MDFloatingLabel):
                 widget.bg_color = (0, 0, 0, 0)
 
-    def on_bg_hint_color(self, instance_speed_dial, color: list) -> NoReturn:
+    def on_bg_hint_color(self, instance_speed_dial, color: list) -> None:
         for widget in self.children:
             if isinstance(widget, MDFloatingBottomButton):
                 widget._bg_color = color
 
     def on_color_icon_root_button(
         self, instance_speed_dial, color: list
-    ) -> NoReturn:
+    ) -> None:
         self._get_count_widget(MDFloatingRootButton).text_color = color
 
     def on_bg_color_stack_button(
         self, instance_speed_dial, color: list
-    ) -> NoReturn:
+    ) -> None:
         for widget in self.children:
             if isinstance(widget, MDFloatingBottomButton):
                 widget.md_bg_color = color
 
-    def on_bg_color_root_button(
-        self, instance_speed_dial, color: list
-    ) -> NoReturn:
+    def on_bg_color_root_button(self, instance_speed_dial, color: list) -> None:
         self._get_count_widget(MDFloatingRootButton).md_bg_color = color
 
-    def set_pos_labels(
-        self, instance_floating_label: MDFloatingLabel
-    ) -> NoReturn:
+    def set_pos_labels(self, instance_floating_label: MDFloatingLabel) -> None:
         """
         Sets the position of the floating labels.
         Called when the application's root window is resized.
@@ -1827,7 +1821,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
 
     def set_pos_root_button(
         self, instance_floating_root_button: MDFloatingRootButton
-    ) -> NoReturn:
+    ) -> None:
         """
         Sets the position of the root button.
         Called when the application's root window is resized.
@@ -1839,7 +1833,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
 
     def set_pos_bottom_buttons(
         self, instance_floating_bottom_button: MDFloatingBottomButton
-    ) -> NoReturn:
+    ) -> None:
         """
         Sets the position of the bottom buttons in a stack.
         Called when the application's root window is resized.
@@ -1857,7 +1851,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
 
     def open_stack(
         self, instance_floating_root_button: MDFloatingRootButton
-    ) -> NoReturn:
+    ) -> None:
         """Opens a button stack."""
 
         for widget in self.children:
@@ -1917,7 +1911,7 @@ class MDFloatingActionButtonSpeedDial(ThemableBehavior, FloatLayout):
         else:
             self.close_stack()
 
-    def do_animation_open_stack(self, anim_data: dict) -> NoReturn:
+    def do_animation_open_stack(self, anim_data: dict) -> None:
         """
         :param anim_data:
             {

--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -717,8 +717,8 @@ class BaseButton(
 
     disabled_color = ColorProperty(None)
     """
-    The color of the text and icon when the button is disabled, in the 
-    (r, g, b, a) format.
+    The color of the text and icon when the button is disabled, in the
+     (r, g, b, a) format.
 
     .. versionadded:: 1.0.0
 

--- a/kivymd/uix/card/card.py
+++ b/kivymd/uix/card/card.py
@@ -568,7 +568,7 @@ __all__ = (
 )
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -617,7 +617,7 @@ class MDSeparator(ThemableBehavior, MDBoxLayout):
         super().__init__(**kwargs)
         self.on_orientation()
 
-    def on_orientation(self, *args) -> NoReturn:
+    def on_orientation(self, *args) -> None:
         self.size_hint = (
             (1, None) if self.orientation == "horizontal" else (None, 1)
         )
@@ -696,13 +696,13 @@ class MDCard(
         )
         self.update_md_bg_color(self, self.theme_cls.theme_style)
 
-    def update_md_bg_color(self, instance_card, theme_style: str) -> NoReturn:
+    def update_md_bg_color(self, instance_card, theme_style: str) -> None:
         if self.md_bg_color in self._bg_color_map:
             self.md_bg_color = get_color_from_hex(
                 colors[theme_style]["CardsDialogs"]
             )
 
-    def set_style(self, *args) -> NoReturn:
+    def set_style(self, *args) -> None:
         self.set_radius()
         self.set_elevation()
         self.set_line_color()
@@ -719,7 +719,7 @@ class MDCard(
             elif self.style == "elevated":
                 self.elevation = 1
 
-    def set_radius(self) -> NoReturn:
+    def set_radius(self) -> None:
         if (
             self.radius == [dp(6), dp(6), dp(6), dp(6)]
             and self.theme_cls.material_style == "M3"
@@ -733,7 +733,7 @@ class MDCard(
 
     def on_ripple_behavior(
         self, interval: Union[int, float], value_behavior: bool
-    ) -> NoReturn:
+    ) -> None:
         self._no_ripple_effect = False if value_behavior else True
 
 
@@ -851,7 +851,7 @@ class MDCardSwipe(RelativeLayout):
 
     def on_anchor(
         self, instance_swipe_to_delete_item, anchor_value: str
-    ) -> NoReturn:
+    ) -> None:
         if anchor_value == "right":
             self.open_progress = 1.0
         else:
@@ -859,7 +859,7 @@ class MDCardSwipe(RelativeLayout):
 
     def on_open_progress(
         self, instance_swipe_to_delete_item, progress_value: float
-    ) -> NoReturn:
+    ) -> None:
         if self.anchor == "left":
             self.children[0].x = self.width * progress_value
         else:
@@ -895,7 +895,7 @@ class MDCardSwipe(RelativeLayout):
                 self.close_card()
         return super().on_touch_down(touch)
 
-    def complete_swipe(self) -> NoReturn:
+    def complete_swipe(self) -> None:
         expr = (
             self.open_progress <= self.max_swipe_x
             if self.anchor == "left"
@@ -906,7 +906,7 @@ class MDCardSwipe(RelativeLayout):
         else:
             self.open_card()
 
-    def open_card(self) -> NoReturn:
+    def open_card(self) -> None:
         if self.type_swipe == "hand":
             swipe_x = (
                 self.max_opened_x
@@ -922,7 +922,7 @@ class MDCardSwipe(RelativeLayout):
         anim.start(self.children[0])
         self.state = "opened"
 
-    def close_card(self) -> NoReturn:
+    def close_card(self) -> None:
         anim = Animation(x=0, t=self.closing_transition, d=self.opening_time)
         anim.bind(on_complete=self._reset_open_progress)
         anim.start(self.children[0])

--- a/kivymd/uix/chip/chip.py
+++ b/kivymd/uix/chip/chip.py
@@ -303,7 +303,7 @@ Only one chip will be selected.
 __all__ = ("MDChip",)
 
 import os
-from typing import NoReturn
+
 
 from kivy import Logger
 from kivy.animation import Animation
@@ -469,20 +469,18 @@ class MDChip(
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def on_long_touch(self, *args) -> NoReturn:
+    def on_long_touch(self, *args) -> None:
         if self.active:
             return
         self.active = True if not self.active else False
 
-    def on_active(self, instance_check, active_value: bool) -> NoReturn:
+    def on_active(self, instance_check, active_value: bool) -> None:
         if active_value:
             self.do_animation_check((0, 0, 0, 0.4), 1)
         else:
             self.do_animation_check((0, 0, 0, 0), 0)
 
-    def do_animation_check(
-        self, md_bg_color: list, scale_value: int
-    ) -> NoReturn:
+    def do_animation_check(self, md_bg_color: list, scale_value: int) -> None:
         Animation(md_bg_color=md_bg_color, t="out_sine", d=0.1).start(
             self.ids.icon_left_box
         )

--- a/kivymd/uix/chip/chip.py
+++ b/kivymd/uix/chip/chip.py
@@ -304,7 +304,6 @@ __all__ = ("MDChip",)
 
 import os
 
-
 from kivy import Logger
 from kivy.animation import Animation
 from kivy.lang import Builder

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -636,7 +636,7 @@ class TableData(RecycleView):
         # resets all checks on all pages
         self.current_selection_check = {}
 
-    def check_all(self, state: str) -> None:
+    def check_all(self, state: str) -> bool:
         """Checks if checkboxes of all rows are in the same state."""
 
         tmp = []

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -43,7 +43,7 @@ __all__ = ("MDDataTable",)
 
 import os
 from collections import defaultdict
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.clock import Clock
 from kivy.lang import Builder
@@ -198,7 +198,7 @@ class CellHeader(MDTooltip, BoxLayout):
 
             box.add_widget(ib, index=1)
 
-    def restore_checks(self, indices: dict) -> NoReturn:
+    def restore_checks(self, indices: dict) -> None:
         curr_checks = self.table_data.current_selection_check
         rows_num = self.table_data.rows_num
         columns = self.table_data.total_col_headings
@@ -213,7 +213,7 @@ class CellHeader(MDTooltip, BoxLayout):
                 new_checks[new_page].append(new_indice)
         self.table_data.current_selection_check = dict(new_checks)
 
-    def set_sort_btn(self, instance_cell_header) -> NoReturn:
+    def set_sort_btn(self, instance_cell_header) -> None:
         btn = instance_cell_header.ids.box.children[-1]
         if btn.opacity:
             btn.size = [dp(24), dp(0)]
@@ -359,9 +359,7 @@ class TableHeader(ThemableBehavior, ScrollView):
                 self.ids.first_cell.ids.separator.height = 0
                 self.ids.first_cell.width = self.cols_minimum[i]
 
-    def on_table_data(
-        self, instance_table_header, instance_table_data
-    ) -> NoReturn:
+    def on_table_data(self, instance_table_header, instance_table_data) -> None:
         """Sets the checkbox in the first cell."""
 
         if self.table_data.check:
@@ -490,7 +488,7 @@ class TableData(RecycleView):
         self.effect_cls = self._parent.effect_cls
         Clock.schedule_once(self.set_default_first_row, 0)
 
-    def get_select_row(self, index: int) -> NoReturn:
+    def get_select_row(self, index: int) -> None:
         """Returns the current row with all elements."""
 
         row = []
@@ -500,12 +498,12 @@ class TableData(RecycleView):
         self._parent.dispatch("on_check_press", row)
         self._get_row_checks()  # update the dict
 
-    def set_default_first_row(self, interval: Union[int, float]) -> NoReturn:
+    def set_default_first_row(self, interval: Union[int, float]) -> None:
         """Set default first row as selected."""
 
         self.ids.row_controller.select_next(self)
 
-    def set_row_data(self) -> NoReturn:
+    def set_row_data(self) -> None:
         data = []
         low = 0
         high = self.total_col_headings - 1
@@ -570,7 +568,7 @@ class TableData(RecycleView):
                 raise ValueError("Set value for column_data in class TableData")
             self.data_first_cells.append(self.table_header.column_data[0][0])
 
-    def set_text_from_of(self, direction: str) -> NoReturn:
+    def set_text_from_of(self, direction: str) -> None:
         """Sets the text of the numbers of displayed pages in table."""
 
         if self.pagination:
@@ -606,7 +604,7 @@ class TableData(RecycleView):
                 f"of {len(self.row_data)}"
             )
 
-    def select_all(self, state: str) -> NoReturn:
+    def select_all(self, state: str) -> None:
         """Sets the checkboxes of all rows to the active/inactive position."""
 
         for i in range(0, len(self.recycle_data), self.total_col_headings):
@@ -638,7 +636,7 @@ class TableData(RecycleView):
         # resets all checks on all pages
         self.current_selection_check = {}
 
-    def check_all(self, state: str) -> NoReturn:
+    def check_all(self, state: str) -> None:
         """Checks if checkboxes of all rows are in the same state."""
 
         tmp = []
@@ -653,19 +651,19 @@ class TableData(RecycleView):
                 tmp.append(cell_row_obj.ids.check.state == state)
         return all(tmp)
 
-    def close_pagination_menu(self, *args) -> NoReturn:
+    def close_pagination_menu(self, *args) -> None:
         """Called when the pagination menu window is closed."""
 
         self.pagination_menu_open = False
 
-    def open_pagination_menu(self) -> NoReturn:
+    def open_pagination_menu(self) -> None:
         """Open pagination menu window."""
 
         if self.pagination_menu.items:
             self.pagination_menu_open = True
             self.pagination_menu.open()
 
-    def set_number_displayed_lines(self, text_item) -> NoReturn:
+    def set_number_displayed_lines(self, text_item) -> None:
         """
         Called when the user sets the number of pages displayed
         in the table.
@@ -677,7 +675,7 @@ class TableData(RecycleView):
         self.set_text_from_of("reset")
         self.pagination_menu.caller.text = text_item
 
-    def set_next_row_data_parts(self, direction: str) -> NoReturn:
+    def set_next_row_data_parts(self, direction: str) -> None:
         """Called when switching the pages of the table."""
 
         if direction == "reset":
@@ -699,7 +697,7 @@ class TableData(RecycleView):
         if self._current_value == 1:
             self.pagination.ids.button_back.disabled = True
 
-    def on_mouse_select(self, instance_cell_row) -> NoReturn:
+    def on_mouse_select(self, instance_cell_row) -> None:
         """Called on the ``on_enter`` event of the :class:`~CellRow` class."""
 
         if not self.pagination_menu_open:
@@ -707,7 +705,7 @@ class TableData(RecycleView):
                 self.ids.row_controller.selected_row = instance_cell_row.index
                 self.ids.row_controller.select_current(self)
 
-    def on_rows_num(self, instance_table_date, value_rows_num: int) -> NoReturn:
+    def on_rows_num(self, instance_table_date, value_rows_num: int) -> None:
         if not self._to_value:
             self._to_value = value_rows_num
 
@@ -718,7 +716,7 @@ class TableData(RecycleView):
 
     def on_pagination(
         self, instance_table_date, instance_table_pagination
-    ) -> NoReturn:
+    ) -> None:
         if self._to_value < len(self.row_data):
             self.pagination.ids.button_forward.disabled = False
 
@@ -1455,7 +1453,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
         Clock.schedule_once(self.create_pagination_menu, 0.5)
         self.bind(row_data=self.update_row_data)
 
-    def update_row_data(self, instance_data_table, data: list) -> NoReturn:
+    def update_row_data(self, instance_data_table, data: list) -> None:
         """
         Called when a the widget data must be updated.
 
@@ -1481,7 +1479,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
         self.pagination.ids.button_back.disabled = True
         Clock.schedule_once(self.create_pagination_menu, 0.5)
 
-    def add_row(self, data: Union[list, tuple]) -> NoReturn:
+    def add_row(self, data: Union[list, tuple]) -> None:
         """
         Added new row to common table.
         Argument `data` is the row data from the list :attr:`row_data`.
@@ -1491,7 +1489,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
 
         self.row_data.append(data)
 
-    def remove_row(self, data: Union[list, tuple]) -> NoReturn:
+    def remove_row(self, data: Union[list, tuple]) -> None:
         """
         Removed row from common table.
         Argument `data` is the row data from the list :attr:`row_data`.
@@ -1501,10 +1499,10 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
 
         self.row_data.remove(data)
 
-    def on_row_press(self, instance_cell_row) -> NoReturn:
+    def on_row_press(self, instance_cell_row) -> None:
         """Called when a table row is clicked."""
 
-    def on_check_press(self, row_data: list) -> NoReturn:
+    def on_check_press(self, row_data: list) -> None:
         """
         Called when the check box in the table row is checked.
 
@@ -1516,7 +1514,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
 
         return self.table_data._get_row_checks()
 
-    def create_pagination_menu(self, interval: Union[int, float]) -> NoReturn:
+    def create_pagination_menu(self, interval: Union[int, float]) -> None:
         menu_items = [
             {
                 "text": f"{i}",
@@ -1619,7 +1617,7 @@ class CellRow(
 
     def notify_checkbox_click(
         self, instance_check: MDCheckbox, active: bool
-    ) -> NoReturn:
+    ) -> None:
         """Called when the table row checkbox is activated/deactivated."""
 
         self.table.get_select_row(self.index)
@@ -1647,7 +1645,7 @@ class CellRow(
 
     def apply_selection(
         self, instance_table_data: TableData, index: int, is_selected: bool
-    ) -> NoReturn:
+    ) -> None:
         """Called when list items of table appear on the screen."""
 
         self.selected = is_selected
@@ -1694,7 +1692,7 @@ class CellRow(
         else:
             self.change_check_state_no_notify("normal")
 
-    def change_check_state_no_notify(self, new_state: str) -> NoReturn:
+    def change_check_state_no_notify(self, new_state: str) -> None:
         checkbox = self.ids.check
         checkbox.unbind(active=self.notify_checkbox_click)
         checkbox.state = new_state
@@ -1702,7 +1700,7 @@ class CellRow(
 
     def select_check(
         self, instance_table_data: MDDataTable, active: bool
-    ) -> NoReturn:
+    ) -> None:
         """Called upon activation/deactivation of the checkbox."""
 
         if active:
@@ -1739,12 +1737,12 @@ class CellRow(
                 self.table._parent.dispatch("on_row_press", self)
             return True
 
-    def on_icon(self, instance_cell_row, name_icon: str) -> NoReturn:
+    def on_icon(self, instance_cell_row, name_icon: str) -> None:
         self.icon_copy = name_icon
 
     def on_table(
         self, instance_cell_row, instance_table_data: TableData
-    ) -> NoReturn:
+    ) -> None:
         """Sets padding/spacing to zero if no checkboxes are used for rows."""
 
         if not instance_table_data.check:

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -294,7 +294,7 @@ class TableHeader(ThemableBehavior, ScrollView):
     sorted_on = StringProperty()
     """
     See :attr:`~MDDataTable.sorted_on`.
-    
+
     :attr:`sorted_on` is an :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
     """
@@ -1364,7 +1364,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
             ...,
             background_color_header=get_color_from_hex("#65275d"),
         )
-        
+
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-background-color-header.png
         :align: center
 
@@ -1385,7 +1385,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
             background_color_header=get_color_from_hex("#65275d"),
             background_color_cell=get_color_from_hex("#451938"),
         )
-        
+
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-background-color-cell.png
         :align: center
 
@@ -1407,7 +1407,7 @@ class MDDataTable(ThemableBehavior, AnchorLayout):
             background_color_cell=get_color_from_hex("#451938"),
             background_color_selected_cell=get_color_from_hex("e4514f"),
         )
-        
+
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/data-tables-background-color-selected-cell.gif
         :align: center
 

--- a/kivymd/uix/dropdownitem/dropdownitem.py
+++ b/kivymd/uix/dropdownitem/dropdownitem.py
@@ -45,7 +45,6 @@ __all__ = ("MDDropDownItem",)
 
 import os
 
-
 from kivy.lang import Builder
 from kivy.properties import NumericProperty, StringProperty
 from kivy.uix.behaviors import ButtonBehavior

--- a/kivymd/uix/dropdownitem/dropdownitem.py
+++ b/kivymd/uix/dropdownitem/dropdownitem.py
@@ -44,7 +44,7 @@ Usage
 __all__ = ("MDDropDownItem",)
 
 import os
-from typing import NoReturn
+
 
 from kivy.lang import Builder
 from kivy.properties import NumericProperty, StringProperty
@@ -96,10 +96,10 @@ class MDDropDownItem(
     and defaults to `'16sp'`.
     """
 
-    def on_text(self, instance_drop_down_item, text_item: str) -> NoReturn:
+    def on_text(self, instance_drop_down_item, text_item: str) -> None:
         self.ids.label_item.text = text_item
 
-    def set_item(self, name_item: str) -> NoReturn:
+    def set_item(self, name_item: str) -> None:
         """Sets new text for an item."""
 
         self.ids.label_item.text = name_item

--- a/kivymd/uix/expansionpanel/expansionpanel.py
+++ b/kivymd/uix/expansionpanel/expansionpanel.py
@@ -145,7 +145,7 @@ __all__ = (
 )
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -208,7 +208,7 @@ class MDExpansionPanelLabel(TwoLineListItem):
         super().__init__(**kwargs)
         Clock.schedule_once(self.set_paddings)
 
-    def set_paddings(self, interval: Union[int, float]) -> NoReturn:
+    def set_paddings(self, interval: Union[int, float]) -> None:
         self._txt_bot_pad = dp(36)
         self._txt_left_pad = dp(0)
 
@@ -355,7 +355,7 @@ class MDExpansionPanel(RelativeLayout):
             MDExpansionPanelThreeLine,
             MDExpansionPanelLabel,
         ],
-    ) -> NoReturn:
+    ) -> None:
         """
         Called when you click on the panel. Called methods to open or close
         a panel.
@@ -377,7 +377,7 @@ class MDExpansionPanel(RelativeLayout):
         if not press_current_panel:
             self.set_chevron_down()
 
-    def set_chevron_down(self) -> NoReturn:
+    def set_chevron_down(self) -> None:
         """Sets the chevron down."""
 
         if not isinstance(self.panel_cls, MDExpansionPanelLabel):
@@ -385,9 +385,7 @@ class MDExpansionPanel(RelativeLayout):
         self.open_panel()
         self.dispatch("on_open")
 
-    def set_chevron_up(
-        self, instance_chevron: MDExpansionChevronRight
-    ) -> NoReturn:
+    def set_chevron_up(self, instance_chevron: MDExpansionChevronRight) -> None:
         """Sets the chevron up."""
 
         if not isinstance(self.panel_cls, MDExpansionPanelLabel):
@@ -395,7 +393,7 @@ class MDExpansionPanel(RelativeLayout):
 
     def close_panel(
         self, instance_expansion_panel, press_current_panel: bool
-    ) -> NoReturn:
+    ) -> None:
         """Method closes the panel."""
 
         if self._anim_playing:
@@ -414,7 +412,7 @@ class MDExpansionPanel(RelativeLayout):
         anim.bind(on_complete=self._disable_anim)
         anim.start(instance_expansion_panel)
 
-    def open_panel(self, *args) -> NoReturn:
+    def open_panel(self, *args) -> None:
         """Method opens a panel."""
 
         if self._anim_playing:

--- a/kivymd/uix/filemanager/filemanager.py
+++ b/kivymd/uix/filemanager/filemanager.py
@@ -133,7 +133,7 @@ __all__ = ("MDFileManager",)
 import locale
 import os
 import re
-from typing import List, NoReturn, Tuple, Union
+from typing import List, None, Tuple, Union
 
 from kivy import platform
 from kivy.factory import Factory
@@ -346,7 +346,7 @@ class MDFileManager(ThemableBehavior, MDRelativeLayout):
             self.ext = [".png", ".jpg", ".jpeg"]
         self.disks = []
 
-    def show_disks(self) -> NoReturn:
+    def show_disks(self) -> None:
         if platform == "win":
             self.disks = sorted(
                 re.findall(
@@ -403,7 +403,7 @@ class MDFileManager(ThemableBehavior, MDRelativeLayout):
             self._window_manager.open()
             self._window_manager_open = True
 
-    def show(self, path: str) -> NoReturn:
+    def show(self, path: str) -> None:
         """
         Forms the body of a directory tree.
 
@@ -547,7 +547,7 @@ class MDFileManager(ThemableBehavior, MDRelativeLayout):
         except OSError:
             return None, None
 
-    def close(self) -> NoReturn:
+    def close(self) -> None:
         """Closes the file manager window."""
 
         self._window_manager.dismiss()
@@ -578,7 +578,7 @@ class MDFileManager(ThemableBehavior, MDRelativeLayout):
             self.current_path = path
             self.show(path)
 
-    def back(self) -> NoReturn:
+    def back(self) -> None:
         """Returning to the branch down in the directory tree."""
 
         path, end = os.path.split(self.current_path)
@@ -592,7 +592,7 @@ class MDFileManager(ThemableBehavior, MDRelativeLayout):
             else:
                 self.show(path)
 
-    def select_directory_on_press_button(self, *args) -> NoReturn:
+    def select_directory_on_press_button(self, *args) -> None:
         """Called when a click on a floating button."""
 
         if self.selector == "multi":

--- a/kivymd/uix/filemanager/filemanager.py
+++ b/kivymd/uix/filemanager/filemanager.py
@@ -133,7 +133,7 @@ __all__ = ("MDFileManager",)
 import locale
 import os
 import re
-from typing import List, None, Tuple, Union
+from typing import List, Tuple, Union
 
 from kivy import platform
 from kivy.factory import Factory

--- a/kivymd/uix/imagelist/imagelist.py
+++ b/kivymd/uix/imagelist/imagelist.py
@@ -119,7 +119,6 @@ __all__ = ("SmartTile", "SmartTileWithLabel", "SmartTileWithStar")
 
 import os
 
-
 from kivy.lang import Builder
 from kivy.properties import (
     BooleanProperty,

--- a/kivymd/uix/imagelist/imagelist.py
+++ b/kivymd/uix/imagelist/imagelist.py
@@ -118,7 +118,7 @@ SmartTileWithLabel
 __all__ = ("SmartTile", "SmartTileWithLabel", "SmartTileWithStar")
 
 import os
-from typing import NoReturn
+
 
 from kivy.lang import Builder
 from kivy.properties import (
@@ -241,7 +241,7 @@ class SmartTileWithStar(SmartTileWithLabel):
     and defaults to `1`.
     """
 
-    def on_stars(self, *args) -> NoReturn:
+    def on_stars(self, *args) -> None:
         for star in range(self.stars):
             self.ids.box.add_widget(
                 _Star(

--- a/kivymd/uix/label/label.py
+++ b/kivymd/uix/label/label.py
@@ -220,7 +220,7 @@ MDIcon with badge icon
 __all__ = ("MDLabel", "MDIcon")
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.clock import Clock
 from kivy.lang import Builder
@@ -343,7 +343,7 @@ class MDLabel(ThemableBehavior, Label, MDAdaptiveWidget):
         else:
             return True
 
-    def update_font_style(self, instance_label, font_style: str) -> NoReturn:
+    def update_font_style(self, instance_label, font_style: str) -> None:
         if self.check_font_styles() is True:
             font_info = self.theme_cls.font_styles[self.font_style]
             self.font_name = font_info[0]
@@ -358,7 +358,7 @@ class MDLabel(ThemableBehavior, Label, MDAdaptiveWidget):
 
     def on_theme_text_color(
         self, instance_label, theme_text_color: str
-    ) -> NoReturn:
+    ) -> None:
         op = self.opposite_colors
         if op:
             self._text_color_str = __MDLabel_colors__.get("OP", "").get(
@@ -382,11 +382,11 @@ class MDLabel(ThemableBehavior, Label, MDAdaptiveWidget):
             else:
                 self.color = [0, 0, 0, 1]
 
-    def on_text_color(self, instance_label, color: list) -> NoReturn:
+    def on_text_color(self, instance_label, color: list) -> None:
         if self.theme_text_color == "Custom":
             self.color = self.text_color
 
-    def on_opposite_colors(self, *args) -> NoReturn:
+    def on_opposite_colors(self, *args) -> None:
         self.on_theme_text_color(self, self.theme_text_color)
 
     def _do_update_theme_color(self, *args):

--- a/kivymd/uix/menu/menu.py
+++ b/kivymd/uix/menu/menu.py
@@ -467,7 +467,7 @@ Center position
 __all__ = ("MDDropdownMenu",)
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -817,14 +817,14 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
 
     def check_position_caller(
         self, instance_window: WindowSDL, width: int, height: int
-    ) -> NoReturn:
+    ) -> None:
         """Called when the application root window is resized."""
 
         # FIXME: Menu position is not recalculated when changing the size of
         #  the root application window.
         self.set_menu_properties(0)
 
-    def set_menu_properties(self, interval: Union[int, float] = 0) -> NoReturn:
+    def set_menu_properties(self, interval: Union[int, float] = 0) -> None:
         """Sets the size and position for the menu window."""
 
         if self.caller:
@@ -938,7 +938,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
                 self.tar_x = self._start_coords[0] - self.target_width
             self._calculate_complete = True
 
-    def ajust_radius(self, interval: Union[int, float]) -> NoReturn:
+    def ajust_radius(self, interval: Union[int, float]) -> None:
         """
         Adjusts the radius of the first and last items in the menu list
         according to the radius that is set for the menu.
@@ -988,7 +988,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
                 self.set_menu_properties()
         return position
 
-    def open(self) -> NoReturn:
+    def open(self) -> None:
         """Animate the opening of a menu window."""
 
         def open(interval):
@@ -1045,7 +1045,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
 
     def on_header_cls(
         self, instance_dropdown_menu, instance_user_menu_header
-    ) -> NoReturn:
+    ) -> None:
         """Called when a value is set to the :attr:`header_cls` parameter."""
 
         def add_content_header_cls(interval):
@@ -1069,7 +1069,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
         super().on_touch_up(touch)
         return True
 
-    def on_dismiss(self) -> NoReturn:
+    def on_dismiss(self) -> None:
         """Called when the menu is closed."""
 
         Window.remove_widget(self)
@@ -1077,7 +1077,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
         self.menu.height = 0
         self.menu.opacity = 0
 
-    def dismiss(self, *args) -> NoReturn:
+    def dismiss(self, *args) -> None:
         """Closes the menu."""
 
         self.on_dismiss()

--- a/kivymd/uix/navigationdrawer/navigationdrawer.py
+++ b/kivymd/uix/navigationdrawer/navigationdrawer.py
@@ -404,7 +404,7 @@ __all__ = (
 )
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation, AnimationTransition
 from kivy.clock import Clock
@@ -454,7 +454,7 @@ class MDNavigationLayout(FloatLayout):
         super().__init__(**kwargs)
         self.bind(width=self.update_pos)
 
-    def update_pos(self, instance_navigation_drawer, pos_x: float) -> NoReturn:
+    def update_pos(self, instance_navigation_drawer, pos_x: float) -> None:
         drawer = self._navigation_drawer
         manager = self._screen_manager
         if not drawer or not manager:
@@ -475,7 +475,7 @@ class MDNavigationLayout(FloatLayout):
             else:
                 manager.width = self.width
 
-    def add_scrim(self, instance_manager: ScreenManager) -> NoReturn:
+    def add_scrim(self, instance_manager: ScreenManager) -> None:
         with instance_manager.canvas.after:
             self._scrim_color = Color(rgba=[0, 0, 0, 0])
             self._scrim_rectangle = Rectangle(
@@ -488,7 +488,7 @@ class MDNavigationLayout(FloatLayout):
 
     def update_scrim_rectangle(
         self, instance_manager: ScreenManager, size: list
-    ) -> NoReturn:
+    ) -> None:
         self._scrim_rectangle.pos = self.pos
         self._scrim_rectangle.size = self.size
 
@@ -734,7 +734,7 @@ class MDNavigationDrawerHeader(MDBoxLayout):
         super().__init__(**kwargs)
         Clock.schedule_once(self.check_content)
 
-    def check_content(self, interval: Union[int, float]) -> NoReturn:
+    def check_content(self, interval: Union[int, float]) -> None:
         """Removes widgets that the user has not added to the container."""
 
         if not self.title:
@@ -859,7 +859,7 @@ class MDNavigationDrawerMenu(ScrollView):
                 widget._drawer_menu = self
             self.ids.menu.add_widget(widget)
 
-    def reset_active_color(self, item: MDNavigationDrawerItem) -> NoReturn:
+    def reset_active_color(self, item: MDNavigationDrawerItem) -> None:
         for widget in self.ids.menu.children:
             if issubclass(widget.__class__, MDNavigationDrawerItem):
                 if widget != item:
@@ -1141,7 +1141,7 @@ class MDNavigationDrawer(MDCard, FakeRectangularElevationBehavior):
         )
         Window.bind(on_keyboard=self._handle_keyboard)
 
-    def set_state(self, new_state="toggle", animation=True) -> NoReturn:
+    def set_state(self, new_state="toggle", animation=True) -> None:
         """
         Change state of the side panel.
         New_state can be one of `"toggle"`, `"open"` or `"close"`.
@@ -1173,7 +1173,7 @@ class MDNavigationDrawer(MDCard, FakeRectangularElevationBehavior):
             else:
                 self.open_progress = 0
 
-    def update_status(self, *_) -> NoReturn:
+    def update_status(self, *_) -> None:
         status = self.status
         if status == "closed":
             self.state = "close"
@@ -1197,7 +1197,7 @@ class MDNavigationDrawer(MDCard, FakeRectangularElevationBehavior):
         else:
             self.opacity = 1
 
-    def get_dist_from_side(self, x: float) -> NoReturn:
+    def get_dist_from_side(self, x: float) -> float:
         if self.anchor == "left":
             return 0 if x < 0 else x
         return 0 if x > Window.width else Window.width - x
@@ -1264,12 +1264,10 @@ class MDNavigationDrawer(MDCard, FakeRectangularElevationBehavior):
             return False
         return True
 
-    def on_radius(
-        self, instance_navigation_drawer, radius_value: list
-    ) -> NoReturn:
+    def on_radius(self, instance_navigation_drawer, radius_value: list) -> None:
         self._radius = radius_value
 
-    def on_type(self, instance_navigation_drawer, drawer_type: str) -> NoReturn:
+    def on_type(self, instance_navigation_drawer, drawer_type: str) -> None:
         if self.type == "standard":
             self.enable_swiping = False
             self.close_on_click = False

--- a/kivymd/uix/navigationrail/navigationrail.py
+++ b/kivymd/uix/navigationrail/navigationrail.py
@@ -100,7 +100,7 @@ Usage
 __all__ = ("MDNavigationRail", "MDNavigationRailItem")
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -237,13 +237,13 @@ class MDNavigationRailItem(
         self._no_ripple_effect = True
         Clock.schedule_once(self.set_width)
 
-    def set_width(self, interval: Union[int, float]) -> NoReturn:
+    def set_width(self, interval: Union[int, float]) -> None:
         """Sets the size of the menu item."""
 
         self.size_hint = (None, None)
         self.size = (self.navigation_rail.width, self.navigation_rail.width)
 
-    def on_enter(self) -> NoReturn:
+    def on_enter(self) -> None:
         if self.navigation_rail.use_hover_behavior:
             Animation(
                 md_bg_color=self.theme_cls.bg_darkest
@@ -253,7 +253,7 @@ class MDNavigationRailItem(
                 d=self.navigation_rail.color_change_duration,
             ).start(self)
 
-    def on_leave(self) -> NoReturn:
+    def on_leave(self) -> None:
         if self.navigation_rail.use_hover_behavior:
             Animation(
                 md_bg_color=self.theme_cls.bg_light
@@ -263,19 +263,15 @@ class MDNavigationRailItem(
                 d=self.navigation_rail.color_change_duration,
             ).start(self)
 
-    def on_release(self) -> NoReturn:
+    def on_release(self) -> None:
         self.navigation_rail.set_color_menu_item(self)
         self.navigation_rail.dispatch("on_item_switch", self)
 
-    def on_visible(
-        self, instance_navigation_rail, visible_value: str
-    ) -> NoReturn:
+    def on_visible(self, instance_navigation_rail, visible_value: str) -> None:
         if visible_value in ("Selected", "Unlabeled"):
             Clock.schedule_once(self.set_item_label_transparency)
 
-    def set_item_label_transparency(
-        self, interval: Union[int, float]
-    ) -> NoReturn:
+    def set_item_label_transparency(self, interval: Union[int, float]) -> None:
         self.ids.lbl_text.text_color = (0, 0, 0, 0)
 
 
@@ -582,7 +578,7 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
 
     def anim_color_normal(
         self, instance_navigation_rail_item: MDNavigationRailItem
-    ) -> NoReturn:
+    ) -> None:
         color = (
             self.theme_cls.text_color
             if not instance_navigation_rail_item.color_normal
@@ -602,7 +598,7 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
 
     def anim_color_active(
         self, instance_navigation_rail_item: MDNavigationRailItem
-    ) -> NoReturn:
+    ) -> None:
         color = (
             self.theme_cls.primary_color
             if not instance_navigation_rail_item.color_active
@@ -636,7 +632,7 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
         else:
             return super().add_widget(widget)
 
-    def open(self) -> NoReturn:
+    def open(self) -> None:
         def set_opacity_title_component(*args):
             if self.use_title:
                 Animation(opacity=1, d=0.2).start(
@@ -660,7 +656,7 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
                 ).start(self.floating_action_button)
             self.dispatch("on_open")
 
-    def close(self) -> NoReturn:
+    def close(self) -> None:
         if self.use_resizeable:
             Animation(width=self.width / 4, d=0.2).start(self)
             if self.use_title:
@@ -697,16 +693,12 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
     def on_action_button(self, floating_action_button):
         """Called when the `MDFloatingActionButton` is pressed."""
 
-    def on_visible(
-        self, instance_navigation_rail, visible_value: str
-    ) -> NoReturn:
+    def on_visible(self, instance_navigation_rail, visible_value: str) -> None:
         for widget in self.ids.box.children:
             if isinstance(widget, MDNavigationRailItem):
                 widget.visible = visible_value
 
-    def on_use_title(
-        self, instance_navigation_rail, title_value: bool
-    ) -> NoReturn:
+    def on_use_title(self, instance_navigation_rail, title_value: bool) -> None:
         def add_title(interval):
             if title_value:
                 self.ids.box_title.add_widget(
@@ -721,7 +713,7 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
 
     def on_use_resizeable(
         self, instance_navigation_rail, resizeable_value: bool
-    ) -> NoReturn:
+    ) -> None:
         def add_item(interval):
             if resizeable_value:
                 for widget in self.ids.box.children:
@@ -737,7 +729,7 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
 
     def on_use_action_button(
         self, instance_navigation_rail, use_value: bool
-    ) -> NoReturn:
+    ) -> None:
         if use_value:
             rail_box = BaseNavigationRailBoxItem(
                 size_hint=(None, None),
@@ -757,32 +749,30 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
 
     def press_floating_action_button(
         self, instance_button: BaseNavigationRailFloatingButton
-    ) -> NoReturn:
+    ) -> None:
         self.dispatch("on_action_button", instance_button)
 
-    def set_action_color_button(self, interval: Union[int, float]) -> NoReturn:
+    def set_action_color_button(self, interval: Union[int, float]) -> None:
         if self.floating_action_button and self.action_color_button:
             self.floating_action_button.md_bg_color = self.action_color_button
 
-    def set_width(self, interval: Union[int, float]) -> NoReturn:
+    def set_width(self, interval: Union[int, float]) -> None:
         self.size_hint_x = None
         self.width = dp(72)
 
-    def set_box_title_size(self, interval: Union[int, float]) -> NoReturn:
+    def set_box_title_size(self, interval: Union[int, float]) -> None:
         if not self.use_title:
             self.remove_widget(self.ids.box_title)
 
-    def set_action_icon_button(self, interval: Union[int, float]) -> NoReturn:
+    def set_action_icon_button(self, interval: Union[int, float]) -> None:
         if self.floating_action_button:
             self.floating_action_button.icon = self.action_icon_button
 
-    def set_action_text_button(self, interval: Union[int, float]) -> NoReturn:
+    def set_action_text_button(self, interval: Union[int, float]) -> None:
         if self.floating_action_button:
             self.floating_action_button.text = self.action_text_button
 
-    def set_color_menu_item(
-        self, instance_item: MDNavigationRailItem
-    ) -> NoReturn:
+    def set_color_menu_item(self, instance_item: MDNavigationRailItem) -> None:
         for item in self.ids.box.children:
             if isinstance(item, MDNavigationRailItem):
                 if instance_item is item:
@@ -790,13 +780,13 @@ class MDNavigationRail(MDCard, FakeRectangularElevationBehavior):
                 else:
                     self.anim_color_normal(item)
 
-    def set_items_color(self, interval: Union[int, float]) -> NoReturn:
+    def set_items_color(self, interval: Union[int, float]) -> None:
         if not self.color_normal:
             self.color_normal = self.theme_cls.text_color
         if not self.color_active:
             self.color_active = self.theme_cls.bg_light
 
-    def set_items_visible(self, interval: Union[int, float]) -> NoReturn:
+    def set_items_visible(self, interval: Union[int, float]) -> None:
         # If the user does not set the `visible` parameter.
         if self.visible == "Persistent":
             for widget in self.ids.box.children:

--- a/kivymd/uix/pickers/colorpicker/colorpicker.py
+++ b/kivymd/uix/pickers/colorpicker/colorpicker.py
@@ -14,7 +14,7 @@ Usage
 
 .. code-block:: python
 
-    from typing import Union, NoReturn
+    from typing import Union, None
 
     from kivy.lang import Builder
 
@@ -49,7 +49,7 @@ Usage
                 on_release=self.get_selected_color,
             )
 
-        def update_color(self, color: list) -> NoReturn:
+        def update_color(self, color: list) -> None:
             self.root.ids.toolbar.md_bg_color = color
 
         def get_selected_color(
@@ -63,7 +63,7 @@ Usage
             print(f"Selected color is {selected_color}")
             self.update_color(selected_color[:-1] + [1])
 
-        def on_select_color(self, instance_gradient_tab, color: list) -> NoReturn:
+        def on_select_color(self, instance_gradient_tab, color: list) -> None:
             '''Called when a gradient image is clicked.'''
 
 
@@ -76,7 +76,7 @@ Usage
 import os
 import struct
 from io import BytesIO
-from typing import List, NoReturn, Union
+from typing import List, None, Union
 
 from kivy.clock import Clock
 from kivy.core.image import Image as CoreImage
@@ -146,14 +146,14 @@ class SelectAlphaChannelWidget(MDBoxLayout):
 
     def on_color_picker(
         self, instance_select_alpha_channel_widget, instance_color_picker
-    ) -> NoReturn:
+    ) -> None:
         instance_color_picker.bind(_rgb=self.set_scale_rgb)
 
     def set_scale_rgb(
         self,
         instance_color_picker,
         color: Union[List[int], List[float]],
-    ) -> NoReturn:
+    ) -> None:
         if color[0] > 1:
             self._rgb = [x / 255.0 for x in color]
         else:
@@ -182,7 +182,7 @@ class SliderTab(MDBoxLayout):
             self.color_picker._opacity_value_selected_color,
         ]
 
-    def on_slide_value(self, *args) -> NoReturn:
+    def on_slide_value(self, *args) -> None:
         """Basic event handler for changing the slider value."""
 
 
@@ -205,7 +205,7 @@ class GradientTab(ThemableBehavior, MDBoxLayout):
 
     def create_gradient_texture(
         self, r_g_b=None, interval: Union[int, float] = 0
-    ) -> NoReturn:
+    ) -> None:
         """
         Creates a gradient value buffer and texture object.
         Called when clicking on the gradient bar to the right.
@@ -260,7 +260,7 @@ class GradientTab(ThemableBehavior, MDBoxLayout):
 
     def create_canvas_with_gradient_texture(
         self, interval: Union[int, float]
-    ) -> NoReturn:
+    ) -> None:
         """Creates a canvas with a gradient texture."""
 
         with self.ids.color_selection_box.canvas:
@@ -282,7 +282,7 @@ class GradientTab(ThemableBehavior, MDBoxLayout):
         rgba = struct.unpack("4B", pixel.pixels)
         return rgba
 
-    def updated_canvas(self, widget, touch, color=None) -> NoReturn:
+    def updated_canvas(self, widget, touch, color=None) -> None:
         """
         Called when clicking on the gradient bar to the right.
         Updates the color of the gradient texture.
@@ -313,7 +313,7 @@ class GradientTab(ThemableBehavior, MDBoxLayout):
             )
         return super().on_touch_down(touch)
 
-    def _update_canvas(self, instance_gradient_widget, size: list) -> NoReturn:
+    def _update_canvas(self, instance_gradient_widget, size: list) -> None:
         self.rectangle.size = self.ids.gradient_widget.size
         self.rectangle.pos = self.ids.gradient_widget.pos
 
@@ -337,7 +337,7 @@ class ColorListTab(MDTabs):
         instance_tab_color_list: TabColorList,
         instance_tabs_label: MDTabsLabel,
         tab_label_text: str,
-    ) -> NoReturn:
+    ) -> None:
         """
         Generates list of colors.
         Called when you click the tab of :class:`~TabColorList` class.
@@ -364,7 +364,7 @@ class ColorListTab(MDTabs):
                     }
                 )
 
-    def on_press_color_item(self, color: list) -> NoReturn:
+    def on_press_color_item(self, color: list) -> None:
         """Called when you click on the color item from the list of colors."""
 
         rgb = [int(value * 255) for value in color[:-1]]
@@ -476,7 +476,7 @@ class MDColorPicker(BaseDialog):
 
     def update_color_slider_item_bottom_navigation(
         self, color: list
-    ) -> NoReturn:
+    ) -> None:
         """
         Updates the color of the slider that sets the transparency value of the
         selected color and the color of bottom navigation items.
@@ -488,7 +488,7 @@ class MDColorPicker(BaseDialog):
             )
         self.ids.bottom_navigation.text_color_active = color
 
-    def update_color_type_buttons(self, color: list) -> NoReturn:
+    def update_color_type_buttons(self, color: list) -> None:
         """
         Updating button colors (display buttons of type of color) to match the
         selected color.
@@ -509,8 +509,8 @@ class MDColorPicker(BaseDialog):
 
     def on_background_down_button_selected_type_color(
         self, instance_color_picker, color: list
-    ) -> NoReturn:
-        def set_background_down(interval: Union[float, int]) -> NoReturn:
+    ) -> None:
+        def set_background_down(interval: Union[float, int]) -> None:
             for (
                 instance_toggle_button
             ) in self.ids.type_color_button_box.children:
@@ -525,7 +525,7 @@ class MDColorPicker(BaseDialog):
         instance_color_picker,
         type_color: str = "",
         interval: Union[float, int] = 0,
-    ) -> NoReturn:
+    ) -> None:
         """Called when buttons are clicked to set the color type."""
 
         if not type_color:
@@ -550,7 +550,7 @@ class MDColorPicker(BaseDialog):
 
             self.ids.lbl_color_value.text = color
 
-    def on_open(self) -> NoReturn:
+    def on_open(self) -> None:
         """Default open event handler."""
 
         if not self.ids.bottom_navigation_gradient.children:
@@ -558,7 +558,7 @@ class MDColorPicker(BaseDialog):
             self._current_tab = self.gradient_tab
             self.ids.bottom_navigation_gradient.add_widget(self.gradient_tab)
 
-    def on_select_color(self, color: list) -> NoReturn:
+    def on_select_color(self, color: list) -> None:
         """Called when a gradient image is clicked."""
 
         if len(color) == 3:
@@ -575,7 +575,7 @@ class MDColorPicker(BaseDialog):
         bottom_navigation_instance,
         bottom_navigation_item_instance,
         name_tab,
-    ) -> NoReturn:
+    ) -> None:
         """Called when switching tabs of bottom navigation."""
 
         if name_tab == "bottom navigation gradient":

--- a/kivymd/uix/pickers/colorpicker/colorpicker.py
+++ b/kivymd/uix/pickers/colorpicker/colorpicker.py
@@ -14,7 +14,7 @@ Usage
 
 .. code-block:: python
 
-    from typing import Union, None
+    from typing import Union
 
     from kivy.lang import Builder
 
@@ -76,7 +76,7 @@ Usage
 import os
 import struct
 from io import BytesIO
-from typing import List, None, Union
+from typing import List, Union
 
 from kivy.clock import Clock
 from kivy.core.image import Image as CoreImage
@@ -474,9 +474,7 @@ class MDColorPicker(BaseDialog):
         )
         Clock.schedule_once(lambda x: self.on_type_color(self), 1)
 
-    def update_color_slider_item_bottom_navigation(
-        self, color: list
-    ) -> None:
+    def update_color_slider_item_bottom_navigation(self, color: list) -> None:
         """
         Updates the color of the slider that sets the transparency value of the
         selected color and the color of bottom navigation items.

--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -144,7 +144,7 @@ import calendar
 import datetime
 import os
 from datetime import date
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy import Logger
 from kivy.animation import Animation
@@ -446,12 +446,12 @@ class BaseDialogPicker(
         self.register_event_type("on_save")
         self.register_event_type("on_cancel")
 
-    def on_save(self, *args) -> NoReturn:
+    def on_save(self, *args) -> None:
         """Events called when the "OK" dialog box button is clicked."""
 
         self.dismiss()
 
-    def on_cancel(self, *args) -> NoReturn:
+    def on_cancel(self, *args) -> None:
         """Events called when the "CANCEL" dialog box button is clicked."""
 
         self.dismiss()
@@ -498,7 +498,7 @@ class DatePickerEnterDataField(MDTextField):
         except ValueError:
             return False
 
-    def do_backspace(self, *args) -> NoReturn:
+    def do_backspace(self, *args) -> None:
         """Prevent deleting text from the middle of a line of a text field."""
 
         self._backspace = True
@@ -551,7 +551,7 @@ class DatePickerEnterDataField(MDTextField):
                     return
             return str(value)
 
-    def on_text(self, instance_field: MDTextField, text: str) -> NoReturn:
+    def on_text(self, instance_field: MDTextField, text: str) -> None:
         if text != "" and not text.isspace() and not self._backspace:
             if len(text) <= 1 and instance_field.focus:
                 instance_field.text = text
@@ -860,14 +860,14 @@ class MDDatePicker(BaseDialogPicker):
 
     def on_device_orientation(
         self, instance_theme_manager: ThemeManager, orientation_value: str
-    ) -> NoReturn:
+    ) -> None:
         if self._input_date_dialog_open:
             if orientation_value == "portrait":
                 self._shift_dialog_height = dp(250)
             if orientation_value == "landscape":
                 self._shift_dialog_height = dp(138)
 
-    def transformation_from_dialog_select_year(self) -> NoReturn:
+    def transformation_from_dialog_select_year(self) -> None:
         self.ids.chevron_left.disabled = False
         self.ids.chevron_right.disabled = False
         self.ids._year_layout.disabled = True
@@ -890,7 +890,7 @@ class MDDatePicker(BaseDialogPicker):
             self.set_month_day(self.day)
             self._sel_day_widget.dispatch("on_release")
 
-    def transformation_to_dialog_select_year(self) -> NoReturn:
+    def transformation_to_dialog_select_year(self) -> None:
         def disabled_chevron_buttons(*args):
             self.ids.chevron_left.disabled = True
             self.ids.chevron_right.disabled = True
@@ -907,7 +907,7 @@ class MDDatePicker(BaseDialogPicker):
         self.generate_list_widgets_years()
         self.set_position_to_current_year()
 
-    def transformation_to_dialog_input_date(self) -> NoReturn:
+    def transformation_to_dialog_input_date(self) -> None:
         def set_date_to_input_field():
             if not self._enter_data_field_two:
                 # Date of current day.
@@ -987,7 +987,7 @@ class MDDatePicker(BaseDialogPicker):
 
     def transformation_from_dialog_input_date(
         self, interval: Union[int, float]
-    ) -> NoReturn:
+    ) -> None:
         self._input_date_dialog_open = False
         self.ids.label_full_date.text = self.set_text_full_date(
             self.sel_year,
@@ -1049,7 +1049,7 @@ class MDDatePicker(BaseDialogPicker):
                 self.theme_cls.device_orientation,
             )
 
-    def compare_date_range(self) -> NoReturn:
+    def compare_date_range(self) -> None:
         # TODO: Add behavior if the minimum date range exceeds the maximum
         #  date range. Use toast?
         if self.max_date <= self.min_date:
@@ -1058,7 +1058,7 @@ class MDDatePicker(BaseDialogPicker):
                 "to 'min_date' value"
             )
 
-    def update_calendar_for_date_range(self) -> NoReturn:
+    def update_calendar_for_date_range(self) -> None:
         # self.compare_date_range()
         self._date_range = self.get_date_range()
         self._calendar_layout.clear_widgets()

--- a/kivymd/uix/progressbar/progressbar.py
+++ b/kivymd/uix/progressbar/progressbar.py
@@ -133,7 +133,7 @@ Determinate
 __all__ = ("MDProgressBar",)
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -246,7 +246,7 @@ class MDProgressBar(ThemableBehavior, ProgressBar):
         super().__init__(**kwargs)
         Clock.schedule_once(self.check_size)
 
-    def check_size(self, interval: Union[int, float]) -> NoReturn:
+    def check_size(self, interval: Union[int, float]) -> None:
         if self.size == [100, 100]:
             if self.orientation == "horizontal":
                 self.size_hint_y = None
@@ -255,7 +255,7 @@ class MDProgressBar(ThemableBehavior, ProgressBar):
                 self.size_hint_x = None
                 self.width = dp(4)
 
-    def start(self) -> NoReturn:
+    def start(self) -> None:
         """Start animation."""
 
         if self.type in ("indeterminate", "determinate"):
@@ -267,17 +267,17 @@ class MDProgressBar(ThemableBehavior, ProgressBar):
                     self._create_determinate_animations()
             self.running_away()
 
-    def stop(self) -> NoReturn:
+    def stop(self) -> None:
         """Stop animation."""
 
         Animation.cancel_all(self)
         self._set_default_value(0)
 
-    def running_away(self, *args) -> NoReturn:
+    def running_away(self, *args) -> None:
         self._set_default_value(0)
         self.running_anim.start(self)
 
-    def catching_up(self, *args) -> NoReturn:
+    def catching_up(self, *args) -> None:
         if self.type == "indeterminate":
             self.reversed = True
         self.catching_anim.start(self)

--- a/kivymd/uix/refreshlayout/refreshlayout.py
+++ b/kivymd/uix/refreshlayout/refreshlayout.py
@@ -103,7 +103,7 @@ Example
 __all__ = ("MDScrollViewRefreshLayout",)
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.core.window import Window
@@ -180,7 +180,7 @@ class MDScrollViewRefreshLayout(ScrollView):
 
         return super().on_touch_up(*args)
 
-    def refresh_done(self) -> NoReturn:
+    def refresh_done(self) -> None:
         if self.refresh_spinner:
             self.refresh_spinner.hide_anim_spinner()
 
@@ -197,7 +197,7 @@ class RefreshSpinner(ThemableBehavior, FloatLayout):
     # kivymd.refreshlayout.MDScrollViewRefreshLayout object
     _refresh_layout = ObjectProperty()
 
-    def start_anim_spinner(self) -> NoReturn:
+    def start_anim_spinner(self) -> None:
         spinner = self.ids.body_spinner
         Animation(
             y=spinner.y - self.theme_cls.standard_increment * 2 + dp(10),
@@ -205,13 +205,13 @@ class RefreshSpinner(ThemableBehavior, FloatLayout):
             t="out_elastic",
         ).start(spinner)
 
-    def hide_anim_spinner(self) -> NoReturn:
+    def hide_anim_spinner(self) -> None:
         spinner = self.ids.body_spinner
         anim = Animation(y=Window.height, d=0.8, t="out_elastic")
         anim.bind(on_complete=self.set_spinner)
         anim.start(spinner)
 
-    def set_spinner(self, *args) -> NoReturn:
+    def set_spinner(self, *args) -> None:
         body_spinner = self.ids.body_spinner
         body_spinner.size = (dp(46), dp(46))
         body_spinner.y = Window.height

--- a/kivymd/uix/selection/selection.py
+++ b/kivymd/uix/selection/selection.py
@@ -254,7 +254,7 @@ Example with FitImage
 __all__ = ("MDSelectionList",)
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -352,7 +352,7 @@ class SelectionItem(ThemableBehavior, MDRelativeLayout, TouchBehavior):
         super().__init__(**kwargs)
         Clock.schedule_once(self.set_progress_round)
 
-    def set_progress_round(self, interval: Union[int, float]) -> NoReturn:
+    def set_progress_round(self, interval: Union[int, float]) -> None:
         with self.canvas.after:
             self._instance_progress_inner_circle_color = Color(
                 rgba=(0, 0, 0, 0)
@@ -392,14 +392,14 @@ class SelectionItem(ThemableBehavior, MDRelativeLayout, TouchBehavior):
                 ],
             )
 
-    def do_selected_item(self, *args) -> NoReturn:
+    def do_selected_item(self, *args) -> None:
         Animation(scale=1, d=0.2).start(self.instance_icon)
         self.selected = True
         self._progress_animation = False
         self._instance_overlay_color.rgba = self.get_overlay_color()
         self.owner.dispatch("on_selected", self)
 
-    def do_unselected_item(self) -> NoReturn:
+    def do_unselected_item(self) -> None:
         Animation(scale=0, d=0.2).start(self.instance_icon)
         self.selected = False
         self._instance_overlay_color.rgba = self.get_overlay_color()
@@ -407,7 +407,7 @@ class SelectionItem(ThemableBehavior, MDRelativeLayout, TouchBehavior):
 
     def do_animation_progress_line(
         self, animation: Animation, instance_selection_item, value: float
-    ) -> NoReturn:
+    ) -> None:
         self._instance_progress_inner_outer_line.circle = (
             self.center_x,
             self.center_y,
@@ -416,11 +416,11 @@ class SelectionItem(ThemableBehavior, MDRelativeLayout, TouchBehavior):
             360 * value,
         )
 
-    def update_overlay_rounded_rec(self, *args) -> NoReturn:
+    def update_overlay_rounded_rec(self, *args) -> None:
         self._instance_overlay_rounded_rec.size = self.size
         self._instance_overlay_rounded_rec.pos = self.pos
 
-    def update_progress_inner_circle_ellipse(self, *args) -> NoReturn:
+    def update_progress_inner_circle_ellipse(self, *args) -> None:
         self._instance_progress_inner_circle_ellipse.size = (
             self.get_progress_round_size()
         )
@@ -428,7 +428,7 @@ class SelectionItem(ThemableBehavior, MDRelativeLayout, TouchBehavior):
             self.get_progress_round_pos()
         )
 
-    def reset_progress_animation(self) -> NoReturn:
+    def reset_progress_animation(self) -> None:
         Animation.cancel_all(self)
         self._progress_animation = False
         self._instance_progress_inner_circle_color.rgba = (0, 0, 0, 0)
@@ -468,7 +468,7 @@ class SelectionItem(ThemableBehavior, MDRelativeLayout, TouchBehavior):
             else self.progress_round_color[:-1] + [0.5]
         )
 
-    def on_long_touch(self, *args) -> NoReturn:
+    def on_long_touch(self, *args) -> None:
         if not self.owner.get_selected():
             self._touch_long = True
             self._progress_animation = True
@@ -488,15 +488,13 @@ class SelectionItem(ThemableBehavior, MDRelativeLayout, TouchBehavior):
                     self.do_selected_item()
         return super().on_touch_down(touch)
 
-    def on__touch_long(
-        self, instance_selection_tem, touch_value: bool
-    ) -> NoReturn:
+    def on__touch_long(self, instance_selection_tem, touch_value: bool) -> None:
         if not touch_value:
             self.reset_progress_animation()
 
     def on__progress_animation(
         self, instance_selection_tem, touch_value: bool
-    ) -> NoReturn:
+    ) -> None:
         if touch_value:
             anim = Animation(_progress_line_end=360, d=1, t="in_out_quad")
             anim.bind(
@@ -645,12 +643,12 @@ class MDSelectionList(MDList):
                 selected_list_items.append(item)
         return selected_list_items
 
-    def unselected_all(self) -> NoReturn:
+    def unselected_all(self) -> None:
         for item in self.children:
             item.do_unselected_item()
         self.selected_mode = False
 
-    def selected_all(self) -> NoReturn:
+    def selected_all(self) -> None:
         for item in self.children:
             item.do_selected_item()
         self.selected_mode = True

--- a/kivymd/uix/sliverappbar/sliverappbar.py
+++ b/kivymd/uix/sliverappbar/sliverappbar.py
@@ -118,7 +118,7 @@ Example
 __all__ = ("MDSliverAppbar", "MDSliverAppbarHeader", "MDSliverAppbarContent")
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.clock import Clock
 from kivy.core.window import Window
@@ -161,7 +161,7 @@ class MDSliverAppbarContent(ThemableBehavior, MDBoxLayout):
         super().__init__(**kwargs)
         Clock.schedule_once(self.set_bg_color)
 
-    def set_bg_color(self, interval: Union[int, float]) -> NoReturn:
+    def set_bg_color(self, interval: Union[int, float]) -> None:
         if self.md_bg_color == [0, 0, 0, 0]:
             self.md_bg_color = self.theme_cls.bg_normal
 
@@ -407,13 +407,13 @@ class MDSliverAppbar(ThemableBehavior, MDBoxLayout):
 
     def on_background_color(
         self, instance_sliver_appbar, color_value: list
-    ) -> NoReturn:
+    ) -> None:
         if self.toolbar_cls:
             self.toolbar_cls.md_bg_color = color_value
 
     def on_toolbar_cls(
         self, instance_sliver_appbar, instance_toolbar_cls: MDToolbar
-    ) -> NoReturn:
+    ) -> None:
         """Called when a value is set to the :attr:`toolbar_cls` parameter."""
 
         # If an MDToolbar object is already in use, delete it
@@ -432,7 +432,7 @@ class MDSliverAppbar(ThemableBehavior, MDBoxLayout):
                 "`kivymd.uix.toolbar.MDToolbar class`"
             )
 
-    def on_vbar(self) -> NoReturn:
+    def on_vbar(self) -> None:
         if not self.background_color:
             self.background_color = self.theme_cls.primary_color
 
@@ -480,7 +480,7 @@ class MDSliverAppbar(ThemableBehavior, MDBoxLayout):
         else:
             super().add_widget(widget, index=index, canvas=canvas)
 
-    def _set_radius(self, instance: MDSliverAppbarContent) -> NoReturn:
+    def _set_radius(self, instance: MDSliverAppbarContent) -> None:
         instance.radius = self.radius
 
     def _get_direction_swipe(self, current_percent: float) -> str:

--- a/kivymd/uix/spinner/spinner.py
+++ b/kivymd/uix/spinner/spinner.py
@@ -110,7 +110,7 @@ Determinate mode
 __all__ = ("MDSpinner",)
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -234,10 +234,10 @@ class MDSpinner(ThemableBehavior, Widget):
                     self._palette = iter(self.palette)
                     Animation(color=next(self._palette), duration=2).start(self)
 
-    def on_palette(self, instance_spinner, palette_list: list) -> NoReturn:
+    def on_palette(self, instance_spinner, palette_list: list) -> None:
         self._palette = iter(palette_list)
 
-    def on_active(self, instance_spinner, active_value: bool) -> NoReturn:
+    def on_active(self, instance_spinner, active_value: bool) -> None:
         self._reset()
         if self.active:
             self.check_determinate()
@@ -248,7 +248,7 @@ class MDSpinner(ThemableBehavior, Widget):
         `determinate = True` mode.
         """
 
-    def check_determinate(self, interval: Union[float, int] = 0) -> NoReturn:
+    def check_determinate(self, interval: Union[float, int] = 0) -> None:
         if self.active:
             if self.determinate:
                 self._start_determinate()

--- a/kivymd/uix/tab/tab.py
+++ b/kivymd/uix/tab/tab.py
@@ -498,7 +498,7 @@ Switching the tab by name
 __all__ = ("MDTabs", "MDTabsBase")
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.clock import Clock
 from kivy.graphics.texture import Texture
@@ -563,13 +563,13 @@ class MDTabsLabel(ToggleButtonBehavior, RectangularRippleBehavior, MDLabel):
             text=self._update_text_size,
         )
 
-    def on_release(self) -> NoReturn:
+    def on_release(self) -> None:
         self.tab_bar.parent.dispatch("on_tab_switch", self.tab, self, self.text)
         # If the label is selected load the relative tab from carousel.
         if self.state == "down":
             self.tab_bar.parent.carousel.load_slide(self.tab)
 
-    def on_texture(self, instance_tabs_label, texture: Texture) -> NoReturn:
+    def on_texture(self, instance_tabs_label, texture: Texture) -> None:
         # Just save the minimum width of the label based of the content.
         if texture:
             max_width = dp(360)
@@ -768,10 +768,10 @@ class MDTabsBase(Widget):
         self.tab_label.padding = dp(16), 0
         self.update_label_text(None, self.tab_label_text)
 
-    def update_label_text(self, instance_user_tab, text_tab: str) -> NoReturn:
+    def update_label_text(self, instance_user_tab, text_tab: str) -> None:
         self.tab_label.text = self.text = self.tab_label_text
 
-    def on_text(self, instance_user_tab, text_tab: str) -> NoReturn:
+    def on_text(self, instance_user_tab, text_tab: str) -> None:
         self.tab_label_text = self.text
 
 
@@ -846,7 +846,7 @@ class MDTabsScrollView(ScrollView):
 
     def goto(
         self, scroll_x: Union[float, None], scroll_y: Union[float, None]
-    ) -> NoReturn:
+    ) -> None:
         """Update event value along with scroll_*."""
 
         def _update(e, x):
@@ -913,7 +913,7 @@ class MDTabsBar(
 
     def update_indicator(
         self, x: Union[float, int], w: Union[float, int], radius=None
-    ) -> NoReturn:
+    ) -> None:
         # Update position and size of the indicator.
         if self.parent.tab_indicator_type == "line-round":
             self.parent._line_x = x
@@ -1224,7 +1224,7 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         self,
         instance_theme_manager: ThemeManager,
         name_theme_style_name_palette: str,
-    ) -> NoReturn:
+    ) -> None:
         """
         Called when the app's color scheme or style has changed
         (dark theme/light theme).
@@ -1384,12 +1384,12 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
         title_label = None
         widget = None
 
-    def on_slide_progress(self, *args) -> NoReturn:
+    def on_slide_progress(self, *args) -> None:
         """
         This event is deployed every available frame while the tab is scrolling.
         """
 
-    def on_carousel_index(self, instance_tabs_carousel, index: int) -> NoReturn:
+    def on_carousel_index(self, instance_tabs_carousel, index: int) -> None:
         """
         Called when the Tab index have changed.
 
@@ -1449,16 +1449,16 @@ class MDTabs(ThemableBehavior, SpecificBackgroundColorBehavior, AnchorLayout):
                     current_tab_label.x, current_tab_label.width
                 )
 
-    def on_ref_press(self, *args) -> NoReturn:
+    def on_ref_press(self, *args) -> None:
         """
         This event will be launched every time the user press a markup enabled
         label with a link or reference inside.
         """
 
-    def on_tab_switch(self, *args) -> NoReturn:
+    def on_tab_switch(self, *args) -> None:
         """This event is launched every time the current tab is changed."""
 
-    def on_size(self, instance_tab, size: list) -> NoReturn:
+    def on_size(self, instance_tab, size: list) -> None:
         """Called when the application screen is resized."""
 
         if self.carousel.current_slide:

--- a/kivymd/uix/templates/rotatewidget/rotatewidget.py
+++ b/kivymd/uix/templates/rotatewidget/rotatewidget.py
@@ -15,7 +15,7 @@ Kivy
 
 .. code-block:: python
 
-    
+
 
     from kivy.animation import Animation
     from kivy.lang import Builder
@@ -61,7 +61,7 @@ KivyMD
 
 .. code-block:: python
 
-    
+
 
     from kivy.animation import Animation
     from kivy.lang import Builder

--- a/kivymd/uix/templates/rotatewidget/rotatewidget.py
+++ b/kivymd/uix/templates/rotatewidget/rotatewidget.py
@@ -59,8 +59,6 @@ KivyMD
 
 .. code-block:: python
 
-
-
     from kivy.animation import Animation
     from kivy.lang import Builder
 

--- a/kivymd/uix/templates/rotatewidget/rotatewidget.py
+++ b/kivymd/uix/templates/rotatewidget/rotatewidget.py
@@ -15,8 +15,6 @@ Kivy
 
 .. code-block:: python
 
-
-
     from kivy.animation import Animation
     from kivy.lang import Builder
     from kivy.app import App

--- a/kivymd/uix/templates/rotatewidget/rotatewidget.py
+++ b/kivymd/uix/templates/rotatewidget/rotatewidget.py
@@ -15,7 +15,7 @@ Kivy
 
 .. code-block:: python
 
-    from typing import NoReturn
+    
 
     from kivy.animation import Animation
     from kivy.lang import Builder
@@ -50,7 +50,7 @@ Kivy
         def build(self):
             return Builder.load_string(KV)
 
-        def change_rotate(self, instance_button: Button) -> NoReturn:
+        def change_rotate(self, instance_button: Button) -> None:
             Animation(rotate_value_angle=45, d=0.3).start(instance_button)
 
 
@@ -61,7 +61,7 @@ KivyMD
 
 .. code-block:: python
 
-    from typing import NoReturn
+    
 
     from kivy.animation import Animation
     from kivy.lang import Builder
@@ -89,7 +89,7 @@ KivyMD
         def build(self):
             return Builder.load_string(KV)
 
-        def change_rotate(self, instance_button: MDRaisedButton) -> NoReturn:
+        def change_rotate(self, instance_button: MDRaisedButton) -> None:
             Animation(rotate_value_angle=45, d=0.3).start(instance_button)
 
 

--- a/kivymd/uix/templates/scalewidget/scalewidget.py
+++ b/kivymd/uix/templates/scalewidget/scalewidget.py
@@ -68,8 +68,6 @@ KivyMD
 
 .. code-block:: python
 
-
-
     from kivy.animation import Animation
     from kivy.lang import Builder
 

--- a/kivymd/uix/templates/scalewidget/scalewidget.py
+++ b/kivymd/uix/templates/scalewidget/scalewidget.py
@@ -15,7 +15,7 @@ Kivy
 
 .. code-block:: python
 
-    from typing import NoReturn
+    
 
     from kivy.animation import Animation
     from kivy.lang import Builder
@@ -54,7 +54,7 @@ Kivy
         def build(self):
             return Builder.load_string(KV)
 
-        def change_scale(self, instance_button: Button) -> NoReturn:
+        def change_scale(self, instance_button: Button) -> None:
             Animation(
                 scale_value_x=0.5,
                 scale_value_y=0.5,
@@ -70,7 +70,7 @@ KivyMD
 
 .. code-block:: python
 
-    from typing import NoReturn
+    
 
     from kivy.animation import Animation
     from kivy.lang import Builder
@@ -98,7 +98,7 @@ KivyMD
         def build(self):
             return Builder.load_string(KV)
 
-        def change_scale(self, instance_button: MDRaisedButton) -> NoReturn:
+        def change_scale(self, instance_button: MDRaisedButton) -> None:
             Animation(
                 scale_value_x=0.5,
                 scale_value_y=0.5,

--- a/kivymd/uix/templates/scalewidget/scalewidget.py
+++ b/kivymd/uix/templates/scalewidget/scalewidget.py
@@ -15,7 +15,7 @@ Kivy
 
 .. code-block:: python
 
-    
+
 
     from kivy.animation import Animation
     from kivy.lang import Builder
@@ -70,7 +70,7 @@ KivyMD
 
 .. code-block:: python
 
-    
+
 
     from kivy.animation import Animation
     from kivy.lang import Builder

--- a/kivymd/uix/templates/scalewidget/scalewidget.py
+++ b/kivymd/uix/templates/scalewidget/scalewidget.py
@@ -15,8 +15,6 @@ Kivy
 
 .. code-block:: python
 
-
-
     from kivy.animation import Animation
     from kivy.lang import Builder
     from kivy.properties import NumericProperty

--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -278,7 +278,7 @@ __all__ = ("MDTextField", "MDTextFieldRect", "MDTextFieldRound")
 
 import os
 import re
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -947,7 +947,7 @@ class MDTextField(ThemableBehavior, TextInput):
     # TODO: Is this method necessary?
     #  During testing, a quick double-click on the text box does not stop
     #  the animation of the hint text height.
-    def cancel_all_animations_on_double_click(self) -> NoReturn:
+    def cancel_all_animations_on_double_click(self) -> None:
         """
         Cancels the animations of the text field when double-clicking on the
         text field.
@@ -967,14 +967,14 @@ class MDTextField(ThemableBehavior, TextInput):
                 "_hint_text_font_size",
             )
 
-    def set_colors_to_updated(self, interval: Union[float, int]) -> NoReturn:
+    def set_colors_to_updated(self, interval: Union[float, int]) -> None:
         for attr_name in self._attr_names_to_updated.keys():
             if getattr(self, attr_name) == [0, 0, 0, 0]:
                 self._colors_to_updated.append(attr_name)
 
     def set_default_colors(
         self, interval: Union[float, int], updated: bool = False
-    ) -> NoReturn:
+    ) -> None:
         """
         Sets the default text field colors when initializing a text field
         object. Also called when the application palette changes.
@@ -1009,7 +1009,7 @@ class MDTextField(ThemableBehavior, TextInput):
         self._line_color_normal = self.line_color_normal
         self._line_color_focus = self.line_color_focus
 
-    def set_notch_rectangle(self, joining: bool = False) -> NoReturn:
+    def set_notch_rectangle(self, joining: bool = False) -> None:
         """
         Animates a notch for the hint text in the rectangle of the text field
         of type `rectangle`.
@@ -1031,7 +1031,7 @@ class MDTextField(ThemableBehavior, TextInput):
             animation.bind(on_progress=on_progress)
             animation.start(self)
 
-    def set_active_underline_width(self, width: Union[float, int]) -> NoReturn:
+    def set_active_underline_width(self, width: Union[float, int]) -> None:
         """Animates the width of the active underline line."""
 
         Animation(
@@ -1040,7 +1040,7 @@ class MDTextField(ThemableBehavior, TextInput):
             t="out_quad",
         ).start(self)
 
-    def set_static_underline_color(self, color: list) -> NoReturn:
+    def set_static_underline_color(self, color: list) -> None:
         """Animates the color of a static underline line."""
 
         Animation(
@@ -1049,47 +1049,47 @@ class MDTextField(ThemableBehavior, TextInput):
             t="out_quad",
         ).start(self)
 
-    def set_active_underline_color(self, color: list) -> NoReturn:
+    def set_active_underline_color(self, color: list) -> None:
         """Animates the fill color for 'fill' mode."""
 
         Animation(_line_color_focus=color, duration=0.2, t="out_quad").start(
             self
         )
 
-    def set_fill_color(self, color: list) -> NoReturn:
+    def set_fill_color(self, color: list) -> None:
         """Animates the color of the hint text."""
 
         Animation(_fill_color=color, duration=0.2, t="out_quad").start(self)
 
-    def set_helper_text_color(self, color: list) -> NoReturn:
+    def set_helper_text_color(self, color: list) -> None:
         """Animates the color of the hint text."""
 
         Animation(_helper_text_color=color, duration=0.2, t="out_quad").start(
             self
         )
 
-    def set_max_length_text_color(self, color: list) -> NoReturn:
+    def set_max_length_text_color(self, color: list) -> None:
         """Animates the color of the max length text."""
 
         Animation(
             _max_length_text_color=color, duration=0.2, t="out_quad"
         ).start(self)
 
-    def set_icon_right_color(self, color: list) -> NoReturn:
+    def set_icon_right_color(self, color: list) -> None:
         """Animates the color of the icon right."""
 
         Animation(_icon_right_color=color, duration=0.2, t="out_quad").start(
             self
         )
 
-    def set_icon_left_color(self, color: list) -> NoReturn:
+    def set_icon_left_color(self, color: list) -> None:
         """Animates the color of the icon left."""
 
         Animation(_icon_left_color=color, duration=0.2, t="out_quad").start(
             self
         )
 
-    def set_hint_text_color(self, focus: bool, error: bool = False) -> NoReturn:
+    def set_hint_text_color(self, focus: bool, error: bool = False) -> None:
         """Animates the color of the hint text."""
 
         if self.mode != "round":
@@ -1105,7 +1105,7 @@ class MDTextField(ThemableBehavior, TextInput):
                 t="out_quad",
             ).start(self)
 
-    def set_pos_hint_text(self, y: float, x: float = 0) -> NoReturn:
+    def set_pos_hint_text(self, y: float, x: float = 0) -> None:
         """Animates the x-axis width and y-axis height of the hint text."""
 
         if self.mode != "round":
@@ -1129,7 +1129,7 @@ class MDTextField(ThemableBehavior, TextInput):
                     t="out_quad",
                 ).start(self)
 
-    def set_hint_text_font_size(self, font_size: float) -> NoReturn:
+    def set_hint_text_font_size(self, font_size: float) -> None:
         """Animates the font size of the hint text."""
 
         if self.mode != "round":
@@ -1137,7 +1137,7 @@ class MDTextField(ThemableBehavior, TextInput):
                 _hint_text_font_size=font_size, duration=0.2, t="out_quad"
             ).start(self)
 
-    def set_max_text_length(self) -> NoReturn:
+    def set_max_text_length(self) -> None:
         """Called when text is entered into a text field."""
 
         if self.max_text_length:
@@ -1145,10 +1145,10 @@ class MDTextField(ThemableBehavior, TextInput):
                 f"{len(self.text)}/{self.max_text_length}"
             )
 
-    def check_text(self, interval: Union[float, int]) -> NoReturn:
+    def check_text(self, interval: Union[float, int]) -> None:
         self.set_text(self, self.text)
 
-    def set_text(self, instance_text_field, text: str) -> NoReturn:
+    def set_text(self, instance_text_field, text: str) -> None:
         """Called when text is entered into a text field."""
 
         self.text = re.sub("\n", " ", text) if not self.multiline else text
@@ -1184,7 +1184,7 @@ class MDTextField(ThemableBehavior, TextInput):
         if self.mode == "round" and not self.text:
             self.hint_text = self.__hint_text
 
-    def set_objects_labels(self) -> NoReturn:
+    def set_objects_labels(self) -> None:
         """
         Creates labels objects for the parameters`helper_text`,`hint_text`,
         etc.
@@ -1210,10 +1210,10 @@ class MDTextField(ThemableBehavior, TextInput):
         self._icon_right_label = MDIcon(theme_text_color="Custom")
         self._icon_left_label = MDIcon(theme_text_color="Custom")
 
-    def on_helper_text(self, instance_text_field, helper_text: str) -> NoReturn:
+    def on_helper_text(self, instance_text_field, helper_text: str) -> None:
         self._helper_text_label.text = helper_text
 
-    def on_focus(self, instance_text_field, focus: bool) -> NoReturn:
+    def on_focus(self, instance_text_field, focus: bool) -> None:
         # TODO: See `cancel_all_animations_on_double_click` method.
         # self.cancel_all_animations_on_double_click()
 
@@ -1287,18 +1287,16 @@ class MDTextField(ThemableBehavior, TextInput):
             else:
                 self.set_static_underline_color(self.line_color_normal)
 
-    def on_icon_left(self, instance_text_field, icon_name: str) -> NoReturn:
+    def on_icon_left(self, instance_text_field, icon_name: str) -> None:
         self._icon_left_label.icon = icon_name
 
-    def on_icon_right(self, instance_text_field, icon_name: str) -> NoReturn:
+    def on_icon_right(self, instance_text_field, icon_name: str) -> None:
         self._icon_right_label.icon = icon_name
 
-    def on_disabled(
-        self, instance_text_field, disabled_value: bool
-    ) -> NoReturn:
+    def on_disabled(self, instance_text_field, disabled_value: bool) -> None:
         pass
 
-    def on_error(self, instance_text_field, error: bool) -> NoReturn:
+    def on_error(self, instance_text_field, error: bool) -> None:
         """
         Changes the primary colors of the text box to match the `error` value
         (text field is in an error state or not).
@@ -1333,19 +1331,19 @@ class MDTextField(ThemableBehavior, TextInput):
             elif self.helper_text_mode == "persistent":
                 self.set_helper_text_color(self.helper_text_color_normal)
 
-    def on_hint_text(self, instance_text_field, hint_text: str) -> NoReturn:
+    def on_hint_text(self, instance_text_field, hint_text: str) -> None:
         if hint_text:
             self.__hint_text = hint_text
         self._hint_text_label.text = hint_text
         self._hint_text_label.font_size = sp(16)
 
-    def on_width(self, instance_text_field, width: float) -> NoReturn:
+    def on_width(self, instance_text_field, width: float) -> None:
         """Called when the application window is resized."""
 
         if self.focus:
             self._underline_width = self.width
 
-    def on_height(self, instance_text_field, value_height: float) -> NoReturn:
+    def on_height(self, instance_text_field, value_height: float) -> None:
         if value_height >= self.max_height and self.max_height:
             self.height = self.max_height
 
@@ -1367,14 +1365,12 @@ class MDTextField(ThemableBehavior, TextInput):
     def on_max_length_text_color(self, instance_text_field, color: list):
         self._max_length_text_color = color
 
-    def _set_color(self, attr_name: str, color: str, updated: bool) -> NoReturn:
+    def _set_color(self, attr_name: str, color: str, updated: bool) -> None:
         if attr_name in self._colors_to_updated or updated:
             if attr_name in self._colors_to_updated:
                 setattr(self, attr_name, color)
 
-    def _set_attr_names_to_updated(
-        self, interval: Union[float, int]
-    ) -> NoReturn:
+    def _set_attr_names_to_updated(self, interval: Union[float, int]) -> None:
         """
         Sets and update the default color dictionary for text field textures.
         """

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -330,7 +330,7 @@ __all__ = ("MDToolbar", "MDBottomAppBar", "MDActionTopAppBarButton")
 
 import os
 from math import cos, radians, sin
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -726,14 +726,14 @@ class MDToolbar(NotchedBox):
         )
         Clock.schedule_once(self.update_floating_radius)
 
-    def set_headline_font_style(self, interval: Union[int, float]) -> NoReturn:
+    def set_headline_font_style(self, interval: Union[int, float]) -> None:
         if self.type_height in ("medium", "large"):
             self.ids.label_headline.font_style = {
                 "medium": "H6",
                 "large": "H5",
             }[self.type_height]
 
-    def on_type(self, instance_toolbar, type_value: str) -> NoReturn:
+    def on_type(self, instance_toolbar, type_value: str) -> None:
         if type_value == "bottom":
             self.action_button.bind(center_x=self.setter("notch_center_x"))
             self.action_button.bind(
@@ -749,9 +749,7 @@ class MDToolbar(NotchedBox):
             )
             self.on_mode(None, self.mode)
 
-    def on_type_height(
-        self, instance_toolbar, height_type_value: str
-    ) -> NoReturn:
+    def on_type_height(self, instance_toolbar, height_type_value: str) -> None:
         if self.theme_cls.material_style == "M2":
             self.height = self.theme_cls.standard_increment
         else:
@@ -769,15 +767,13 @@ class MDToolbar(NotchedBox):
     def on_action_button(self, *args):
         pass
 
-    def on_md_bg_color(self, instance_toolbar, color_value: list) -> NoReturn:
+    def on_md_bg_color(self, instance_toolbar, color_value: list) -> None:
         if self.type == "bottom":
             self.md_bg_color = [0, 0, 0, 0]
         else:
             set_bars_colors(color_value, None, self.theme_cls.theme_style)
 
-    def on_left_action_items(
-        self, instance_toolbar, items_value: list
-    ) -> NoReturn:
+    def on_left_action_items(self, instance_toolbar, items_value: list) -> None:
         def on_left_action_items(interval: Union[int, float]):
             self.update_action_bar(self.ids.left_actions, items_value)
 
@@ -785,30 +781,30 @@ class MDToolbar(NotchedBox):
 
     def on_right_action_items(
         self, instance_toolbar, items_value: list
-    ) -> NoReturn:
+    ) -> None:
         def on_right_actions(interval: Union[int, float]):
             self.update_action_bar(self.ids.right_actions, items_value)
 
         Clock.schedule_once(on_right_actions)
 
-    def on_icon(self, instance_toolbar, icon_name: str) -> NoReturn:
+    def on_icon(self, instance_toolbar, icon_name: str) -> None:
         self.action_button.icon = icon_name
 
-    def on_icon_color(self, instance, icon_name: str) -> NoReturn:
+    def on_icon_color(self, instance, icon_name: str) -> None:
         self.action_button.md_bg_color = icon_name
 
     def on_md_bg_bottom_color(
         self, instance_toolbar, color_value: list
-    ) -> NoReturn:
+    ) -> None:
         set_bars_colors(None, color_value, self.theme_cls.theme_style)
 
-    def on_anchor_title(self, instance_toolbar, anchor_value: str) -> NoReturn:
+    def on_anchor_title(self, instance_toolbar, anchor_value: str) -> None:
         def on_anchor_title(interval: Union[int, float]):
             self.ids.label_title.halign = anchor_value
 
         Clock.schedule_once(on_anchor_title)
 
-    def on_mode(self, instance_toolbar, mode_value: str) -> NoReturn:
+    def on_mode(self, instance_toolbar, mode_value: str) -> None:
         if self.type == "top":
             return
 
@@ -854,27 +850,27 @@ class MDToolbar(NotchedBox):
 
         Clock.schedule_once(on_mode)
 
-    def set_md_bg_color(self, instance_toolbar, color_value: list) -> NoReturn:
+    def set_md_bg_color(self, instance_toolbar, color_value: list) -> None:
         if color_value == [1.0, 1.0, 1.0, 0.0]:
             self.md_bg_color = self.theme_cls.primary_color
 
-    def set_notch(self) -> NoReturn:
+    def set_notch(self) -> None:
         anim = Animation(d=0.1) + Animation(
             notch_radius=self.action_button.width / 2 + dp(8),
             d=0.1,
         )
         anim.start(self)
 
-    def set_shadow(self, *args) -> NoReturn:
+    def set_shadow(self, *args) -> None:
         self.action_button._elevation = self.action_button.elevation
 
     def update_bar_height(
         self, instance_theme_manager, material_style_value: str
-    ) -> NoReturn:
+    ) -> None:
         self.on_type_height(self, self.type_height)
         self.update_anchor_title(material_style_value)
 
-    def update_floating_radius(self, interval: Union[int, float]) -> NoReturn:
+    def update_floating_radius(self, interval: Union[int, float]) -> None:
         self.action_button.radius = self.action_button.width / 2
 
     def update_anchor_title(self, material_style_value: str) -> str:
@@ -889,7 +885,7 @@ class MDToolbar(NotchedBox):
 
     def update_action_bar(
         self, instance_box_layout, action_bar_items: list
-    ) -> NoReturn:
+    ) -> None:
         instance_box_layout.clear_widgets()
         new_width = 0
         for item in action_bar_items:
@@ -917,26 +913,26 @@ class MDToolbar(NotchedBox):
             )
         instance_box_layout.width = new_width
 
-    def update_md_bg_color(self, *args) -> NoReturn:
+    def update_md_bg_color(self, *args) -> None:
         self.md_bg_color = self.theme_cls._get_primary_color()
 
     def update_opposite_colors(
         self, instance_toolbar, opposite_value: bool
-    ) -> NoReturn:
+    ) -> None:
         if opposite_value:
             self.ids.label_title.theme_text_color = ""
 
-    def update_action_bar_text_colors(self, *args) -> NoReturn:
+    def update_action_bar_text_colors(self, *args) -> None:
         for child in self.ids["left_actions"].children:
             child.text_color = self.specific_text_color
         for child in self.ids["right_actions"].children:
             child.text_color = self.specific_text_color
 
-    def remove_notch(self) -> NoReturn:
+    def remove_notch(self) -> None:
         anim = Animation(d=0.1) + Animation(notch_radius=0, d=0.1)
         anim.start(self)
 
-    def remove_shadow(self) -> NoReturn:
+    def remove_shadow(self) -> None:
         self.action_button._elevation = 0
 
     def _on_resize(self, instance, width, height):

--- a/kivymd/uix/tooltip/tooltip.py
+++ b/kivymd/uix/tooltip/tooltip.py
@@ -67,7 +67,7 @@ In Python code:
 __all__ = ("MDTooltip", "MDTooltipViewClass")
 
 import os
-from typing import NoReturn, Union
+from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -198,7 +198,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
                 y = Window.height - (self._tooltip.height + dp(10))
         return x, y
 
-    def display_tooltip(self, interval: Union[int, float]) -> NoReturn:
+    def display_tooltip(self, interval: Union[int, float]) -> None:
         if not self._tooltip:
             return
         Window.add_widget(self._tooltip)
@@ -220,7 +220,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         else:
             Clock.schedule_once(self.animation_tooltip_show, 0)
 
-    def animation_tooltip_show(self, interval: Union[int, float]) -> NoReturn:
+    def animation_tooltip_show(self, interval: Union[int, float]) -> None:
         """Animation of opening tooltip on the screen."""
 
         if self._tooltip:
@@ -230,9 +230,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
             ).start(self._tooltip)
             self.dispatch("on_show")
 
-    def animation_tooltip_dismiss(
-        self, interval: Union[int, float]
-    ) -> NoReturn:
+    def animation_tooltip_dismiss(self, interval: Union[int, float]) -> None:
         """
         .. versionadded:: 1.0.0
 
@@ -246,16 +244,16 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
             anim.bind(on_complete=self._on_dismiss_anim_complete)
             anim.start(self._tooltip)
 
-    def remove_tooltip(self, *args) -> NoReturn:
+    def remove_tooltip(self, *args) -> None:
         """Removes the tooltip widget from the screen."""
 
         Window.remove_widget(self._tooltip)
 
-    def on_long_touch(self, touch, *args) -> NoReturn:
+    def on_long_touch(self, touch, *args) -> None:
         if DEVICE_TYPE != "desktop":
             self.on_enter(True)
 
-    def on_enter(self, *args) -> NoReturn:
+    def on_enter(self, *args) -> None:
         """
         See
         :attr:`~kivymd.uix.behaviors.hover_behavior.HoverBehavior.on_enter`
@@ -274,7 +272,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
                 )
                 Clock.schedule_once(self.display_tooltip, -1)
 
-    def on_leave(self) -> NoReturn:
+    def on_leave(self) -> None:
         """
         See
         :attr:`~kivymd.uix.behaviors.hover_behavior.HoverBehavior.on_leave`
@@ -285,10 +283,10 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         if self._tooltip:
             Clock.schedule_once(self.animation_tooltip_dismiss)
 
-    def on_show(self) -> NoReturn:
+    def on_show(self) -> None:
         """Default dismiss event handler."""
 
-    def on_dismiss(self) -> NoReturn:
+    def on_dismiss(self) -> None:
         """
         .. versionadded:: 1.0.0
 

--- a/kivymd/uix/transition/transition.py
+++ b/kivymd/uix/transition/transition.py
@@ -30,7 +30,6 @@ You have multiple transitions available by default, such as:
 
 __all__ = ("MDFadeSlideTransition",)
 
-from typing import NoReturn
 
 from kivy.animation import Animation, AnimationTransition
 from kivy.uix.screenmanager import (
@@ -43,7 +42,7 @@ from kivy.uix.screenmanager import (
 class MDFadeSlideTransition(SlideTransition):
     _direction = "up"
 
-    def start(self, instance_screen_manager: ScreenManager) -> NoReturn:
+    def start(self, instance_screen_manager: ScreenManager) -> None:
         """
         Starts the transition. This is automatically called by the
         :class:`ScreenManager`.
@@ -76,7 +75,7 @@ class MDFadeSlideTransition(SlideTransition):
             self.screen_in.y = 0
             self.screen_in.opacity = 0
 
-    def on_progress(self, progression: float) -> NoReturn:
+    def on_progress(self, progression: float) -> None:
         progression = AnimationTransition.out_quad(progression)
 
         if self._direction == "up":
@@ -90,7 +89,7 @@ class MDFadeSlideTransition(SlideTransition):
             )
             self.screen_out.opacity = 1 - progression
 
-    def on_complete(self) -> NoReturn:
+    def on_complete(self) -> None:
         if self._direction == "down":
             self._direction = "up"
         else:

--- a/kivymd/uix/transition/transition.py
+++ b/kivymd/uix/transition/transition.py
@@ -30,7 +30,6 @@ You have multiple transitions available by default, such as:
 
 __all__ = ("MDFadeSlideTransition",)
 
-
 from kivy.animation import Animation, AnimationTransition
 from kivy.uix.screenmanager import (
     ScreenManager,


### PR DESCRIPTION
### Description of the problem

In a lot of the type hinted functions, the return type hint "NoReturn" was wrongly used.
It's supposed to be used with functions that (under all conditions) _do not_ return.
Example for a NoReturn function:
```python
def stop() -> NoReturn:
    raise RuntimeError()
```

### Reproducing the problem

An Example of where it was used wrongly:
```python
def set_active_underline_width(self, width: Union[float, int]) -> NoReturn:
    """Animates the width of the active underline line."""

    Animation( _underline_width=width, duration=(0.2 if self.line_anim else 0), t="out_quad" ).start(self)
```
[Animation(...).start() always returns None] 

### Description of Changes

Every occasion of NoReturn was checked and changed to None, as all of them were wrong.
