### PR TITLE
Fixed a weak link to the `MDTopAppBar` header

### DIFF
--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -1218,7 +1218,7 @@ class MDTopAppBar(NotchedBox, WindowController):
         """
 
         def on_anchor_title(interval: Union[int, float]):
-            self.ids.label_title.halign = anchor_value
+            self.ids.label_title.__self__.halign = anchor_value
 
         Clock.schedule_once(on_anchor_title)
 


### PR DESCRIPTION
The error of a weak link to the `MDTopAppBar` header has been fixed, the appearance of this error has a magical character for me so far, perhaps it has something to do with a large number of widgets in the application, I follow the recommendations from the kivy documentation, I blow the link strong.

```
Traceback (most recent call last):
   File "C:\Users\pikro\PycharmProjects\<APP>\main.py", line 3610, in run_app
     main_app.run()
   File "C:\Users\pikro\Anaconda3\envs\<APP>\lib\site-packages\kivy\app.py", line 955, in run
     runTouchApp()
   File "C:\Users\pikro\Anaconda3\envs\<APP>\lib\site-packages\kivy\base.py", line 574, in runTouchApp
     EventLoop.mainloop()
   File "C:\Users\pikro\Anaconda3\envs\<APP>\lib\site-packages\kivy\base.py", line 339, in mainloop
     self.idle()
   File "C:\Users\pikro\Anaconda3\envs\<APP>\lib\site-packages\kivy\base.py", line 379, in idle
     Clock.tick()
   File "C:\Users\pikro\Anaconda3\envs\<APP>\lib\site-packages\kivy\clock.py", line 733, in tick
     self.post_idle(ts, self.idle())
   File "C:\Users\pikro\Anaconda3\envs\<APP>\lib\site-packages\kivy\clock.py", line 776, in post_idle
     self._process_events()
   File "kivy\_clock.pyx", line 620, in kivy._clock.CyClockBase._process_events
   File "kivy\_clock.pyx", line 653, in kivy._clock.CyClockBase._process_events
   File "kivy\_clock.pyx", line 649, in kivy._clock.CyClockBase._process_events
   File "kivy\_clock.pyx", line 218, in kivy._clock.ClockEvent.tick
   File "C:\Users\pikro\Anaconda3\envs\<APP>\lib\site-packages\kivymd\uix\toolbar\toolbar.py", line 1221, in on_anchor_title
     self.ids.label_title.halign = anchor_value
   File "kivy\properties.pyx", line 961, in kivy.properties.ObservableDict.__getattr__
   File "kivy\properties.pyx", line 955, in kivy.properties.ObservableDict._weak_return
   File "kivy\weakproxy.pyx", line 42, in kivy.weakproxy.WeakProxy.__class__.__get__
   File "kivy\weakproxy.pyx", line 28, in kivy.weakproxy.WeakProxy.__ref__
 ReferenceError: weakly-referenced object no longer exists
 ```

https://user-images.githubusercontent.com/40869738/175809850-ae847717-680b-45b4-8da5-03c8206c4190.mp4


