### PR TITLE
MDDatePicker: Move some logic from kv to code

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.kv
+++ b/kivymd/uix/pickers/datepicker/datepicker.kv
@@ -317,9 +317,7 @@
                 if self.owner.selector_color \
                 else self.theme_cls.primary_color[:-1] + [.3] \
                 ) \
-                if not self.disabled \
-                and self.text \
-                and self.check_date(self.owner.year, self.owner.month, int(self.text)) \
+                if self.is_in_range \
                 else (0, 0, 0, 0)
         RoundedRectangle:
             size:
@@ -327,47 +325,19 @@
                 if root.theme_cls.device_orientation == "portrait" \
                 else \
                 (dp(32), dp(28)) \
-                if self.index in [6, 13, 20, 27, 34] or self.owner._date_range \
-                and self.text and self.owner._date_range[-1] == date( \
-                self.current_year, \
-                self.current_month, \
-                int(self.text) \
-                ) \
-                or self.text and int(self.text) == \
-                calendar.monthrange(self.current_year, self.current_month)[1] \
+                if self.is_range_end or self.is_week_end or self.is_month_end \
                 else (dp(46), dp(28))
             pos:
                 (self.x - dp(1.5), self.y + dp(5)) \
                 if root.theme_cls.device_orientation == "portrait" else \
                 (self.x, self.y + 1)
             radius:
-                [0, 0, 0, 0] if not self.owner._date_range else \
-                ( \
-                [self.width / 2, 0, 0, self.width / 2] \
-                if self.text and self.owner._date_range[0] == date( \
-                self.current_year, \
-                self.current_month, \
-                int(self.text) \
-                ) \
-                or (self.index in [0, 7, 14, 21, 28] and root.is_selected) \
-                else \
-                ( \
-                [0, 0, 0, 0] if self.text \
-                and self.owner._date_range[-1] != date( \
-                self.current_year, \
-                self.current_month, \
-                int(self.text) \
-                ) \
-                and self.index not in [6, 13, 20, 27, 30] \
-                else [0, self.width / 2, self.width, 0] \
-                if root.is_selected or self.text \
-                and self.owner._date_range[-1] == date( \
-                self.current_year, \
-                self.current_month, \
-                int(self.text) \
-                ) \
-                else [0, 0, 0, 0]) \
-                )
+                [
+                self.width / 2 if self.is_range_start else 0,
+                self.width / 2 if self.is_range_end else 0,
+                self.width / 2 if self.is_range_end else 0,
+                self.width / 2 if self.is_range_start else 0,
+                ]
 
         # Selection circle.
         Color:


### PR DESCRIPTION
### Description of Changes

Previously, complex calculations of the size and radius of the corners of rectangles highlighting the selected date range were performed in the kv file. The widget itself was trying to figure out whether its date is in the selected range, whether it corresponds to the end of the range, and whether other dates are shown on the right. Now, `update_calendar` independently performs these calculations and informs the widget only of the information that directly affects its display. 

I added the `is_in_range`, `is_range_start` and `is_range_end` properties so that the widget does not perform calculations with dates. As a result, the `current_year` property, `current_month` property, and `check_date` method became unnecessary, so I removed them.

As I described in #1368, some selection rectangles in landscape orientation should be wider, others narrower. It depends on whether the date is the end of the range, month or week. Now, this information is supplied by setting the properties `is_range_end`, `is_month_end` and `is_week_end`. The `is_week_end` property never changes after the widget is created, and the rest of the properties are set inside the `update_calendar`. Since now the widget does not calculate its place on the calendar, the `index` property is no longer needed, so it was removed.