### PR TITLE
Fix `MDDatePicker` bug (#1169)

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -771,7 +771,7 @@ class DatePickerYearSelectableItem(RecycleDataViewBehavior, MDLabel):
         if super().on_touch_down(touch):
             return True
         if self.collide_point(*touch.pos) and self.selectable:
-            self.owner.year = int(self.text)
+            self.owner.sel_year = int(self.text)
             # self.owner.sel_year = self.owner.year
             self.owner.ids.label_full_date.text = self.owner.set_text_full_date(
                 self.owner.sel_year,
@@ -1077,10 +1077,10 @@ class MDDatePicker(BaseDialogPicker):
 
         self._calendar_layout.clear_widgets()
         self.generate_list_widgets_days()
-        self.update_calendar(self.year, self.month)
+        self.update_calendar(self.sel_year, self.sel_month)
 
         if self.mode != "range":
-            self.set_month_day(self.day)
+            self.set_month_day(self.sel_day)
             self._sel_day_widget.dispatch("on_release")
 
     def transformation_to_dialog_select_year(self) -> None:
@@ -1529,7 +1529,6 @@ class MDDatePicker(BaseDialogPicker):
     def set_month_day(self, day) -> None:
         for idx in range(len(self._calendar_list)):
             if str(day) == str(self._calendar_list[idx].text):
-                self._sel_day_widget = self._calendar_list[idx]
                 self.sel_day = int(self._calendar_list[idx].text)
                 if self._sel_day_widget:
                     self._sel_day_widget.is_selected = False


### PR DESCRIPTION
### Description of the problem

See #1169. Switching to the year selection dialog and back resets the selected date to default.

### Description of Changes

@floi is right. `MDDatePicker.transformation_from_dialog_select_year` method (that is called when switching back via the triangle icon) uses the `day` field, which is responsible for the default date day set by the user, instead of using the `sel_day` field, which is responsible for the selected date day. I have fixed it.

In the same method, the author makes a similar mistake: he uses `year` and `month` instead of `sel_year` and `sel_month` to update the calendar. It works because the same mistake is made in the `DatePickerYearSelectableItem.on_touch_down` method, which, when clicked on the year, sets the `year` field instead of `sel_year`. It's not directly related to the bug, but I have fixed it in the same PR, because it's very close to the issue and because it threatens to become a source of bugs in the future.

In addition, an error in the `MDDatePicker.set_month_day` method caused the selection not to be removed from the previously selected date widget, and we saw two selected dates at the same time — the old and the new.

### Code for testing new changes

```python
from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker

KV = '''
MDFloatLayout:

    MDTopAppBar:
        title: "MDDatePicker"
        pos_hint: {"top": 1}
        elevation: 10

    MDRaisedButton:
        id:button
        text: "Open date picker"
        pos_hint: {'center_x': .5, 'center_y': .5}
        on_release: app.show_date_picker()
'''


class Test(MDApp):
    def build(self):
        return Builder.load_string(KV)

    def on_save(self, instance, value, date_range):
        '''
        Events called when the "OK" dialog box button is clicked.

        :type instance: <kivymd.uix.picker.MDDatePicker object>;

        :param value: selected date;
        :type value: <class 'datetime.date'>;

        :param date_range: list of 'datetime.date' objects in the selected range;
        :type date_range: <class 'list'>;
        '''

        print(instance, value, date_range)
        self.root.ids.button.text = str(value)

    def on_cancel(self, instance, value):
        '''Events called when the "CANCEL" dialog box button is clicked.'''

    def show_date_picker(self):
        self.date_dialog = MDDatePicker()
        self.date_dialog.bind(on_save=self.on_save, on_cancel=self.on_cancel)
        self.date_dialog.open()

Test().run()
```


### Screenshots of the solution to the problem

Run the code:

![image](https://user-images.githubusercontent.com/27895729/193663887-30164bf3-a65c-4530-ab3f-dde5808b351c.png)

Click on the button:

![image](https://user-images.githubusercontent.com/27895729/193663976-9b1ad45f-e842-41cb-9a4c-55efd22df88d.png)

Select a different day than the default (October 20):

![image](https://user-images.githubusercontent.com/27895729/193664130-5a28a35f-0e75-437a-ab3f-205901e67101.png)

Switch to year mode via the triangle icon:

![image](https://user-images.githubusercontent.com/27895729/193664481-ef9befa4-6d6a-4fd5-9c27-eed13840c979.png)

Without changing the year, switch back to day selection:

![image](https://user-images.githubusercontent.com/27895729/193664614-8173367e-94a6-4869-8334-1974631186ef.png)

The date we selected earlier still seems selected. 

Click on the OK:

![image](https://user-images.githubusercontent.com/27895729/193665019-f3c620c7-2d2d-436b-8c07-191116c2baed.png)

The date we selected is written on the button, as expected.