### PR TITLE
Fix `MDDatePicker` bug: year duplicates

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -1545,6 +1545,7 @@ class MDDatePicker(BaseDialogPicker):
         pass
 
     def generate_list_widgets_years(self) -> None:
+        self.ids._year_layout.data = []
         for i, number_year in enumerate(range(self.min_year, self.max_year)):
             self.ids._year_layout.data.append(
                 {


### PR DESCRIPTION
### Description of the problem

If you switch to the year selection and back several times, duplicates appear in the list of years. When you click on duplicates, widgets that have been duplicated are highlighted, but not the duplicates themselves, which creates the feeling that nothing is happening. Maybe, closes issue #1164.

### Reproducing the problem

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.date_picker = MDDatePicker(min_year=2020, max_year=2022)
        self.date_picker.open()


Test().run()
```

### Screenshots of the problem

![image](https://user-images.githubusercontent.com/27895729/193775943-dab712de-8631-406a-bb70-48864f8f319c.png)

![image](https://user-images.githubusercontent.com/27895729/193776003-788f1c4c-91e3-41bb-911c-f4b3c0c73be1.png)

![image](https://user-images.githubusercontent.com/27895729/193776067-b3383e8c-5e08-42b0-9921-db9c72d92c72.png)

![image](https://user-images.githubusercontent.com/27895729/193776134-e1de6e19-7c26-4f3a-ba07-072f6a074c63.png)

### Description of Changes

I added clearing the list before filling in.

### Screenshots of the solution to the problem

![image](https://user-images.githubusercontent.com/27895729/193776615-740ea035-2180-4b99-9361-52bf1271112c.png)

![image](https://user-images.githubusercontent.com/27895729/193776669-07711d66-3c84-4329-af34-72f6de07af54.png)

![image](https://user-images.githubusercontent.com/27895729/193776718-5a3d6f76-61db-47cd-9a09-ff3b9f25ab08.png)

![image](https://user-images.githubusercontent.com/27895729/193776767-29b8d7a4-1578-426d-81be-14c68572c77f.png)
