### PR TITLE
Removed the `badge_icon` default argument in the `MDTab` class to fix a bug with a red spot on the icon

### DIFF
--- a/kivymd/uix/bottomnavigation/bottomnavigation.py
+++ b/kivymd/uix/bottomnavigation/bottomnavigation.py
@@ -357,7 +357,7 @@ class MDTab(MDScreen, ThemableBehavior):
     and defaults to `'checkbox-blank-circle'`.
     """
 
-    badge_icon = StringProperty("blank")
+    badge_icon = StringProperty()
     """
     Tab header badge icon.
 


### PR DESCRIPTION
In material design version 2 there is a bug in which a red dot is displayed on top of the icon, this is due to the fact that there is a standard designation for the `badge` icon.
```py
from kivymd.app import MDApp
from kivy.lang import Builder

KV = """
BoxLayout:
    orientation:'vertical'

    MDToolbar:
        title: 'Bottom navigation'
        md_bg_color: .2, .2, .2, 1
        specific_text_color: 1, 1, 1, 1
        right_action_items: [["switch", lambda x: app.change_style()]]

    MDBottomNavigation:
        id: btn_nav
        panel_color: .2, .2, .2, 1

        MDBottomNavigationItem:
            id: one
            name: 'screen 1'
            text: 'Python'
            icon: 'language-python'

            MDLabel:
                text: 'Python'
                halign: 'center'

        MDBottomNavigationItem:
            id: two
            name: 'screen 2'
            text: 'C++'
            icon: 'language-cpp'

            MDLabel:
                text: 'I programming of C++'
                halign: 'center'

        MDBottomNavigationItem:
            id: three
            name: 'screen 3'
            text: 'JS'
            icon: 'language-javascript'

            MDLabel:
                text: 'JS'
                halign: 'center'

"""


class Test(MDApp):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.theme_cls.primary_palette = "Gray"

    def build(self):
        return Builder.load_string(KV)

    def change_style(self):
        if self.theme_cls.material_style == 'M2':
            self.theme_cls.material_style = 'M3'
            icons = [self.root.ids.one.icon, self.root.ids.two.icon, self.root.ids.three.icon]
        else:
            self.theme_cls.material_style = 'M2'
            icons = ['', '', '']

        self.root.ids.one.badge_icon = icons[0]
        self.root.ids.two.badge_icon = icons[1]
        self.root.ids.three.badge_icon = icons[2]


Test().run()
```

https://user-images.githubusercontent.com/40869738/167295750-9645a164-e60a-4f89-b525-1d9f22bb588e.mp4


