### PR TITLE
Implementing solution for issue #1340

### DIFF
--- a/kivymd/uix/datatables/datatables.kv
+++ b/kivymd/uix/datatables/datatables.kv
@@ -65,7 +65,7 @@
     size_hint_y: None
     height: self.minimum_height
     spacing: "4dp"
-    tooltip_text: root.text
+    tooltip_text: root.tooltip if root.tooltip else root.text
 
     BoxLayout:
         id: box

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -334,8 +334,8 @@ class TableHeader(ThemableBehavior, ScrollView):
                     (
                         CellHeader(
                             text=col_heading[0],
-                            tooltip=col_heading[2],
-                            sort_action=col_heading[3],
+                            sort_action=col_heading[2],
+                            tooltip=col_heading[3],
                             width=self.cols_minimum[i],
                             table_data=self.table_data,
                             is_sorted=(col_heading[0] == self.sorted_on),
@@ -344,7 +344,7 @@ class TableHeader(ThemableBehavior, ScrollView):
                         if len(col_heading) == 4
                         else CellHeader(
                             text=col_heading[0],
-                            tooltip=col_heading[2],
+                            sort_action=col_heading[2],
                             width=self.cols_minimum[i],
                             table_data=self.table_data,
                         )
@@ -359,7 +359,7 @@ class TableHeader(ThemableBehavior, ScrollView):
             else:
                 # Sets the text in the first cell.
                 self.ids.first_cell.text = col_heading[0]
-                self.ids.first_cell.tooltip = col_heading[2] if len(col_heading) in [3,4] else ''
+                self.ids.first_cell.tooltip = col_heading[3] if len(col_heading) == 4 else ''
                 self.ids.first_cell.ids.separator.height = 0
                 self.ids.first_cell.width = self.cols_minimum[i]
 

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -146,6 +146,14 @@ class CellHeader(MDTooltip, BoxLayout):
     and defaults to `''`.
     """
 
+    tooltip = StringProperty()
+    """
+    tooltip containing descriptive text for the column. If the tooltip
+    is not provided, column `text` shall be used instead.
+    :attr:`tooltip` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+    """
+
     # TODO: Added example.
     sort_action = ObjectProperty()
     """
@@ -326,16 +334,24 @@ class TableHeader(ThemableBehavior, ScrollView):
                     (
                         CellHeader(
                             text=col_heading[0],
-                            sort_action=col_heading[2],
+                            tooltip=col_heading[2],
+                            sort_action=col_heading[3],
                             width=self.cols_minimum[i],
                             table_data=self.table_data,
                             is_sorted=(col_heading[0] == self.sorted_on),
                             sorted_order=self.sorted_order,
                         )
-                        if len(col_heading) == 3
+                        if len(col_heading) == 4
                         else CellHeader(
                             text=col_heading[0],
+                            tooltip=col_heading[2],
                             width=self.cols_minimum[i],
+                            table_data=self.table_data,
+                        )
+                        if len(col_heading) == 3
+                        else CellHandler(
+                            text=col_heading[0],
+                            width=self.cols_minimum[i]
                             table_data=self.table_data,
                         )
                     )
@@ -343,6 +359,7 @@ class TableHeader(ThemableBehavior, ScrollView):
             else:
                 # Sets the text in the first cell.
                 self.ids.first_cell.text = col_heading[0]
+                self.ids.first_cell.tootip = col_heading[2] if len(col_heading) in [3,4] else ''
                 self.ids.first_cell.ids.separator.height = 0
                 self.ids.first_cell.width = self.cols_minimum[i]
 

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -359,7 +359,7 @@ class TableHeader(ThemableBehavior, ScrollView):
             else:
                 # Sets the text in the first cell.
                 self.ids.first_cell.text = col_heading[0]
-                self.ids.first_cell.tootip = col_heading[2] if len(col_heading) in [3,4] else ''
+                self.ids.first_cell.tooltip = col_heading[2] if len(col_heading) in [3,4] else ''
                 self.ids.first_cell.ids.separator.height = 0
                 self.ids.first_cell.width = self.cols_minimum[i]
 

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -351,7 +351,7 @@ class TableHeader(ThemableBehavior, ScrollView):
                         if len(col_heading) == 3
                         else CellHandler(
                             text=col_heading[0],
-                            width=self.cols_minimum[i]
+                            width=self.cols_minimum[i],
                             table_data=self.table_data,
                         )
                     )

--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -349,7 +349,7 @@ class TableHeader(ThemableBehavior, ScrollView):
                             table_data=self.table_data,
                         )
                         if len(col_heading) == 3
-                        else CellHandler(
+                        else CellHeader(
                             text=col_heading[0],
                             width=self.cols_minimum[i],
                             table_data=self.table_data,


### PR DESCRIPTION
### Description of the problem

This PR is intended to implement a solution for issue #1340 which I raised previously. This PR adds the ability to create a custom tooltip to be displayed as a descriptive text for the column instead of just displaying the column name.

### Description of Changes

This PR introduces a new variable `tooltip` of type `kivy.properties.StringProperty` to contain the descriptive text for the column. The `column_data` property is also expanded to contain a tuple of 4 items instead of 3 as before. The items are arrange in the form `column_data = [ (column_name, column_size, column_tooltip, column_sort_function) ]`

### Screenshots of the solution

![image](https://user-images.githubusercontent.com/35004147/189613793-6c6793a0-ce14-45c8-a7f4-d8e917ddb9c5.png)

### Code for testing new changes

```python
from kivymd.app import MDApp
from kivymd.uix.datatables import MDDataTable
from kivy.metrics import dp

class TestApp(MDApp):
    def build (self):
        return MDDataTable(column_data = [("column 1",dp(30),"this is column one"), ("column2",dp(30),"this is column two")]

TestApp().run()
```
