### PR TITLE
fix(MDIconButton): Fix sizings of MDIconButton as icon_size is changed.

### DIFF
--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -487,7 +487,7 @@ from kivy.animation import Animation
 from kivy.clock import Clock
 from kivy.core.window import Window
 from kivy.lang import Builder
-from kivy.metrics import dp
+from kivy.metrics import dp, sp
 from kivy.properties import (
     BooleanProperty,
     BoundedNumericProperty,
@@ -1262,6 +1262,7 @@ class MDIconButton(OldButtonIconMixin, ButtonContentsIcon, BaseButton):
     """
 
     _min_width = NumericProperty(0)
+    _default_icon_pad = max(dp(48) - sp(24), 0)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -1272,12 +1273,13 @@ class MDIconButton(OldButtonIconMixin, ButtonContentsIcon, BaseButton):
 
     def set_size(self, interval: Union[int, float]) -> None:
         """
-        Sets the custom icon size if the value of the `icon_size`
-        attribute is not zero. Otherwise, the icon size is set to `(48, 48)`.
+        Sets the icon width/height based on the current `icon_size`
+        attribute, or the default value if it is zero. The icon size
+        is set to `(48, 48)` for an icon with the default font_size 24sp.
         """
-
-        self.width = "48dp" if not self.icon_size else dp(self.icon_size + 23)
-        self.height = "48dp" if not self.icon_size else dp(self.icon_size + 23)
+        d = self._default_icon_pad + (self.icon_size or sp(24))
+        self.width = d
+        self.height = d
 
 
 class MDFloatingActionButton(

--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -1277,9 +1277,9 @@ class MDIconButton(OldButtonIconMixin, ButtonContentsIcon, BaseButton):
         attribute, or the default value if it is zero. The icon size
         is set to `(48, 48)` for an icon with the default font_size 24sp.
         """
-        d = self._default_icon_pad + (self.icon_size or sp(24))
-        self.width = d
-        self.height = d
+        diameter = self._default_icon_pad + (self.icon_size or sp(24))
+        self.width = diameter
+        self.height = diameter
 
 
 class MDFloatingActionButton(


### PR DESCRIPTION
By default, font size is 24sp and icon size will then be 48dp.
Note that this is half-way between the MD2 'regular' (56dp) and
'mini' (40dp) floating action button - there isn't actually any
MD spec for an 'icon button'.

Fixes issue #1081 .

### Description of the problem

Sizing of MDIconButton is wrong in an environment where sp(1) != 1, and the icons have a custom icon_size set that isn't 24sp (the default).

### Describe the algorithm of actions that leads to the problem

Create an MDIconButton. Give it a custom icon size that isn't the default (e.g. 30sp). Use an 'sp' size (correct in this case).
View on a PC (where typically sp(1) = 1) and Android (where sp(1) != 1). The icons are the wrong size on Android (too large).

### Reproducing the problem

```python

from kivy.lang import Builder
from kivymd.app import MDApp
from kivymd.uix.button import MDIconButton
from kivy.metrics import sp, dp

KV = '''
MDScreen:

    MDIconButton:
        icon: "language-python"
        pos_hint: {"center_x": .5, "center_y": .9}
        md_bg_color: [1,0,0,1]

    MDIconButton:
        icon: "language-python"
        pos_hint: {"center_x": .5, "center_y": .8}
        md_bg_color: [1,0,0,1]
        icon_size: "24sp"

    MDIconButton:
        icon: "language-python"
        pos_hint: {"center_x": .5, "center_y": .7}
        md_bg_color: [1,0,0,1]
        icon_size: "16sp"

    MDIconButton:
        icon: "language-python"
        pos_hint: {"center_x": .5, "center_y": .6}
        md_bg_color: [1,0,0,1]
        icon_size: "32sp"
'''

class Example(MDApp):
    def build(self):
        return Builder.load_string(KV)

Example().run()
```

### Screenshots of the problem

Button icon_sizes are: default, 24sp, 16sp, 32sp

Linux:
![image](https://user-images.githubusercontent.com/4930097/170544697-e0b9d054-7c9b-4a8f-b725-f02ceb06abb3.png)

Android:
![image](https://user-images.githubusercontent.com/4930097/170545360-0f1e4846-5149-49ed-906e-d0406b4ea838.png)

### Description of Changes

Set the width and the height of the button to `dp(48) + icon_size - sp(24)`, where `icon_size` is set to `sp(24)` if not otherwise set. The default icon size is 24sp, and thus the default width/height is 48dp.

This is actually implemented by adding the `icon_size or sp(24)` to `max(dp(48) - sp(24), 0)` which ensures the width will always be positive for positive icon_size (regardless of the relationship between sp and dp).

### Screenshots of the solution to the problem

Button icon_sizes are: default, 24sp, 16sp, 32sp

Linux:
![image](https://user-images.githubusercontent.com/4930097/170544345-6d14940c-38af-42d4-bc00-689f0b0c03b1.png)

Android:
![image](https://user-images.githubusercontent.com/4930097/170545882-84e8286c-c95d-4304-a92c-653bf52e381b.png)

### Code for testing new changes

(same as demo code, also will be tested with a range of button scripts)
