### PR TITLE
Added `reset_focus_on_text_empty` to `MDTextField` class

### DIFF
--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -882,7 +882,7 @@ class MDTextField(ThemableBehavior, TextInput):
     """
     Is the text field unfocused if there are no characters in it.
     :attr:`reset_focus_on_text_empty` is an :class:`~kivy.properties.BooleanProperty`
-    and defaults to `False`.
+    and defaults to `True`.
     """
 
     # The x-axis position of the hint text in the text field.

--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -878,6 +878,13 @@ class MDTextField(ThemableBehavior, TextInput):
     and defaults to `'Roboto'`.
     """
 
+    reset_focus_on_text_empty = BooleanProperty(True)
+    """
+    Is the text field unfocused if there are no characters in it.
+    :attr:`reset_focus_on_text_empty` is an :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
+
     # The x-axis position of the hint text in the text field.
     _hint_x = NumericProperty(0)
     # The y-axis position of the hint text in the text field.
@@ -1175,7 +1182,7 @@ class MDTextField(ThemableBehavior, TextInput):
             if self.mode == "rectangle":
                 self.set_notch_rectangle()
 
-        if not self.text:
+        if not self.text and self.reset_focus_on_text_empty:
             self.on_focus(instance_text_field, False)
             self.focus = False
 


### PR DESCRIPTION
Added the ability to leave the text field active if all text is deleted. This can be useful when entering a password (if the user made a mistake and clamped the backspace) and in many other cases.


```python
from kivy.lang import Builder

from kivymd.app import MDApp

KV = '''
BoxLayout:
    padding: "10dp"
    orientation: 'vertical'

    MDTextField:
        hint_text: "Text field with `reset_focus_on_text_empty=True`"
        
    MDTextField:
        hint_text: "Text field with `reset_focus_on_text_empty=False`"
        reset_focus_on_text_empty: False
'''


class Test(MDApp):

    def build(self):
        return Builder.load_string(KV)


Test().run()
```


https://user-images.githubusercontent.com/40869738/159114621-332fcc54-6cab-4b5e-a9bb-dba8a1210d5e.mp4

