### PR TITLE
Fix #1371: `MDDatePicker` date selection error

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -1406,10 +1406,7 @@ class MDDatePicker(BaseDialogPicker):
                 "set_text_full_date:\n\t" f"Month [{month}] out of range."
             )
         if int(day) > calendar.monthrange(int(year), (month))[1]:
-            raise ValueError(
-                "set_text_full_date:\n\t"
-                f"Day [{day}] out of range for the month {month}"
-            )
+            return ""
         date = datetime.date(int(year), int(month), int(day))
         separator = (
             "\n"


### PR DESCRIPTION
### Description of the problem

#1371 Error when trying to select a date in a month, the number of days in which is less than the day number of the currently selected date.

### Description of Changes

Now, the `set_text_full_date` method does not throw an error if the selected date turned out to be incorrect. It is expected that further changes of the day, month or year may make the date correct. This is a quick fix.

### Code for testing new changes

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.date_picker = MDDatePicker()
        self.date_picker.open()


Test().run()
```

### Screenshots of the solution to the problem

![image](https://user-images.githubusercontent.com/27895729/193990009-dc41b9fa-842f-40f5-97ca-ba4140efcc37.png)

![image](https://user-images.githubusercontent.com/27895729/193990036-41441571-47cb-4f16-a455-58b1dfd13fa1.png)

![image](https://user-images.githubusercontent.com/27895729/193990072-792e5992-a552-4746-a5f3-7eee8216cc1c.png)