### PR TITLE
fix: Fix issues with disabling/undisabling icon buttons with theme_icon_color

### DIFF
--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -78,7 +78,6 @@
         icon: root.icon
         font_size: root.icon_size if root.icon_size else self.font_size
         font_name: root.font_name if root.font_name else self.font_name
-        disabled: root.disabled
         opposite_colors: root.opposite_colors
         text_color:
             # FIXME: ValueError: None is not allowed for MDIcon.text_color.
@@ -88,8 +87,7 @@
             root.theme_cls.disabled_hint_text_color
         on_icon:
             if self.icon not in md_icons.keys(): self.size_hint = (1, 1)
-        theme_text_color:
-            root._theme_icon_color if not root.disabled else "Primary"
+        theme_text_color: root._theme_icon_color
 
 
 <ButtonContentsIconText>
@@ -140,7 +138,6 @@
             size_hint_x: None
             pos_hint: {"center_y": .5}
             icon: root.icon
-            disabled: root.disabled
             opposite_colors: root.opposite_colors
             font_size:
                 root.icon_size \
@@ -150,8 +147,7 @@
                 root._icon_color \
                 if not root.disabled else \
                 root.theme_cls.disabled_hint_text_color
-            theme_text_color:
-                root._theme_icon_color if not root.disabled else "Primary"
+            theme_text_color: root._theme_icon_color
 
         MDLabel:
             id: lbl_txt


### PR DESCRIPTION
### Description of the problem

Currently, if an icon button (MDIconButton, MDFloatingActionButton, MDRectangleFlatIconButton etc.) has theme_icon_color set to an acceptable value ('Primary', 'Secondary', 'Hint', 'Error', 'Custom' or 'ContrastParentBackground'), the icon itself will have a color set by that theme (e.g. red for 'Error').

However, when the icon is disabled and then subsequently un-disabled, for several themes it remains grey (disabled color) and does not regain its previous color. This is due to theme_text_color in the MDIcon itself (a child widget of the button) setting the theme_text_color to 'Primary' when the button is disabled. While it is set back to the button's _theme_icon_color afterwards, the ordering of this means the color of the MDIcon doesn't actually end up being updated.

### Describe the algorithm of actions that leads to the problem

1. Create (for example) an MDIconButton
2. Set theme_icon_color to (for example) 'Error'
3. The button is red
4. Disable the button
5. The button is grey
6. Un-disable the button
7. The button _should_ be red again, but remains grey

### Reproducing the problem

```python
from kivy.lang import Builder
from kivymd.app import MDApp

KV = """
MDBoxLayout:
    orientation: "horizontal"
    adaptive_height: True

    MDIconButton:
        id: icon_primary
        icon: "language-python"
        icon_size: "64sp"
        theme_icon_color: "Primary"
    MDIconButton:
        id: icon_secondary
        icon: "language-python"
        icon_size: "64sp"
        theme_icon_color: "Secondary"
    MDIconButton:
        id: icon_hint
        icon: "language-python"
        icon_size: "64sp"
        theme_icon_color: "Hint"
    MDIconButton:
        id: icon_error
        icon: "language-python"
        icon_size: "64sp"
        theme_icon_color: "Error"
    MDIconButton:
        id: icon_contrast
        icon: "language-python"
        icon_size: "64sp"
        theme_icon_color: "ContrastParentBackground"
    MDIconButton:
        id: icon_custom
        icon: "language-python"
        icon_size: "64sp"
        theme_icon_color: "Custom"
        icon_color: [0.0, 1.0, 0.0, 1.0]

    MDFlatButton:
        text: "Disable"
        on_release:
            icon_primary.disabled = True
            icon_secondary.disabled = True
            icon_hint.disabled = True
            icon_error.disabled = True
            icon_contrast.disabled = True
            icon_custom.disabled = True

    MDFlatButton:
        text: "Undisable"
        on_release:
            icon_primary.disabled = False
            icon_secondary.disabled = False
            icon_hint.disabled = False
            icon_error.disabled = False
            icon_contrast.disabled = False
            icon_custom.disabled = False
"""


class Test(MDApp):

    def build(self):
        return Builder.load_string(KV)

Test().run()

```

### Screenshots of the problem

Icons are, from left to right, theme_icon_color of 'Primary', 'Secondary', 'Hint', 'Error', 'ContrastParentBackground', 'Custom' (with icon_color [0.0, 1.0, 0.0, 1.0]).

**Without the fix**
Before disabling
![image](https://user-images.githubusercontent.com/4930097/177580504-82e27c32-042d-4216-a4da-bc4b4948f38f.png)
After disabling
![image](https://user-images.githubusercontent.com/4930097/177580568-a241c98f-f7b2-4ea4-be6a-bb79270ed764.png)
After undisabling
![image](https://user-images.githubusercontent.com/4930097/177580621-3b0295dd-162e-426e-a25d-d6b5cea5256a.png)

### Description of Changes

It isn't actually needed to change the theme_text_color to 'Primary' when the button is disabled, so it is just bound to the _theme_icon_color of the parent button widget. There is also an extraneous 'disabled' binding which is unnecessary as MDIcon (a label) doesn't have 'disabled'; this is removed.

### Screenshots of the solution to the problem

**With the fix**
Before disabling
![image](https://user-images.githubusercontent.com/4930097/177580166-7976e724-80dc-4831-b957-0416f799838e.png)
After disabling
![image](https://user-images.githubusercontent.com/4930097/177580237-8afab479-9517-4aad-aa84-ba17eff78047.png)
After undisabling
![image](https://user-images.githubusercontent.com/4930097/177580449-9a7cb8cd-dffb-407a-99e2-26f312ac40b1.png)


### Code for testing new changes

Same as the minimal example above.
