### PR TITLE
Added support for custom icons to `MDIcon` class

### DIFF
--- a/kivymd/uix/label/label.kv
+++ b/kivymd/uix/label/label.kv
@@ -1,4 +1,5 @@
 #:import md_icons kivymd.icon_definitions.md_icons
+#:import os os
 
 
 <MDLabel>
@@ -21,8 +22,8 @@
             size: self.size
 
     font_style: "Icon"
-    text: u"{}".format(md_icons[root.icon]) if root.icon in md_icons else "blank"
-    source: None if root.icon in md_icons else root.icon
+    text: u"{}".format(md_icons[root.icon]) if root.icon in md_icons else u"{}".format(root.icon)
+    source: None if root.icon in md_icons or not os.path.isfile(root.icon) else root.icon
 
     # Badge icon.
     MDLabel:
@@ -32,8 +33,8 @@
         color: root.badge_icon_color
         text:
             u"{}".format(md_icons[root.badge_icon]) \
-            if root.badge_icon in md_icons else \
-            ""
+            if root.badge_icon in md_icons else "" \
+            if not root.badge_icon else u"{}".format(root.badge_icon)
         pos:
             root.x + root.width / 2 + self.width / 2 - dp(6), \
             root.y + self.texture_size[1] / 2 + dp(6)


### PR DESCRIPTION
### WIP

Added support for custom icons. At the moment, it remains to fix the bug with the height of the icon (or it's not a bug at all)... Related to https://github.com/kivymd/KivyMD/issues/1005

```py
from kivy.lang import Builder
from kivymd.app import MDApp
from kivymd.uix.label import MDIcon

KV = '''
<CustomMDIcon>
    font_name: "JandaFlowerDoodles.ttf"
    color: 0, 0, 1, 1
    canvas.before:
        Color:
            rgba: 1, 0, 0, 0.2
        Rectangle:
            pos: self.pos
            size: self.size
            
Screen:
    ScrollView:
        MDList:
            CustomMDIcon:
                icon: "007a"
                
            CustomMDIcon:
                icon: "006c"
            
            MDIcon:
                icon: 'git'
                
            MDIcon:
                icon: 'git'
                badge_icon: "numeric-10"
'''


class CustomMDIcon(MDIcon):
    pass


class MainApp(MDApp):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.screen = Builder.load_string(KV)

    def build(self):
        return self.screen


MainApp().run()

```

[font](https://www.1001fonts.com/janda-flower-doodles-font.html)
![image](https://user-images.githubusercontent.com/40869738/172165413-fbd21d62-f6f3-47b1-bee9-d6f2fdc6feef.png)
