### PR TITLE
Added `kivy-ios` build example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,6 @@ Do not forget to run `buildozer android clean` or remove `.buildozer` directory
 before building if version was updated (Buildozer doesn't update already
 downloaded packages).
 
-### How to use with [kivy-ios](https://github.com/kivy/kivy-ios)
-
-```bash
-toolchain build python3 kivy pillow
-toolchain pip install --no-deps https://github.com/kivymd/KivyMD/archive/master.zip
-```
-
 #### On Linux
 
 - Use Buildozer [directly](https://github.com/kivy/buildozer#installing-buildozer-with-target-python-3-default) 
@@ -141,6 +134,19 @@ toolchain pip install --no-deps https://github.com/kivymd/KivyMD/archive/master.
   to build your packages automatically on push or pull request.
 - See [full workflow example](https://github.com/ArtemSBulgakov/buildozer-action#full-workflow).
 
+### How to use with [kivy-ios](https://github.com/kivy/kivy-ios)
+
+```bash
+toolchain build python3 kivy pillow
+toolchain pip install --no-deps kivymd
+```
+
+**NOTE**
+
+Until the release of the KivyMD library version 1.0.0 has been released, use
+```ini
+toolchain pip install --no-deps https://github.com/kivymd/KivyMD/archive/master.zip
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ toolchain pip install --no-deps kivymd
 **NOTE**
 
 Until the release of the KivyMD library version 1.0.0 has been released, use
-```ini
+```bash
 toolchain pip install --no-deps https://github.com/kivymd/KivyMD/archive/master.zip
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Do not forget to run `buildozer android clean` or remove `.buildozer` directory
 before building if version was updated (Buildozer doesn't update already
 downloaded packages).
 
+### How to use with [kivy-ios](https://github.com/kivy/kivy-ios)
+
+```bash
+toolchain build python3 kivy pillow
+toolchain pip install --no-deps https://github.com/kivymd/KivyMD/archive/master.zip
+```
+
 #### On Linux
 
 - Use Buildozer [directly](https://github.com/kivy/buildozer#installing-buildozer-with-target-python-3-default) 


### PR DESCRIPTION
Due to the fact that `kivy-ios` automatically solves all dependencies, it is necessary to install the `kivymd` package without dependencies, because the pillow recipe version will always be lower than the latest one. Otherwise there is a bug:
```bash
 ImportError: The _imaging extension was built for another version of Pillow or PIL:
 Core version: 8.2.0
 Pillow version: 9.2.0
```