### PR TITLE
DatePicker: Clear selection when year is out of range

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -1086,6 +1086,8 @@ class MDDatePicker(BaseDialogPicker):
         if self.min_year <= self.year < self.max_year:
             index = self.year - self.min_year
             self.ids._year_layout.children[0].select_node(index)
+        else:
+            self.ids._year_layout.children[0].clear_selection()
 
     def transformation_to_dialog_input_date(self) -> None:
         def set_date_to_input_field():


### PR DESCRIPTION
### Describe the algorithm of actions that leads to the problem

1. Go to the calendar page of the year between `min_year` and `max_year`.
2. Switch to the year selecting dialog via the triangle icon and back.
3. Then, using chevrons, go to any month of the year outside the range.
4. Switch to the year selection dialog via the triangle icon.

The previously selected year is highlighted as selected. However, if you go back to the calendar without selecting anything, you will be taken to the year you were before switching to the year selection dialog, not to the highlighted one. If the current year is outside the range, no year should be highlighted, because the user expects that going back will bring him to the highlighted year.

### Reproducing the problem

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.date_picker = MDDatePicker(day=1, month=1, year=1914)
        self.date_picker.open()


Test().run()
```

### Screenshots of the problem

https://user-images.githubusercontent.com/27895729/194542317-641c0da3-8909-4add-a51f-f1ea5fd6a37c.mp4

### Description of Changes

The existing code each time the year selection dialog opens sets the selection on the current year widget. If there is no such widget, nothing is selected. But it is also important to clear the selection that could have remained after previous dialog openings. So I added the appropriate check.

### Screenshots of the solution to the problem

https://user-images.githubusercontent.com/27895729/194544406-bb1e8a1d-b803-4216-985e-390bba6e5ff1.mp4
