### PR TITLE
MDDatePicker: Refactor color rules

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.kv
+++ b/kivymd/uix/pickers/datepicker/datepicker.kv
@@ -31,9 +31,7 @@
 
         canvas:
             Color:
-                rgb:
-                    app.theme_cls.primary_color \
-                    if not root.primary_color else root.primary_color
+                rgb: root.primary_color or app.theme_cls.primary_color
             RoundedRectangle:
                 size:
                     (dp(328), dp(120)) \
@@ -48,9 +46,7 @@
                     if root.theme_cls.device_orientation == "portrait" \
                     else (root.radius[0], dp(0), dp(0), root.radius[3])
             Color:
-                rgba:
-                    app.theme_cls.bg_normal \
-                    if not root.accent_color else root.accent_color
+                rgba: root.accent_color or app.theme_cls.bg_normal
             RoundedRectangle:
                 size:
                     (dp(328), dp(512) - dp(120) - root._shift_dialog_height) \
@@ -79,9 +75,7 @@
                 (dp(24), root.height - self.height - dp(18)) \
                 if root.theme_cls.device_orientation == "portrait" \
                 else (dp(24), root.height - self.height - dp(24))
-            text_color:
-                root.specific_text_color \
-                if not root.text_toolbar_color else root.text_toolbar_color
+            text_color: root.text_toolbar_color or root.specific_text_color
 
         MDLabel:
             id: label_full_date
@@ -104,24 +98,11 @@
                 root.set_text_full_date(root.sel_year, root.sel_month, root.sel_day, \
                 root.theme_cls.device_orientation)
             text_color:
-                ( \
-                root.specific_text_color \
-                if not root.text_toolbar_color else root.text_toolbar_color \
-                ) \
-                if root.theme_cls.device_orientation == "portrait" \
-                else \
-                ( \
-                ( \
-                self.theme_cls.primary_color \
-                if not root.primary_color else root.primary_color \
-                ) \
-                if root._input_date_dialog_open \
-                else \
-                ( \
-                root.specific_text_color \
-                if not root.text_toolbar_color else root.text_toolbar_color \
-                ) \
-                )
+                root.text_toolbar_color or root.specific_text_color \
+                if root.theme_cls.device_orientation == "portrait" else \
+                root.primary_color or self.theme_cls.primary_color \
+                if root._input_date_dialog_open else \
+                root.text_toolbar_color or root.specific_text_color
 
         RecycleView:
             id: _year_layout
@@ -164,9 +145,7 @@
                 (root.height - dp(120) + dp(12)) \
                 if root.theme_cls.device_orientation == "portrait" \
                 else  dp(12)
-            text_color:
-                root.specific_text_color \
-                if not root.text_toolbar_color else root.text_toolbar_color
+            text_color: root.text_toolbar_color or root.specific_text_color
 
         MDLabel:
             id: label_month_selector
@@ -180,9 +159,7 @@
                 (dp(24), root.height - dp(120) - self.height - dp(20)) \
                 if root.theme_cls.device_orientation == "portrait" \
                 else (dp(168) + dp(24), label_title.y)
-            text_color:
-                app.theme_cls.text_color \
-                if not root.text_color else root.text_color
+            text_color: root.text_color or app.theme_cls.text_color
 
         DatePickerIconTooltipButton:
             id: triangle
@@ -199,9 +176,7 @@
                 (label_month_selector.width + dp(14), root.height - dp(123) - self.height) \
                 if root.theme_cls.device_orientation == "portrait" \
                 else (dp(180) + label_month_selector.width, label_title.y - dp(14))
-            text_color:
-                app.theme_cls.text_color \
-                if not root.text_color else root.text_color
+            text_color: root.text_color or app.theme_cls.text_color
             md_bg_color_disabled: 0, 0, 0, 0
 
         DatePickerIconTooltipButton:
@@ -218,9 +193,7 @@
                 root.height - dp(120) - self.height / 2 - dp(30) \
                 if root.theme_cls.device_orientation == "portrait" \
                 else dp(272)
-            text_color:
-                app.theme_cls.text_color \
-                if not root.text_color else root.text_color
+            text_color: root.text_color or app.theme_cls.text_color
 
         DatePickerIconTooltipButton:
             id: chevron_right
@@ -236,9 +209,7 @@
                 root.height - dp(120) - self.height / 2 - dp(30) \
                 if root.theme_cls.device_orientation == "portrait" \
                 else dp(272)
-            text_color:
-                app.theme_cls.text_color \
-                if not root.text_color else root.text_color
+            text_color: root.text_color or app.theme_cls.text_color
 
         # TODO: Replace the GridLayout with a RecycleView
         # if it improves performance.
@@ -280,10 +251,7 @@
             text: "OK"
             theme_text_color: "Custom"
             font_name: root.font_name
-            text_color:
-                root.theme_cls.primary_color \
-                if not root.text_button_color else \
-                root.text_button_color
+            text_color: root.text_button_color or root.theme_cls.primary_color
             on_release: root.on_ok_button_pressed()
 
         MDFlatButton:
@@ -293,10 +261,7 @@
             theme_text_color: "Custom"
             pos: root.width - self.width - ok_button.width - dp(10), dp(10)
             font_name: root.font_name
-            text_color:
-                root.theme_cls.primary_color \
-                if not root.text_button_color else \
-                root.text_button_color
+            text_color: root.text_button_color or root.theme_cls.primary_color
 
 
 <DatePickerDaySelectableItem>
@@ -312,11 +277,7 @@
     canvas.before:
         Color:
             rgba:
-                (\
-                self.owner.selector_color[:-1] + [.3] \
-                if self.owner.selector_color \
-                else self.theme_cls.primary_color[:-1] + [.3] \
-                ) \
+                (self.owner.selector_color or self.theme_cls.primary_color)[:-1] + [.3] \
                 if self.is_in_range \
                 else (0, 0, 0, 0)
         RoundedRectangle:
@@ -342,10 +303,7 @@
         # Selection circle.
         Color:
             rgba:
-                ( \
-                self.theme_cls.primary_color if not root.owner.selector_color \
-                else root.owner.selector_color \
-                ) \
+                root.owner.selector_color or self.theme_cls.primary_color \
                 if root.is_selected and not self.disabled \
                 else (0, 0, 0, 0)
         Ellipse:
@@ -363,25 +321,11 @@
         font_name: root.owner.font_name
         theme_text_color: "Custom"
         text_color:
-            ( \
-            root.theme_cls.primary_color \
-            if not root.owner.text_current_color \
-            else root.owner.text_current_color \
-            ) \
-            if root.is_today and not root.is_selected \
-            else ( \
-            ( \
-            root.theme_cls.text_color \
-            if not root.is_selected or root.owner.mode == "range" \
-            else (1, 1, 1, 1) \
-            ) \
-            if not root.owner.text_color \
-            else \
-            ( \
-            root.owner.text_color \
-            if not root.is_selected else (1, 1, 1, 1)) \
-            )
-
+            root.owner.accent_color or root.theme_cls.bg_normal \
+            if root.is_selected else \
+            root.owner.text_current_color or root.theme_cls.primary_color \
+            if root.is_today else \
+            root.owner.text_color or root.theme_cls.text_color
 
 <DatePickerWeekdayLabel>
     font_style: "Caption"
@@ -395,9 +339,7 @@
     size:
         (dp(40), dp(40)) if root.theme_cls.device_orientation == "portrait" \
         else (dp(32), dp(32))
-    text_color:
-        app.theme_cls.disabled_hint_text_color \
-        if not root.owner.text_weekday_color else root.owner.text_weekday_color
+    text_color: root.owner.text_weekday_color or app.theme_cls.disabled_hint_text_color
 
 
 <DatePickerYearSelectableItem>
@@ -406,13 +348,21 @@
     valign: "middle"
     halign: "center"
     text: root.text
+    theme_text_color: "Custom"
+    text_color:
+        (0, 0, 0, 0) \
+        if self.owner is None else \
+        self.owner.accent_color or self.owner.theme_cls.bg_normal \
+        if self.selected else \
+        self.owner.text_color or self.owner.theme_cls.text_color
     on_text: root.font_name = root.owner.font_name
 
     canvas.before:
         Color:
             rgba:
-                root.selected_color if root.selected_color \
-                else self.theme_cls.primary_color
+                self.owner.selector_color or self.theme_cls.primary_color \
+                if self.selected else \
+                (0, 0, 0, 0)
         RoundedRectangle:
             pos: self.x + dp(12), self.y
             size: self.width - dp(24), self.height
@@ -441,7 +391,4 @@
     opacity: 0
     hint_text: "dd/mm/yyyy"
     input_filter: root.input_filter
-    fill_color:
-        (0, 0, 0, .15) \
-        if not self.owner.input_field_background_color \
-        else root.owner.input_field_background_color
+    fill_color: root.owner.input_field_background_color or (0, 0, 0, .15)

--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -755,7 +755,7 @@ class DatePickerYearSelectableItem(RecycleDataViewBehavior, MDLabel):
     """Implements an item for a pick list of the year."""
 
     index = None
-    selected_color = ColorProperty([0, 0, 0, 0])
+    selected = BooleanProperty(False)
     owner = ObjectProperty()
 
     def refresh_view_attrs(self, rv, index, data):
@@ -777,22 +777,7 @@ class DatePickerYearSelectableItem(RecycleDataViewBehavior, MDLabel):
             return self.parent.select_with_touch(self.index, touch)
 
     def apply_selection(self, table_data, index, is_selected):
-        if is_selected:
-            self.selected_color = (
-                self.owner.selector_color
-                if self.owner.selector_color
-                else self.theme_cls.primary_color
-            )
-            self.text_color = (1, 1, 1, 1)
-        else:
-            if int(self.text) == self.owner.sel_year:
-                self.text_color = (
-                    self.theme_cls.primary_color
-                    if not self.owner.text_current_color
-                    else self.owner.text_current_color
-                )
-            self.selected_color = [0, 0, 0, 0]
-            self.text_color = (0, 0, 0, 1)
+        self.selected = is_selected
 
 
 # TODO: Add the feature to embed the `MDDatePicker` class in other layouts


### PR DESCRIPTION
### Description of Changes

When we try to determine which color we will use, most often we choose between two colors. If the corresponding color is defined in the MDDatePicker instance, we use it, otherwise, we use the theme color. It was written as `color2 if color1 is None else color1`. In some cases, this operation was distributed over a complex conditional expression. I rewrote it as `color1 or color2` because it's more concise and less distracting from the meaning of the expression.

In one of these confusing expressions, after refactoring, it turned out that the color of the label text of the selected date was hard-coded in white. The light color of the selection will make the label text invisible:

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.theme_cls.theme_style = "Dark"
        self.theme_cls.primary_palette = "Orange"
        self.date_picker = MDDatePicker(selector_color='white')
        self.date_picker.open()


Test().run()
```

![image](https://user-images.githubusercontent.com/27895729/194746785-e9bfbb0f-8d09-47ac-a9d1-da5f37e89f35.png)

To fix this behavior, I used the background color:

![image](https://user-images.githubusercontent.com/27895729/194747130-6db1032a-4022-4646-a16c-ab0b226afd8b.png)

I did the same for the year selection dialog. It also fixed the color difference between the text color of the selected date and the selected year:

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.date_picker = MDDatePicker()
        self.date_picker.open()


Test().run()
```
![image](https://user-images.githubusercontent.com/27895729/194747462-e88f98ab-1802-408f-a3e6-51e6989de04e.png)

![image](https://user-images.githubusercontent.com/27895729/194747470-909efaf5-d750-4059-ac3c-9d23d01d18c3.png)

There is no difference now:

![image](https://user-images.githubusercontent.com/27895729/194747539-0e282303-0b55-4470-86e0-41797c499e39.png)

![image](https://user-images.githubusercontent.com/27895729/194747552-e7259533-87a5-480a-8e34-70c4d3ce637f.png)

In the end, I found out that my #1380 turned out to be wrong. It was necessary not to remove the unused `selected` property, but to use it. Now the selection and text colors are calculated in the kv file in the same way as in other places: the code no longer manages colors directly.