### PR TITLE
Fix `MDDatePicker` bug in displaying the selected date range

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.kv
+++ b/kivymd/uix/pickers/datepicker/datepicker.kv
@@ -355,12 +355,14 @@
                 if root.theme_cls.device_orientation == "portrait" \
                 else \
                 (dp(32), dp(28)) \
-                if self.index in [6, 13, 20, 27, 30] or self.owner._date_range \
+                if self.index in [6, 13, 20, 27, 34] or self.owner._date_range \
                 and self.text and self.owner._date_range[-1] == date( \
                 self.current_year, \
                 self.current_month, \
                 int(self.text) \
                 ) \
+                or self.text and int(self.text) == \
+                calendar.monthrange(self.current_year, self.current_month)[1] \
                 else (dp(46), dp(28))
             pos:
                 (self.x - dp(1.5), self.y + dp(5)) \


### PR DESCRIPTION
### Description of the problem

See #1367

### Reproducing the problem

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        date_dialog = MDDatePicker(mode='range')
        date_dialog.open()


Test().run()
```

### Screenshots of the problem

![image](https://user-images.githubusercontent.com/27895729/193377533-4f024a5c-de23-4634-9397-5339c66a2770.png)

### Description of Changes

To display the selection of the range, semi-transparent rectangles are drawn behind each day label. In landscape orientation, a lot of empty space appears between adjacent labels, therefore, to make the selection look continuous, rectangles are drawn wider. 

However, if wide rectangles are drawn for day labels, after which there are no other day labels in this row anymore, it will be seen that the selection on the right is wider than on the left. If wide rectangles are drawn for the last day of the selected range, it will look as if the selection goes beyond the circle that highlights the end of the range. So some rectangles should be wide and some should be narrow.

In `datepicker.kv` file we see the following lines specifying the size of described rectangles:

```kv
size:
    (dp(44), dp(32)) \
    if root.theme_cls.device_orientation == "portrait" \
    else \
    (dp(32), dp(28)) \
    if self.index in [6, 13, 20, 27, 30] or self.owner._date_range \
    and self.text and self.owner._date_range[-1] == date( \
    self.current_year, \
    self.current_month, \
    int(self.text) \
    ) \
    else (dp(46), dp(28))
```

Narrow rectangles are drawn for labels of days with indexes 6, 13, 20, 27, and 30. The first four indexes correspond to the Sundays of the first four weeks. However, the index 30 corresponds not to Sunday of the fifth week, but to Wednesday. To fix this error, I replaced 30 with 34.

Also, a rectangle is drawn narrow if it corresponds to the end of the selected range. That's right. But there is another case where the rectangle should be drawn narrow: if it corresponds to the last day of the month. Therefore, I introduced an additional condition that says that the rectangle should be narrow if its day number is equal to the number of days in the current month.

### Screenshots of the solution to the problem

![image](https://user-images.githubusercontent.com/27895729/193378694-478991b0-9d88-420a-b66d-6020138367e1.png)
