### PR TITLE
timepicker.py: Fix import failure b/c of broken list type annotation

### DIFF
--- a/kivymd/uix/pickers/timepicker/timepicker.py
+++ b/kivymd/uix/pickers/timepicker/timepicker.py
@@ -107,7 +107,7 @@ import datetime
 import os
 import re
 import time
-from typing import Union
+from typing import List, Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -275,7 +275,7 @@ class TimeInput(MDRelativeLayout):
         self._hour.text = hour
         self._minute.text = minute
 
-    def get_time(self) -> list[str, str]:
+    def get_time(self) -> List[str]:
         hour = self._hour.text.strip()
         minute = self._minute.text.strip()
         return [hour, minute]


### PR DESCRIPTION
While most python versions don't complain about it, `python-3.8.10`
of Linux Mint 20.2 fails to import `kivymd/uix/pickers/timepicker` with:
`TypeError: 'type' object is not subscriptable`

### Description of the problem

With the `python-3.8.10` of Linux Mint 20.2, the result of either
```py
from kivymd.uix.pickers import MDDatePicker
```
or
```py
from kivymd.uix.pickers import MDTimePicker
```
is:
```py
TypeError: 'type' object is not subscriptable
```
and mypy reports:
```py
kivymd/uix/pickers/timepicker/timepicker.py:279: error: "list" is not subscriptable, use "typing.List" instead
kivymd/uix/pickers/timepicker/timepicker.py:279: error: "list" expects 1 type argument, but 2 given
```

### Description of Changes

Instead of the broken annotation `list[str, str]` which does not annotate for a List, annotate with `List[str]`.  This fixes the using MDTimePicker on Linux Mint 20.2 and fixes the shown errors from mypy.