### PR TITLE
Fixed `on_enter` calling function in `MDTooltip` class

### DIFF
--- a/kivymd/uix/tooltip/tooltip.py
+++ b/kivymd/uix/tooltip/tooltip.py
@@ -290,6 +290,11 @@ class MDTooltip(ThemableBehavior, HoverBehavior, TouchBehavior):
         """
 
         if not args and DEVICE_TYPE == "desktop":
+            for children in Window.children:
+                if isinstance(children, MDTooltipViewClass):
+                    self._tooltip = children
+                    return
+
             if self.tooltip_text:
                 self._tooltip = MDTooltipViewClass(
                     tooltip_bg_color=self.tooltip_bg_color,


### PR DESCRIPTION
When hovering the cursor over a widget with a tooltip before creating a window and shifting the cursor by 1 pixel *(for example)* leads to a double trigger `on_enter` (with `self._tooltip = None`) this leads to the appearance of two tooltips on the screen.

### Example
```py
from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.button import MDIconButton
from kivymd.uix.tooltip import MDTooltip

KV = '''
<MenuButton>
    tooltip_text: self.icon
    
    
Screen:
    orientation: "vertical"
    
    MDToolbar:
        title: "MDToolbar"
        right_action_items: [["folder", lambda x: print(), 'Text ' * 5]]
        pos_hint: {'top': 1}

    MDBoxLayout:
        adaptive_size: True
        spacing: dp(10)
        pos_hint: {"center_x": .5, "center_y": .5}
         
        MenuButton:
            icon: 'home'
            
        MenuButton:
            icon: 'language-python'
        
        MenuButton:
            icon: 'github'
'''


class MenuButton(MDIconButton, MDTooltip):
    pass


class Test(MDApp):
    def build(self):
        return Builder.load_string(KV)


Test().run()
```

### Bug demonstration
https://user-images.githubusercontent.com/40869738/175658602-d8da533c-b707-4f9c-8c89-8fb0d6d81fd8.mp4

### How reproduce bug
https://user-images.githubusercontent.com/40869738/177828635-66e37a6e-a480-47d5-a8ca-cc18b55c6b33.mp4


