### PR TITLE
make elevation behavior compatible with opengl>4.0

### DIFF
--- a/kivymd/data/glsl/elevation/elevation.frag
+++ b/kivymd/data/glsl/elevation/elevation.frag
@@ -10,6 +10,12 @@ corner radius:
 https://iquilezles.org/articles/distfunctions
 */
 
+float mysmoothstep(float a, float b, float x) {
+    float t = clamp((x - a) / (b - a), 0.0, 1.0);
+ 
+    return t * t * (3.0 - (2.0 * t));
+}
+
 float roundedBoxSDF(vec2 centerPosition, vec2 size, vec4 radius) {
     radius.xy = (centerPosition.x > 0.0) ? radius.xy : radius.zw;
     radius.x = (centerPosition.y > 0.0) ? radius.x : radius.y;
@@ -20,7 +26,7 @@ float roundedBoxSDF(vec2 centerPosition, vec2 size, vec4 radius) {
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Smooth the result (free antialiasing).
-    float smoothedAlpha = 1.0 - smoothstep(0.0, 0.0, 1.0);
+    float smoothedAlpha = 1.0 - mysmoothstep(0.0, 0.0, 1.0);
     // Get the resultant shape.
     vec4 quadColor = mix(
         vec4(
@@ -36,7 +42,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float shadowDistance = roundedBoxSDF(
         fragCoord.xy - mouse.xy - (size / 2.0), size / 2.0, shadow_radius
     );
-    float shadowAlpha = 1.0 - smoothstep(
+    float shadowAlpha = 1.0 - mysmoothstep(
         -shadow_softness, shadow_softness, shadowDistance
     );
     fragColor = mix(quadColor, shadow_color, shadowAlpha - smoothedAlpha);

--- a/kivymd/data/glsl/elevation/elevation.frag
+++ b/kivymd/data/glsl/elevation/elevation.frag
@@ -10,12 +10,6 @@ corner radius:
 https://iquilezles.org/articles/distfunctions
 */
 
-float mysmoothstep(float a, float b, float x) {
-    float t = clamp((x - a) / (b - a), 0.0, 1.0);
- 
-    return t * t * (3.0 - (2.0 * t));
-}
-
 float roundedBoxSDF(vec2 centerPosition, vec2 size, vec4 radius) {
     radius.xy = (centerPosition.x > 0.0) ? radius.xy : radius.zw;
     radius.x = (centerPosition.y > 0.0) ? radius.x : radius.y;
@@ -26,7 +20,8 @@ float roundedBoxSDF(vec2 centerPosition, vec2 size, vec4 radius) {
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Smooth the result (free antialiasing).
-    float smoothedAlpha = 1.0 - mysmoothstep(0.0, 0.0, 1.0);
+    float edge0 = 0.0;
+    float smoothedAlpha = 1.0 - smoothstep(0.0, edge0, 1.0);
     // Get the resultant shape.
     vec4 quadColor = mix(
         vec4(
@@ -42,7 +37,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float shadowDistance = roundedBoxSDF(
         fragCoord.xy - mouse.xy - (size / 2.0), size / 2.0, shadow_radius
     );
-    float shadowAlpha = 1.0 - mysmoothstep(
+    float shadowAlpha = 1.0 - smoothstep(
         -shadow_softness, shadow_softness, shadowDistance
     );
     fragColor = mix(quadColor, shadow_color, shadowAlpha - smoothedAlpha);


### PR DESCRIPTION
fix the smooth of shadow

By specified the input type edge0 in smoothstep function, elevation.frag is now compatible with opengl>4.0.

before
![image](https://user-images.githubusercontent.com/19823482/187977159-b0fdc4fa-a806-42fd-8407-d20c8f12e29a.png)


after
![image](https://user-images.githubusercontent.com/19823482/187977072-a39e3834-5705-43d3-865a-43feafb10c24.png)
