### PR TITLE
Fix `MDDatePicker` bug

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -1600,9 +1600,3 @@ class MDDatePicker(BaseDialogPicker):
             else self.year
         )
         self.update_calendar(year, month)
-        if self.sel_day:
-            x = calendar.monthrange(year, month)[1]
-            if x < self.sel_day:
-                self.sel_day = (
-                    x if year <= self.sel_year and month <= self.sel_year else 1
-                )


### PR DESCRIPTION
The selected date now does not change when switching to another page.



### Description of the problem

#1365

### Description of Changes

When switching the page, the `MDDatePicker.change_month` function is called. At the end of the function we see the following lines:

```python
if self.sel_day:
    x = calendar.monthrange(year, month)[1]
    if x < self.sel_day:
        self.sel_day = (
            x if year <= self.sel_year and month <= self.sel_year else 1
        )
```
These lines change the day of the selected date if there are too few days in the month we switched to. Perhaps it was an attempt to fix some bug. But there is no reason to change the day of the selected date when switching to another page. So I deleted these lines.


### Code for testing new changes

Use the same code as in the issue:

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        date_dialog = MDDatePicker(day=31, month=10, year=2022)
        date_dialog.bind(on_save=self.on_save)
        date_dialog.open()

    def on_save(self, instance, value, date_range):
        print(value)


Test().run()
```

### Screenshots of the solution to the problem

The selected date is October 31:

![image](https://user-images.githubusercontent.com/27895729/193341905-90c65c59-292a-4e3f-af03-e624a5c5677e.png)

Switch to the previous month:

![image](https://user-images.githubusercontent.com/27895729/193341988-4b32c38e-3d58-4207-be9d-a5e0956c7ea8.png)

The date label text is not changed:

![image](https://user-images.githubusercontent.com/27895729/193342076-fb37e4bb-282a-4a61-9a58-f4d6fe5c1ea1.png)

Switch back to the October page:

![image](https://user-images.githubusercontent.com/27895729/193342165-c9869bbc-0a4c-4d6f-97ee-5f5fb0066740.png)

Both the date label and the highlighted date say that we have selected October 31:

![image](https://user-images.githubusercontent.com/27895729/193342207-8c7c2597-f55b-4c0b-9c20-71bec603f58b.png)

Click OK:

![image](https://user-images.githubusercontent.com/27895729/193342391-8518f98d-344f-44c0-827b-d566967b3a18.png)

The `on_save` handler gets October 31, which we have selected:

![image](https://user-images.githubusercontent.com/27895729/193342540-6c266aa6-0247-4856-b22e-91512d183ea8.png)
