### PR TITLE
Fix Elevation behavior during transitions

### DIFF
--- a/kivymd/uix/behaviors/elevation.py
+++ b/kivymd/uix/behaviors/elevation.py
@@ -371,6 +371,7 @@ from kivy.properties import (
     ColorProperty,
     ListProperty,
     NumericProperty,
+    ObjectProperty,
     VariableListProperty,
 )
 from kivy.uix.widget import Widget
@@ -585,6 +586,7 @@ class CommonElevationBehavior(Widget):
     and defaults to `[0.4, 0.4, 0.4, 0.8]`.
     """
 
+    _transition_ref = ObjectProperty()
     _has_relative_position = BooleanProperty(defaultvalue=False)
     _elevation = 0
     _shadow_color = [0.0, 0.0, 0.0, 0.0]
@@ -610,23 +612,61 @@ class CommonElevationBehavior(Widget):
         Clock.schedule_once(self.after_init)
 
     def after_init(self, *args):
-        Clock.schedule_once(self.check_for_relative_pos)
+        Clock.schedule_once(self.check_for_relative_behavior)
         Clock.schedule_once(self.set_shader_string)
         Clock.schedule_once(lambda x: self.on_elevation(self, self.elevation))
         self.on_pos()
 
-    def check_for_relative_pos(self, *args) -> None:
+    def check_for_relative_behavior(self, *args) -> None:
         """
-        Checks if the widget has relative position properties and if necessary
-        binds Window.on_draw call to update window position
+        Checks if the widget has relative properties and if necessary
+        binds Window.on_draw and screen events to fix behavior
         """
 
-        if self.pos == self.window_pos:
-            return
-        else:
+        if self.pos != self.window_pos:
             self._has_relative_position = True
 
-        Window.bind(on_draw=self.update_window_position)
+        # loops to check if its inside screenmanager or bottom_navigation
+        widget = self
+        while True:
+            # checks if has screen event function
+            # works for Screen and MDTab objects
+            if hasattr(widget, "on_pre_enter"):
+                widget.bind(on_pre_enter=self.apply_correction)
+                widget.bind(on_pre_leave=self.apply_correction)
+                widget.bind(on_enter=self.reset_correction)
+                widget.bind(on_leave=self.reset_correction)
+                self._has_relative_position = True
+
+                # save refs to objects with transition property
+                if hasattr(widget, "header"):  # specific to bottom_nav
+                    self._transition_ref = widget.header.panel
+                elif hasattr(widget, "manager"):  # specific to screen
+                    if widget.manager:  # manager cant be None
+                        self._transition_ref = widget.manager
+                break
+
+            elif widget.parent and str(widget) != str(widget.parent):
+                widget = widget.parent
+            else:
+                break
+
+        if self._has_relative_position:
+            Window.bind(on_draw=self.update_window_position)
+
+    def apply_correction(self, *args):
+        if self._transition_ref:
+            transition = str(self._transition_ref.transition)
+            # Slide and Card transitions only need _has_relative_pos to be always on
+            if "SlideTransition" in transition or "CardTransition" in transition:
+                self.context.use_parent_modelview = False
+            else:
+                self.context.use_parent_modelview = True
+
+    def reset_correction(self, *args):
+        self.context.use_parent_modelview = False
+        self.update_window_position()
+
 
     def get_shader_string(self) -> str:
         shader_string = ""
@@ -696,7 +736,7 @@ class CommonElevationBehavior(Widget):
         if not hasattr(self, "rect"):
             return
 
-        if self._has_relative_position:
+        if self._has_relative_position and not self.context.use_parent_modelview:
             pos = self.window_pos
         else:
             pos = self.pos


### PR DESCRIPTION
Fix #1327 by applying correction during the transitions + Clue to definitive solution 

Correction works on every transition, except SwapTransition

Followed @mp-007 suggestion on #1327 to enable "_has_relative_position" if its inside a widget with a Card or Slide transition.
Also enables "_has_relative_position" if it is inside a Screen widget , 
then during the transitions "use_parent_modelview" is enabled if necessary.

Test code for the PR fix, can also test with #1327 test code.
Tests with a more complex code are needed.
```
from kivymd.app import MDApp
from kivy.lang import Builder

KV = '''
BoxLayout:
    orientation:'vertical'

    ## works
        #:import FadeTransition kivy.uix.screenmanager.FadeTransition
        #:import WipeTransition kivy.uix.screenmanager.WipeTransition
        #:import RiseInTransition kivy.uix.screenmanager.RiseInTransition
        #:import FallOutTransition kivy.uix.screenmanager.FallOutTransition       
        #:import SlideTransition kivy.uix.screenmanager.SlideTransition
        #:import CardTransition kivy.uix.screenmanager.CardTransition
    
    ## does not work 
        #:import SwapTransition kivy.uix.screenmanager.SwapTransition

    MDBottomNavigation:
        id:nav
        panel_color: .2, .2, .2, 1

        MDBottomNavigationItem:
            name: 'screen 1'
            text: 'screen 1'
            MDRaisedButton:
                text: 'SlideTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.2, "center_y":0.8}
                on_release: nav.transition = SlideTransition                 
            MDRaisedButton:
                text: 'CardTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.3, "center_y":0.7}
                on_release: nav.transition = CardTransition    
            MDRaisedButton:
                text: 'FallOutTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.4, "center_y":0.6}
                on_release: nav.transition = FallOutTransition            
            MDRaisedButton:
                text: 'RiseInTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.5}
                on_release: nav.transition = RiseInTransition
            MDRaisedButton:
                text: 'WipeTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.6, "center_y":0.4}
                on_release: nav.transition = WipeTransition            
            MDRaisedButton:
                text: 'FadeTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.7, "center_y":0.3}
                on_release: nav.transition = FadeTransition
            MDRaisedButton:
                text: 'SwapTransition'
                md_bg_color: (1,0,0,1)
                pos_hint: {"center_x":0.8, "center_y":0.2}
                on_release: nav.transition = SwapTransition
            
        MDBottomNavigationItem:
            name: 'screen 2'
            text: 'screen 2'

            MDRaisedButton:
                text: 'SlideTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.3, "center_y":0.8}
                on_release: nav.transition = SlideTransition                 
            MDRaisedButton:
                text: 'CardTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.4, "center_y":0.7}
                on_release: nav.transition = CardTransition    
            MDRaisedButton:
                text: 'FallOutTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.6}
                on_release: nav.transition = FallOutTransition            
            MDRaisedButton:
                text: 'RiseInTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.5}
                on_release: nav.transition = RiseInTransition
            MDRaisedButton:
                text: 'WipeTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.4}
                on_release: nav.transition = WipeTransition            
            MDRaisedButton:
                text: 'FadeTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.6, "center_y":0.3}
                on_release: nav.transition = FadeTransition
            MDRaisedButton:
                text: 'SwapTransition'
                md_bg_color: (1,0,0,1)
                pos_hint: {"center_x":0.7, "center_y":0.2}
                on_release: nav.transition = SwapTransition                      

        MDBottomNavigationItem:
            name: 'screen 3'
            text: 'screen 3'

            MDRaisedButton:
                text: 'SlideTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.8}
                on_release: nav.transition = SlideTransition                 
            MDRaisedButton:
                text: 'CardTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.7}
                on_release: nav.transition = CardTransition    
            MDRaisedButton:
                text: 'FallOutTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.6}
                on_release: nav.transition = FallOutTransition            
            MDRaisedButton:
                text: 'RiseInTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.5}
                on_release: nav.transition = RiseInTransition
            MDRaisedButton:
                text: 'WipeTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.4}
                on_release: nav.transition = WipeTransition            
            MDRaisedButton:
                text: 'FadeTransition'
                md_bg_color: (0,1,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.3}
                on_release: nav.transition = FadeTransition
            MDRaisedButton:
                text: 'SwapTransition'
                md_bg_color: (1,0,0,1)
                pos_hint: {"center_x":0.5, "center_y":0.2}
                on_release: nav.transition = SwapTransition          
                        
'''

class Test(MDApp):

    def build(self):
        return Builder.load_string(KV)

Test().run()
```

---------------------------------------------------------------------------------------------------

Clues to definitive solution on elevation shadow:

Oddly enough, I found out that the shadows that don't appear normally when use_parent_modelview is enabled and the widget have relative positions,  appears during the shader transitions. So, I used it to show the correct shadow positions during the transitions. 

To observe this you have to change
``` 
self.context = RenderContext(use_parent_projection=True)
```

to 

``` 
self.context = RenderContext(use_parent_projection=True, use_parent_modelview=True)
```

and comment out this line to have the old behavior
``` 
Clock.schedule_once(self.check_for_relative_behavior)
```

Then during a shader transition you observe the shadow popping up and disappearing again.

So, It seems that there is something inside the ShaderTransition.add_screen function code that ends up correcting the shadow position when making the screen_in and screen_out. 
Also if you disable ShaderTransition.remove_screen you can see the correct shadow clearly (but it freezes the screen).

kivy.uix.screenmanager.ShaderTransition.add_screen code
```
def add_screen(self, screen):
        self.screen_in.pos = self.screen_out.pos
        self.screen_in.size = self.screen_out.size
        self.manager.real_remove_widget(self.screen_out)
        self.manager.canvas.add(self.screen_out.canvas)

        def remove_screen_out(instr):
            Clock.schedule_once(self._remove_out_canvas, -1)
            self.render_ctx.remove(instr)

        self.fbo_in = self.make_screen_fbo(self.screen_in)
        self.fbo_out = self.make_screen_fbo(self.screen_out)
        self.manager.canvas.add(self.fbo_in)
        self.manager.canvas.add(self.fbo_out)

        self.render_ctx = RenderContext(fs=self.fs, vs=self.vs,
                                        use_parent_modelview=True,
                                        use_parent_projection=True)
        with self.render_ctx:
            BindTexture(texture=self.fbo_out.texture, index=1)
            BindTexture(texture=self.fbo_in.texture, index=2)
            x, y = self.screen_in.pos
            w, h = self.fbo_in.texture.size
            Rectangle(size=(w, h), pos=(x, y),
                      tex_coords=self.fbo_in.texture.tex_coords)
            Callback(remove_screen_out)
        self.render_ctx['tex_out'] = 1
        self.render_ctx['tex_in'] = 2
        self.manager.canvas.add(self.render_ctx)
```

Unfortunately, I don't understand clearly what is going on in the code. 
So, I hope this clue helps to get the definitive solution.