### PR TITLE
DatePickerYearSelectableItem: Cleanup on_touch_down

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -767,13 +767,6 @@ class DatePickerYearSelectableItem(RecycleDataViewBehavior, MDLabel):
             return True
         if self.collide_point(*touch.pos):
             self.owner.year = int(self.text)
-            # self.owner.sel_year = self.owner.year
-            self.owner.ids.label_full_date.text = self.owner.set_text_full_date(
-                self.owner.sel_year,
-                self.owner.sel_month,
-                self.owner.sel_day,
-                self.owner.theme_cls.device_orientation,
-            )
             return self.parent.select_with_touch(self.index, touch)
 
     def apply_selection(self, table_data, index, is_selected):


### PR DESCRIPTION
### Description of Changes

The selected date does not change when you click on the year widget (it only happens when switching to the calendar), so changing the label text has no effect. The corresponding code has been removed.