### PR TITLE
Fix pillow version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
                 "sphinx-notfound-page",
             ],
         },
-        install_requires=["kivy>=2.0.0", "pillow>=8.2.0"],
+        install_requires=["kivy>=2.0.0", "pillow==8.2.0"],
         setup_requires=[],
         python_requires=">=3.6",
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
                 "sphinx-notfound-page",
             ],
         },
-        install_requires=["kivy>=2.0.0", "pillow==8.2.0"],
+        install_requires=["kivy>=2.0.0", "pillow==8.4.0"],
         setup_requires=[],
         python_requires=">=3.6",
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
                 "sphinx-notfound-page",
             ],
         },
-        install_requires=["kivy>=2.0.0", "pillow"],
+        install_requires=["kivy>=2.0.0", "pillow>=8.2.0"],
         setup_requires=[],
         python_requires=">=3.6",
         entry_points={


### PR DESCRIPTION
Now pillow does not have a recipe for version 9.2, this is important, since `kivy-ios` resolves all dependencies.

https://github.com/kivy/kivy-ios/issues/732