### PR TITLE
Fix `FloatButton` `md_bg_color` in `MDFileManager` class

### DIFF
--- a/kivymd/uix/filemanager/filemanager.py
+++ b/kivymd/uix/filemanager/filemanager.py
@@ -153,7 +153,7 @@ from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.modalview import ModalView
 
 from kivymd import images_path, uix_path
-from kivymd.theming import ThemableBehavior
+from kivymd.theming import ThemableBehavior, ThemeManager
 from kivymd.uix.behaviors import CircularRippleBehavior
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.list import BaseListItem, ContainerSupport
@@ -334,17 +334,21 @@ class MDFileManager(ThemableBehavior, MDRelativeLayout):
             or self.selector == "multi"
             or self.selector == "folder"
         ):
-            self.add_widget(
-                FloatButton(
-                    callback=self.select_directory_on_press_button,
-                    md_bg_color=self.theme_cls.primary_color,
-                    icon=self.icon,
-                )
+            self.float_button = FloatButton(
+                callback=self.select_directory_on_press_button,
+                md_bg_color=self.theme_cls.primary_color,
+                icon=self.icon,
             )
+
+            self.add_widget(self.float_button)
+            self.theme_cls.bind(primary_color=self._change_bg_color)
 
         if self.preview:
             self.ext = [".png", ".jpg", ".jpeg"]
         self.disks = []
+
+    def _change_bg_color(self, inst: ThemeManager, color: list):
+        self.float_button.md_bg_color = color
 
     def show_disks(self) -> None:
         if platform == "win":

--- a/kivymd/uix/filemanager/filemanager.py
+++ b/kivymd/uix/filemanager/filemanager.py
@@ -153,7 +153,7 @@ from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.modalview import ModalView
 
 from kivymd import images_path, uix_path
-from kivymd.theming import ThemableBehavior, ThemeManager
+from kivymd.theming import ThemableBehavior
 from kivymd.uix.behaviors import CircularRippleBehavior
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.list import BaseListItem, ContainerSupport
@@ -182,10 +182,17 @@ class IconButton(CircularRippleBehavior, ButtonBehavior, FitImage):
     """Folder icons/thumbnails images in ``preview`` mode."""
 
 
-class FloatButton(AnchorLayout):
+class FloatButton(ThemableBehavior, AnchorLayout):
     callback = ObjectProperty()
     md_bg_color = ColorProperty([1, 1, 1, 1])
     icon = StringProperty()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.theme_cls.bind(primary_palette=self.set_md_bg_color)
+
+    def set_md_bg_color(self, *args):
+        self.md_bg_color = self.theme_cls.primary_color
 
 
 class ModifiedOneLineIconListItem(ContainerSupport, BaseListItem):
@@ -334,21 +341,17 @@ class MDFileManager(ThemableBehavior, MDRelativeLayout):
             or self.selector == "multi"
             or self.selector == "folder"
         ):
-            self.float_button = FloatButton(
-                callback=self.select_directory_on_press_button,
-                md_bg_color=self.theme_cls.primary_color,
-                icon=self.icon,
+            self.add_widget(
+                FloatButton(
+                    callback=self.select_directory_on_press_button,
+                    md_bg_color=self.theme_cls.primary_color,
+                    icon=self.icon,
+                )
             )
-
-            self.add_widget(self.float_button)
-            self.theme_cls.bind(primary_color=self._change_bg_color)
 
         if self.preview:
             self.ext = [".png", ".jpg", ".jpeg"]
         self.disks = []
-
-    def _change_bg_color(self, inst: ThemeManager, color: list):
-        self.float_button.md_bg_color = color
 
     def show_disks(self) -> None:
         if platform == "win":


### PR DESCRIPTION
When changing `primary_palette`, the color of the button did not change

```py
from kivy.core.window import Window
from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.filemanager import MDFileManager
from kivymd.toast import toast

KV = '''
BoxLayout:
    orientation: 'vertical'

    MDToolbar:
        title: "MDFileManager"
        left_action_items: [['menu', lambda x: None]]
        elevation: 10

    FloatLayout:

        MDRoundFlatIconButton:
            text: "Open manager"
            icon: "folder"
            pos_hint: {'center_x': .5, 'center_y': .6}
            on_release: app.file_manager_open()
            
        MDRoundFlatIconButton:
            text: "Change primary color"
            icon: "folder"
            pos_hint: {'center_x': .5, 'center_y': .5}
            on_release: app.theme_cls.primary_palette = "Red"
'''


class Example(MDApp):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        Window.bind(on_keyboard=self.events)
        self.manager_open = False
        self.file_manager = MDFileManager(
            exit_manager=self.exit_manager,
            select_path=self.select_path,
        )

    def build(self):
        return Builder.load_string(KV)

    def file_manager_open(self):
        self.file_manager.show('/')  # output manager to the screen
        self.manager_open = True

    def select_path(self, path):
        '''It will be called when you click on the file name
        or the catalog selection button.

        :type path: str;
        :param path: path to the selected directory or file;
        '''

        self.exit_manager()
        toast(path)

    def exit_manager(self, *args):
        '''Called when the user reaches the root of the directory tree.'''

        self.manager_open = False
        self.file_manager.close()

    def events(self, instance, keyboard, keycode, text, modifiers):
        '''Called when buttons are pressed on the mobile device.'''

        if keyboard in (1001, 27):
            if self.manager_open:
                self.file_manager.back()
        return True


Example().run()
```

https://user-images.githubusercontent.com/40869738/179244059-20cad997-708f-4f52-bab5-1ce24038ccdf.mp4