### PR TITLE
Fix #1226: MDTimePicker._set_am_pm(): set am_pm to "am" or "pm"

### DIFF
--- a/kivymd/uix/pickers/timepicker/timepicker.py
+++ b/kivymd/uix/pickers/timepicker/timepicker.py
@@ -630,7 +630,9 @@ class MDTimePicker(BaseDialogPicker):
     def _get_am_pm(self, selected):
         self.am_pm = selected
 
-    def _set_am_pm(self, selected):
+    def _set_am_pm(self, selected: str) -> None:
+        """Used by set_time() to manually set the mode to "am" or "pm"."""
+        self.am_pm = selected
         self._am_pm_selector.mode = self.am_pm
         self._am_pm_selector.selected = self.am_pm
 


### PR DESCRIPTION
### Description of the problem

#1226

### Describe the algorithm of actions that leads to the problem

To manually set `MDTimePicker` time dialog with a specified time, `MDTimePicker.set_time()` is used.
`MDTimePicker.set_time()` does:
```py
        if hour > 12:
            hour -= 12
            mode = "pm"
        else:
            mode = "am"
        self._set_am_pm(mode)
```
But `MDTimePicker._set_am_pm()` does not set `self.am_pm`, which is used in `MDTimePicker._get_data()`.

Therefore `MDTimePicker.set_time()` fails to update the time dialog to "pm" state when `hour` is > 12.

### Reproducing the problem

#1226

### Screenshots of the problem

#1226

### Description of Changes

In `MDTimePicker._set_am_pm()` set `self.am_pm` to the am_pm mode selected by the caller:
https://github.com/bernhardkaindl/KivyMD/blob/19a6ddd40637d91189809cf200132bca1eaf0813/kivymd/uix/pickers/timepicker/timepicker.py#L635
```py
self.am_pm = selected
```
I think this is correct because `self.am_pm` is used by `_get_data()` when converting the time data to a string:
https://github.com/kivymd/KivyMD/blob/5a5db42ac8b526bc4bebdecf71b1ef33e8e4537b/kivymd/uix/pickers/timepicker/timepicker.py#L641