### PR TITLE
Fix stable red color even when no error is thrown - hot reload

### DIFF
--- a/kivymd/tools/hotreload/app.py
+++ b/kivymd/tools/hotreload/app.py
@@ -298,8 +298,9 @@ class MDApp(BaseApp):
         from kivy.core.window import Window
         from kivy.utils import get_color_from_hex
 
-        Window.clearcolor = get_color_from_hex("#e50000")
-        scroll = Factory.ScrollView(scroll_y=0)
+        scroll = Factory.MDScrollView(
+            scroll_y=0, md_bg_color=get_color_from_hex("#e50000")
+        )
         lbl = Factory.Label(
             text_size=(Window.width - 100, None),
             size_hint_y=None,

--- a/kivymd/uix/scrollview.py
+++ b/kivymd/uix/scrollview.py
@@ -34,10 +34,15 @@ __all__ = ("MDScrollView",)
 
 from kivy.uix.scrollview import ScrollView
 
-from kivymd.uix.behaviors import DeclarativeBehavior, SpecificBackgroundColorBehavior
+from kivymd.uix.behaviors import (
+    DeclarativeBehavior,
+    SpecificBackgroundColorBehavior,
+)
 
 
-class MDScrollView(DeclarativeBehavior, SpecificBackgroundColorBehavior, ScrollView):
+class MDScrollView(
+    DeclarativeBehavior, SpecificBackgroundColorBehavior, ScrollView
+):
     """
     ScrollView class. For more information, see in the
     :class:`~kivy.uix.scrollview.ScrollView` class documentation.

--- a/kivymd/uix/scrollview.py
+++ b/kivymd/uix/scrollview.py
@@ -34,10 +34,10 @@ __all__ = ("MDScrollView",)
 
 from kivy.uix.scrollview import ScrollView
 
-from kivymd.uix.behaviors import DeclarativeBehavior
+from kivymd.uix.behaviors import DeclarativeBehavior, SpecificBackgroundColorBehavior
 
 
-class MDScrollView(DeclarativeBehavior, ScrollView):
+class MDScrollView(DeclarativeBehavior, SpecificBackgroundColorBehavior, ScrollView):
     """
     ScrollView class. For more information, see in the
     :class:`~kivy.uix.scrollview.ScrollView` class documentation.


### PR DESCRIPTION
### Description

Added background color attrs for `MDScrollView`, this is shown as implemented in docs (https://kivymd.readthedocs.io/en/latest/components/scrollview/) but in codebase it is not 

Fixes stable red color even when no error is thrown
Currently the `hotreload.MDApp` sets `Window.clearcolor` for showing a warning color
But this affects the application's background color, So I replaced `kivy.ScrollView` with `kivymd.MDScrollView` and used `md_bg_color` attr


