### PR TITLE
`MDDatePicker`: Fix a crash when switching to a month BC

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -1545,31 +1545,9 @@ class MDDatePicker(BaseDialogPicker):
         Called when "chevron-left" and "chevron-right" buttons are pressed.
         Switches the calendar to the previous/next month.
         """
-
-        operation = 1 if operation == "next" else -1
-        month = (
-            12
-            if self.month + operation == 0
-            else 1
-            if self.month + operation == 13
-            else self.month + operation
-        )
-        year = (
-            self.year - 1
-            if self.month + operation == 0
-            else self.year + 1
-            if self.month + operation == 13
-            else self.year
-        )
+        month_delta = 1 if operation == "next" else -1
+        year = self.year + (self.month - 1 + month_delta) // 12
+        month = (self.month - 1 + month_delta) % 12 + 1
+        if year <= 0:
+            year, month = 1, 1
         self.update_calendar(year, month)
-
-        # TODO: perhaps this PR - https://github.com/kivymd/KivyMD/pull/1366 -
-        #  does not take into account all the nuances.
-        #  Therefore, the code that was removed by this PR has been added
-        #  and commented out.
-        # if self.sel_day:
-        #     x = calendar.monthrange(year, month)[1]
-        #     if x < self.sel_day:
-        #         self.sel_day = (
-        #             x if year <= self.sel_year and month <= self.sel_year else 1
-        #         )


### PR DESCRIPTION

### Description of the problem

When trying to switch to the month before January 1, the program crashes with an error. I doubt that anyone will face this problem in practice, so I did not figure out how to remove the left chevron when switching to January 1, but at least it is easy to fix the program crash.

### Reproducing the problem

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.date_picker = MDDatePicker(day=1, month=1, year=1)
        self.date_picker.open()


Test().run()
```

### Screenshots of the problem


https://user-images.githubusercontent.com/27895729/194481022-d2cca226-597c-478c-81b8-4d392849fb47.mp4

### Description of Changes

The code of `change_month` has been slightly simplified. Added a condition canceling the transition to the previous month. 

Also, I removed the outdated TODO. After #1375, it is clear that the commented code will not be needed, because there is no movement of the selection when we switch between calendar pages, which means that the selection does not need to be corrected. But if you think that TODO is still necessary, I will return it with the next commit.

### Screenshots of the solution to the problem

https://user-images.githubusercontent.com/27895729/194484720-c8128412-47e5-4cec-afed-88506eaacb36.mp4

