### PR TITLE
fix elevation for low opengl versions

### DIFF
--- a/kivymd/data/glsl/elevation/elevation.frag
+++ b/kivymd/data/glsl/elevation/elevation.frag
@@ -10,6 +10,14 @@ corner radius:
 https://iquilezles.org/articles/distfunctions
 */
 
+// For lower opengl version
+
+float custom_smoothstep(float a, float b, float x) {
+    float t = clamp((x - a) / (b - a), 0.0, 1.0);
+
+    return t * t * (3.0 - 2.0 * t);
+}
+
 float roundedBoxSDF(vec2 centerPosition, vec2 size, vec4 radius) {
     radius.xy = (centerPosition.x > 0.0) ? radius.xy : radius.zw;
     radius.x = (centerPosition.y > 0.0) ? radius.x : radius.y;
@@ -21,7 +29,7 @@ float roundedBoxSDF(vec2 centerPosition, vec2 size, vec4 radius) {
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Smooth the result (free antialiasing).
     float edge0 = 0.0;
-    float smoothedAlpha = 1.0 - smoothstep(0.0, edge0, 1.0);
+    float smoothedAlpha = 1.0 - custom_smoothstep(0.0, edge0, 1.0);
     // Get the resultant shape.
     vec4 quadColor = mix(
         vec4(
@@ -37,7 +45,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float shadowDistance = roundedBoxSDF(
         fragCoord.xy - mouse.xy - (size / 2.0), size / 2.0, shadow_radius
     );
-    float shadowAlpha = 1.0 - smoothstep(
+    float shadowAlpha = 1.0 - custom_smoothstep(
         -shadow_softness, shadow_softness, shadowDistance
     );
     fragColor = mix(quadColor, shadow_color, shadowAlpha - smoothedAlpha);

--- a/kivymd/uix/behaviors/elevation.py
+++ b/kivymd/uix/behaviors/elevation.py
@@ -611,7 +611,7 @@ class CommonElevationBehavior(Widget):
         with self.context:
             self.rect = RoundedRectangle(pos=self.pos, size=self.size)
 
-        Clock.schedule_once(self.after_init)
+        self.after_init()
 
     def after_init(self, *args):
         Clock.schedule_once(self.check_for_relative_behavior)


### PR DESCRIPTION
Closes #1352
### Description of the problem

SIGFAULT of app while rendering shadow

### Solution
Just by adding custom_smoothstep

### Reproducing the problem

```python
from kivy.lang import Builder
from kivymd.app import MDApp
from kivy.animation import Animation
KV = """
MDRelativeLayout:
	md_bg_color:0,0,0,1
	MDCard:
		pos_hint:{"center_x":0.5,"center_y":0.5}
		md_bg_color:1,0,0,1
		size_hint:0.5,0.5
		elevation:2
"""

class App(MDApp):
	
	def build(self):
		return Builder.load_string(KV)

	def animate(self,instance):
		Animation(pos_hint)
App().run()

```
The above code segfaluts on low opengl because `smoothstep` is missing and by adding `custom_smoothstep` the problem is fixed 

### Screenshots of the problem

![image](https://user-images.githubusercontent.com/68729523/193508598-515b9145-1daa-48b7-bc9f-005243251159.png)


### Screenshots of the solution to the problem


![image](https://user-images.githubusercontent.com/68729523/193508339-2752b5d9-e378-4b56-bc80-e1af385f5586.png)

custom_smoothstep taken from https://registry.khronos.org/OpenGL-Refpages/gl4/html/smoothstep.xhtml