### PR TITLE
MDDatePicker: Simplify selection circles + Fix #1383

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.kv
+++ b/kivymd/uix/pickers/datepicker/datepicker.kv
@@ -307,34 +307,6 @@
         else (dp(32), dp(32))
     disabled: True
 
-    canvas:
-        Color:
-            rgba:
-                ( \
-                ( \
-                self.theme_cls.primary_color if not root.owner.selector_color \
-                else root.owner.selector_color \
-                ) \
-                if root.is_selected and not self.disabled \
-                else (0, 0, 0, 0) \
-                ) \
-                if self.owner.mode != "range" else \
-                ( \
-                ( \
-                self.theme_cls.primary_color if not root.owner.selector_color \
-                else root.owner.selector_color \
-                ) \
-                if root.is_selected and not self.disabled \
-                and (self.owner.mode == "range" and self.owner._start_range_date) \
-                else (0, 0, 0, 0) \
-                )
-        Ellipse:
-            size:
-                (dp(42), dp(42)) \
-                if root.theme_cls.device_orientation == "portrait" \
-                else (dp(32), dp(32))
-            pos: self.pos
-
     # Fill marking the available dates of the range, if using the `range` mode
     # or use `min_date/max_date`.
     canvas.before:
@@ -397,29 +369,15 @@
                 else [0, 0, 0, 0]) \
                 )
 
-        # Circle marking the beginning and end of the date range if the "range"
-        # mode is used.
+        # Selection circle.
         Color:
             rgba:
-                [0, 0, 0, 0] if not self.owner._date_range else \
-                (
                 ( \
                 self.theme_cls.primary_color if not root.owner.selector_color \
                 else root.owner.selector_color \
                 ) \
-                if self.text and self.owner._date_range[0] == date( \
-                self.current_year, \
-                self.current_month, \
-                int(self.text) \
-                ) \
-                or \
-                self.text and self.owner._date_range[-1] == date( \
-                self.current_year, \
-                self.current_month, \
-                int(self.text) \
-                ) \
-                else (0, 0, 0, 0) \
-                )
+                if root.is_selected and not self.disabled \
+                else (0, 0, 0, 0)
         Ellipse:
             size:
                 (dp(42), dp(42)) \

--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -1272,7 +1272,11 @@ class MDDatePicker(BaseDialogPicker):
 
     def update_calendar(self, year, month) -> None:
         self.year, self.month = year, month
-        selected_date = date(self.sel_year, self.sel_month, self.sel_day)
+        if self.mode == "picker":
+            selected_date = date(self.sel_year, self.sel_month, self.sel_day)
+            selected_dates = {selected_date}
+        else:
+            selected_dates = {self._start_range_date, self._end_range_date}
         dates = self.calendar.itermonthdates(year, month)
         for widget, widget_date in zip_longest(self._calendar_list, dates):
             # Only widgets whose dates are in the displayed month are visible.
@@ -1285,7 +1289,7 @@ class MDDatePicker(BaseDialogPicker):
             widget.current_year = year
             widget.current_month = month
             widget.is_today = visible and widget_date == self.today
-            widget.is_selected = visible and widget_date == selected_date
+            widget.is_selected = visible and widget_date in selected_dates
             # I don't understand why, but this line is important. Without this
             # line, some widgets that we are trying to disable remain enabled.
             widget.disabled = False


### PR DESCRIPTION
### Description of Changes

Previously, each `MDDatePickerDaySelectableItem` had two circles to highlight the selected date. They differed only in the logic of determining when to show the circle. Now he has only one left, and the logic of its display is entirely controlled by `update_calendar`. Also, it fixes #1383.

### Screenshots of the solution to the problem

https://user-images.githubusercontent.com/27895729/194692880-853e9055-e94e-4ed9-871f-2b7bbaf4c0c8.mp4