### PR TITLE
Fixed the display of the `gradient` icon in the `MDColorPicker` class

### DIFF
--- a/kivymd/uix/pickers/colorpicker/colorpicker.kv
+++ b/kivymd/uix/pickers/colorpicker/colorpicker.kv
@@ -255,7 +255,7 @@
             MDBottomNavigationItem:
                 id: bottom_navigation_gradient
                 name: "bottom navigation gradient"
-                icon: "gradient"
+                icon: "gradient-vertical"
 
             MDBottomNavigationItem:
                 id: view_headline


### PR DESCRIPTION
Icons called *gradient* do not exist, there is only *gradient-vertical*
![2022-03-19_13-14-37](https://user-images.githubusercontent.com/40869738/159117127-becdcf11-623c-4a83-98e8-e7c22b2d68b6.png)
![2022-03-19_13-14-15](https://user-images.githubusercontent.com/40869738/159117131-b342b8e6-4397-47ea-bdb4-52ac8539a982.png)
![2022-03-19_13-18-13](https://user-images.githubusercontent.com/40869738/159117132-5357018a-ab62-45ac-b1b4-b0922c8c04a5.png)
