### PR TITLE
Fix title position in `update_anchor_title` function in `NotchedBox` class

### DIFF
--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -1310,8 +1310,7 @@ class MDTopAppBar(NotchedBox, WindowController):
         if material_style_value == "M2":
             self.anchor_title = "left"
         elif material_style_value == "M3" and self.type != "bottom":
-            if not self.anchor_title:
-                self.anchor_title = "center"
+            self.anchor_title = "center"
         elif material_style_value == "M3" and self.type == "bottom":
             self.anchor_title = "left"
         return self.anchor_title


### PR DESCRIPTION
```py
from kivymd.app import MDApp
from kivy.lang.builder import Builder
from kivymd.uix.toolbar import MDTopAppBar
from kivymd.toast import toast

KV = """
Screen:
    MDTopAppBar:
        title: "MDTopAppBar"
        pos_hint: {'top': 1}
        elevation: 10
        left_action_items: [['menu', lambda x: print]]

    MDRaisedButton:
        text: "Change style"
        pos_hint: {"center_x": .5, "center_y": .5}
        on_release: app.change_style()
"""


class MainApp(MDApp):
    def build(self):
        self.theme_cls.material_style = 'M3'
        return Builder.load_string(KV)

    def change_style(self):
        if self.theme_cls.material_style == 'M2':
            self.theme_cls.material_style = 'M3'
        else:
            self.theme_cls.material_style = 'M2'

        toast(self.theme_cls.material_style)


MainApp().run()
```

https://user-images.githubusercontent.com/40869738/175776171-64a0393c-61da-404d-b152-3a0727441140.mp4

