### PR TITLE
Fix `MDDatePicker` bug: no year initial selection

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -1099,6 +1099,9 @@ class MDDatePicker(BaseDialogPicker):
         self.ids.triangle.icon = "menu-up"
         self.generate_list_widgets_years()
         self.set_position_to_current_year()
+        if self.min_year <= self.year < self.max_year:
+            index = self.year - self.min_year
+            self.ids._year_layout.children[0].select_node(index)
 
     def transformation_to_dialog_input_date(self) -> None:
         def set_date_to_input_field():


### PR DESCRIPTION

### Description of the problem

If you switch to year selection for the first time, no year will be highlighted.

### Reproducing the problem

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.date_picker = MDDatePicker(min_year=2020, max_year=2024)
        self.date_picker.open()


Test().run()
```

### Screenshots of the problem

![image](https://user-images.githubusercontent.com/27895729/193783361-a5381bfd-a997-4cca-b2a7-8ab5e828c448.png)

![image](https://user-images.githubusercontent.com/27895729/193783422-5d9a65ca-19e7-4c2f-b68a-c5dcc65342c0.png)

### Description of Changes

Now, every time the user switches to the year selection, the current year is highlighted as selected, because if you do nothing and go back, you will get to the previous year. If the current year is not in the list, nothing is selected.

### Screenshots of the solution to the problem

![image](https://user-images.githubusercontent.com/27895729/193784306-a3e94d72-decc-4009-bfd8-8175a749fde1.png)

![image](https://user-images.githubusercontent.com/27895729/193784355-8850da5f-b7f0-440b-8154-06e54e4cac81.png)
