### PR TITLE
Removed forced defocusing in the `MDTextField` class in the `set_text` function

### DIFF
--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -1111,8 +1111,16 @@ class MDTextField(ThemableBehavior, TextInput):
         if self.mode != "round":
             Animation(_hint_y=y, duration=0.2, t="out_quad").start(self)
             if self.mode == "rectangle":
+                if not self.icon_left:
+                    _hint_x = x
+                else:
+                    if y == dp(10):
+                        _hint_x = dp(-16)
+                    else:
+                        _hint_x = dp(20)
+
                 Animation(
-                    _hint_x=x if not self.icon_left else dp(-16),
+                    _hint_x=_hint_x,
                     duration=0.2,
                     t="out_quad",
                 ).start(self)
@@ -1171,6 +1179,7 @@ class MDTextField(ThemableBehavior, TextInput):
                 if self.mode != "rectangle"
                 else dp(10)
             )
+
             self.set_hint_text_font_size(sp(12))
             if self.mode == "rectangle":
                 self.set_notch_rectangle()
@@ -1182,6 +1191,9 @@ class MDTextField(ThemableBehavior, TextInput):
             self.hint_text = ""
         if self.mode == "round" and not self.text:
             self.hint_text = self.__hint_text
+
+    def set_x_pos(self):
+        pass
 
     def set_objects_labels(self) -> None:
         """
@@ -1261,11 +1273,14 @@ class MDTextField(ThemableBehavior, TextInput):
             if self.mode == "rectangle" and not self.text:
                 self.set_notch_rectangle(joining=True)
             if not self.text:
-                self.set_pos_hint_text(
-                    dp(38)
-                    if not self.icon_left or self.mode == "rectangle"
-                    else (dp(34) if not self.mode == "fill" else dp(38))
-                )
+                if self.mode == "rectangle":
+                    y = dp(38)
+                elif self.mode == "fill":
+                    y = dp(46)
+                else:
+                    y = dp(34)
+
+                self.set_pos_hint_text(y)
                 self.set_hint_text_font_size(sp(16))
             if self.icon_right:
                 self.set_icon_right_color(self.icon_right_color_normal)

--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -1184,7 +1184,7 @@ class MDTextField(ThemableBehavior, TextInput):
             if self.mode == "rectangle":
                 self.set_notch_rectangle()
 
-        if not self.text:
+        if not self.text and not self.focus:
             self.on_focus(instance_text_field, False)
 
         if self.mode == "round" and self.text:

--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -1177,7 +1177,6 @@ class MDTextField(ThemableBehavior, TextInput):
 
         if not self.text:
             self.on_focus(instance_text_field, False)
-            self.focus = False
 
         if self.mode == "round" and self.text:
             self.hint_text = ""


### PR DESCRIPTION
The forced defocusing, which was a crutch, has been removed.

Tests:
```py
from kivy.lang import Builder
from kivy.uix.textinput import TextInput
from kivy.clock import Clock

from kivymd.app import MDApp
from kivymd.utils import asynckivy

KV = """
MDScreen:
    MDBoxLayout:
        id: box
        orientation: "vertical"
        spacing: "20dp"
        adaptive_height: True
        size_hint_x: .8
        pos_hint: {"center_x": .5, "center_y": .5}

        MDTextField:
            hint_text: "Label"
            helper_text: "Error massage"
            mode: "rectangle"
            max_text_length: 5
            use_bubble: True

        MDTextField:
            icon_left: "git"
            hint_text: "Label"
            helper_text: "Error massage"
            mode: "rectangle"
            use_bubble: True

        MDTextField:
            icon_left: "git"
            hint_text: "Label"
            helper_text: "Error massage"
            mode: "fill"
            use_bubble: True

        MDTextField:
            hint_text: "Label"
            helper_text: "Error massage"
            mode: "fill"
            use_bubble: True

        MDTextField:
            hint_text: "Label"
            helper_text: "Error massage"
            use_bubble: True

        MDTextField:
            icon_left: "git"
            hint_text: "Label"
            helper_text: "Error massage"
            use_bubble: True

        MDTextField:
            hint_text: "Round mode"
            mode: "round"
            max_text_length: 15
            helper_text: "Massage"
            use_bubble: True
            
        MDRectangleFlatButton:
            text: 'Start tests'
            pos_hint: {"center_x": .5}
            on_release: app.start_tests()
            
"""


class Test(MDApp):
    def build(self):
        return Builder.load_string(KV)

    def start_tests(self):
        Clock.schedule_once(self.insert)
        Clock.schedule_once(self.cut, 1.0)
        Clock.schedule_once(self.paste, 1.5)
        Clock.schedule_once(lambda dt: asynckivy.start(self.do_backspace(dt)), 2.0)

    def insert(self, dt: float):
        for widget in self.root.ids.box.children:
            if issubclass(widget.__class__, TextInput):
                widget.insert_text('Text')

    def cut(self, dt: float):
        for widget in self.root.ids.box.children:
            if issubclass(widget.__class__, TextInput):
                widget.select_all()
                widget.cut()

    def paste(self, dt: float):
        for widget in self.root.ids.box.children:
            if issubclass(widget.__class__, TextInput):
                widget.paste()

    async def do_backspace(self, dt: float):
        for widget in self.root.ids.box.children:
            if issubclass(widget.__class__, TextInput):
                for _ in range(len(widget.text)):
                    await asynckivy.sleep(0.04)
                    widget.do_backspace(from_undo=False, mode='bkspc')


Test().run()

```

No problems were noticed during manual testing. Related to #1207 

**kivy: 2.1.0**

https://user-images.githubusercontent.com/40869738/159165835-ce2a5b88-4cee-4d1d-a337-0cd5a1e25eda.mp4


