### PR TITLE
Fixed a bug related to scaling

### DIFF
--- a/kivymd/uix/pickers/colorpicker/colorpicker.py
+++ b/kivymd/uix/pickers/colorpicker/colorpicker.py
@@ -271,7 +271,7 @@ class GradientTab(ThemableBehavior, MDBoxLayout):
                 radius=self.color_picker.radius,
                 group="gradient",
             )
-            self.bind(size=self._update_canvas)
+            self.bind(size=lambda instance, size: Clock.schedule_once(lambda dt: self._update_canvas(instance, size)))
 
     def get_rgba_color_from_touch_region(self, widget, touch) -> List[int]:
         """


### PR DESCRIPTION
When the window was sharply scaled, the canvas size did not change

```python
from typing import Union

from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.pickers import MDColorPicker

KV = '''
MDScreen:

    MDToolbar:
        id: toolbar
        title: "MDToolbar"
        pos_hint: {"top": 1}

    MDRaisedButton:
        text: "OPEN PICKER"
        pos_hint: {"center_x": .5, "center_y": .5}
        md_bg_color: toolbar.md_bg_color
        on_release: app.open_color_picker()
'''


class MyApp(MDApp):
    def build(self):
        return Builder.load_string(KV)

    def open_color_picker(self):
        color_picker = MDColorPicker(size_hint=(0.45, 0.85))
        color_picker.open()
        color_picker.bind(
            on_select_color=self.on_select_color,
            on_release=self.get_selected_color,
        )

    def update_color(self, color: list) -> None:
        self.root.ids.toolbar.md_bg_color = color

    def get_selected_color(
            self,
            instance_color_picker: MDColorPicker,
            type_color: str,
            selected_color: Union[list, str],
    ):
        '''Return selected color.'''

        print(f"Selected color is {selected_color}")
        self.update_color(selected_color[:-1] + [1])

    def on_select_color(self, instance_gradient_tab, color: list) -> None:
        '''Called when a gradient image is clicked.'''


MyApp().run()

```

https://user-images.githubusercontent.com/40869738/166140010-61751677-87b7-4896-8e9b-8d3e4a914eff.mp4


