### PR TITLE
`MDDatePicker`: Fix #1377.

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -1057,9 +1057,7 @@ class MDDatePicker(BaseDialogPicker):
         Animation(opacity=1, d=0.15).start(self.ids.chevron_left)
         Animation(opacity=1, d=0.15).start(self.ids.chevron_right)
         Animation(_scale_year_layout=0, d=0.15).start(self)
-        Animation(
-            _shift_dialog_height=dp(0), _scale_calendar_layout=1, d=0.15
-        ).start(self)
+        Animation(_scale_calendar_layout=1, d=0.15).start(self)
 
         self._calendar_layout.clear_widgets()
         self.generate_list_widgets_days()
@@ -1076,9 +1074,9 @@ class MDDatePicker(BaseDialogPicker):
 
         self._select_year_dialog_open = True
         self.ids._year_layout.disabled = False
-        self._scale_calendar_layout = 0
         Animation(opacity=0, d=0.15).start(self.ids.chevron_left)
         Animation(opacity=0, d=0.15).start(self.ids.chevron_right)
+        Animation(_scale_calendar_layout=0, d=0.15).start(self)
         anim = Animation(_scale_year_layout=1, d=0.15)
         anim.bind(on_complete=disabled_chevron_buttons)
         anim.start(self)


### PR DESCRIPTION
### Description of the problem

When we switch to the calendar from the year selection dialog, an animation starts, which increases the size of the calendar to the maximum in 150ms. But when we switch to the year selection dialog, the size of the calendar instantly decreases to 0. If the animation did not finish when the size was set to 0, it will continue to increase the size of the calendar. Eventually, the calendar size will become the maximum, and the size of the year selection dialog will become the maximum too. So, we see them both.

### Description of Changes

Now, when switching to the year selection dialog, an animation starts, which reduces the calendar size in the same 150ms. This ensures that the last size setting to 0 will occur after the animation of increasing the size is completed. This is not a good solution, because we can't show the calendar instantly, but the user experience from too slow animation will be better than from mixing two dialogs. To fix this problem correctly, we will have to complicate the animation system so that when new animations are started, the previous ones are completed instantly.

Also, I removed the animation of increasing the height of the entire dialog box to the maximum, which started when switching from the year selection dialog. Obviously, this is a mistake, because this height is already set to maximum.

### Code for testing new changes

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.date_picker = MDDatePicker()
        self.date_picker.open()


Test().run()
```


### Screenshots of the solution to the problem

https://user-images.githubusercontent.com/27895729/194469204-d0eccdf6-4bf5-46fa-8cb3-7cb2bcae7b54.mp4