### PR TITLE
Fix issue #1164

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -744,6 +744,11 @@ class DatePickerDaySelectableItem(
 
             self.owner.set_selected_widget(self)
 
+    def on_touch_down(self, touch):
+        # if year_layout is active don't dispatch on_touch_down events, so date items don't consume touch
+        if not self.owner.ids._year_layout.disabled:
+            return
+        super().on_touch_down(touch)
 
 class DatePickerYearSelectableItem(RecycleDataViewBehavior, MDLabel):
     """Implements an item for a pick list of the year."""


### PR DESCRIPTION
The date items were consuming the touch event even when the layout was disabled, interfering on the year layout touch events