### PR TITLE
fixed bug, MDDataTable and MDTooltip

### DIFF
--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -500,8 +500,10 @@ class TableData(RecycleView):
 
     def set_default_first_row(self, interval: Union[int, float]) -> None:
         """Set default first row as selected."""
-
-        self.ids.row_controller.select_next(self)
+        try:
+            self.ids.row_controller.select_next(self)
+        except IndexError:
+            ...
 
     def set_row_data(self) -> None:
         data = []

--- a/kivymd/uix/tooltip/tooltip.py
+++ b/kivymd/uix/tooltip/tooltip.py
@@ -200,8 +200,6 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         return x, y
 
     def display_tooltip(self, interval: Union[int, float]) -> None:
-        if not self._tooltip and not self._tooltip.parent:
-            return
         try:
             Window.add_widget(self._tooltip)
             pos = self.to_window(self.center_x, self.center_y)

--- a/kivymd/uix/tooltip/tooltip.py
+++ b/kivymd/uix/tooltip/tooltip.py
@@ -83,6 +83,7 @@ from kivy.properties import (
     StringProperty,
 )
 from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.widget import WidgetException
 
 from kivymd import uix_path
 from kivymd.font_definitions import theme_font_styles
@@ -201,25 +202,27 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
     def display_tooltip(self, interval: Union[int, float]) -> None:
         if not self._tooltip and not self._tooltip.parent:
             return
+        try:
+            Window.add_widget(self._tooltip)
+            pos = self.to_window(self.center_x, self.center_y)
+            x = pos[0] - self._tooltip.width / 2
 
-        Window.add_widget(self._tooltip)
-        pos = self.to_window(self.center_x, self.center_y)
-        x = pos[0] - self._tooltip.width / 2
+            if not self.shift_y:
+                y = pos[1] - self._tooltip.height / 2 - self.height / 2 - dp(20)
+            else:
+                y = pos[1] - self._tooltip.height / 2 - self.height + self.shift_y
 
-        if not self.shift_y:
-            y = pos[1] - self._tooltip.height / 2 - self.height / 2 - dp(20)
-        else:
-            y = pos[1] - self._tooltip.height / 2 - self.height + self.shift_y
+            x, y = self.adjust_tooltip_position(x, y)
+            self._tooltip.pos = (x, y)
 
-        x, y = self.adjust_tooltip_position(x, y)
-        self._tooltip.pos = (x, y)
-
-        if DEVICE_TYPE == "desktop":
-            Clock.schedule_once(
-                self.animation_tooltip_show, self.tooltip_display_delay
-            )
-        else:
-            Clock.schedule_once(self.animation_tooltip_show, 0)
+            if DEVICE_TYPE == "desktop":
+                Clock.schedule_once(
+                    self.animation_tooltip_show, self.tooltip_display_delay
+                )
+            else:
+                Clock.schedule_once(self.animation_tooltip_show, 0)
+        except WidgetException:
+            ...
 
     def animation_tooltip_show(self, interval: Union[int, float]) -> None:
         """Animation of opening tooltip on the screen."""


### PR DESCRIPTION
### Description of the problem

Bug when selecting a row in the table while it is created
the bug is rare but it exists after several attempts at one time it happens

### Describe the algorithm of actions that leads to the problem
hover over the table while it is being created

### Reproducing the problem
```python
self.ids.table.add_widget(
MDDataTable(
check=True,
column_data=[
        ("X", dp(30)),
        ("X", dp(20)),
        ("X", dp(20))
    ],
row_data=[['1','1','1'],['1','1','1'],['1','1','1'],['1','1','1'],['1','1','1']])
```
### Screenshots of the problem
![bug-1](https://user-images.githubusercontent.com/53744463/165639816-d8066c6f-7230-459b-b86c-aeebae5b5351.jpg)
![bug-2](https://user-images.githubusercontent.com/53744463/165639818-b5bed159-0f4d-4098-9837-f822db7c33cd.jpg)

### Description of Changes

try and except in datatable and tooltip

### Screenshots of the solution to the problem

```python
kivymd/uix/datatables/datatables.py
try:
    self.ids.row_controller.select_next(self)
except IndexError:
     ...
```
```python
kivymd/uix/tooltip/tooltip.py
try:
    Window.add_widget(self._tooltip)
    pos = self.to_window(self.center_x, self.center_y)
   [....]
except WidgetException:
    ...
```

