### PR TITLE
Properly fix https://github.com/kivymd/KivyMD/issues/1220

### DIFF
--- a/kivymd/uix/tooltip/tooltip.py
+++ b/kivymd/uix/tooltip/tooltip.py
@@ -199,7 +199,7 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         return x, y
 
     def display_tooltip(self, interval: Union[int, float]) -> None:
-        if not self._tooltip and not self._tooltip.parent:
+        if not self._tooltip or self._tooltip.parent:
             return
 
         Window.add_widget(self._tooltip)


### PR DESCRIPTION

### Description of the problem

As described in https://github.com/kivymd/KivyMD/issues/1220

@HeaTTheatR made a fix, but it did not resolve the problem, as I outlined [here](https://github.com/kivymd/KivyMD/issues/1220#issuecomment-1088140635):
> `if not self._tooltip and not self._tooltip.parent:` does not prevent the crash, as it will only return if there is no tooltip *and* the tooltip does not have a parent (meaning if there is no tooltip, you will get another crash, as None has no parent), and if there is a tooltip but it already has a parent, both conditions will be false.

### Describe the algorithm of actions that leads to the problem

As described in https://github.com/kivymd/KivyMD/issues/1220

### Reproducing the problem

As described in https://github.com/kivymd/KivyMD/issues/1220

### Screenshots of the problem

As described in https://github.com/kivymd/KivyMD/issues/1220

### Description of Changes

Changing `if not self._tooltip and not self._tooltip.parent:` to `if not self._tooltip or self._tooltip.parent:` makes the function return if there is *either* no tooltip or the tooltip already has a parent. This resolves both possible crashes in the current code, by ensuring that the function exits if it would crash by continuing.

### Code for testing new changes

Same code as used in https://github.com/kivymd/KivyMD/issues/1220
