### PR TITLE
Add option for controlling button icon position

### DIFF
--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -134,12 +134,12 @@
         adaptive_size: True
         padding: 0
         spacing: "4dp"
+        orientation: 'vertical' if root.icon_position == 'top' else 'horizontal'
 
         MDIcon:
             id: lbl_ic
             size_hint_x: None
-            pos_hint: {"center_y": .5}
-            icon: root.icon
+            pos_hint: {"center_x": .5} if root.icon_position == 'top' else {'center_y': .5}            icon: root.icon
             disabled: root.disabled
             opposite_colors: root.opposite_colors
             font_size:

--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -139,7 +139,8 @@
         MDIcon:
             id: lbl_ic
             size_hint_x: None
-            pos_hint: {"center_x": .5} if root.icon_position == 'top' else {'center_y': .5}            icon: root.icon
+            pos_hint: {"center_x": .5} if root.icon_position == "top" else {"center_y": .5}
+            icon: root.icon
             disabled: root.disabled
             opposite_colors: root.opposite_colors
             font_size:

--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -1059,6 +1059,11 @@ class ButtonContentsIconText:
     and defaults to [12dp, 8dp, 16dp, 8dp].
     """
 
+    icon_position = OptionProperty("left", options=["left", "top"])
+    """
+    Control icon position [left, top)]
+    """
+
 
 # Old MD Button classes
 

--- a/kivymd/uix/button/button.py
+++ b/kivymd/uix/button/button.py
@@ -1061,7 +1061,11 @@ class ButtonContentsIconText:
 
     icon_position = OptionProperty("left", options=["left", "top"])
     """
-    Control icon position [left, top)]
+    Decides where the icon will be placed visually in relation to the label.
+    Available options are: 'left', 'top'.
+
+    :attr:`icon_position` is an :class:`~kivy.properties.OptionProperty`
+    and defaults to `'left'`.
     """
 
 


### PR DESCRIPTION


### Description of the problem

Currently a user can only have the icon to the left of the label for buttons. This change will give the user the possibility to place the icon above the label instead.

### Description of Changes

Added an icon_position OptionProperty with support for left (default) and top.  This property will control the layout of the label and the icon in ButtonContentsIconText class.

### Code for testing new changes

```python
# Code that demonstrates the correctness of the new changes:
MDRectangleFlatIconButton(icon='history', text='Label beneath icon', icon_position='top')
```