### PR TITLE
MDDatePicker: Change range mode behaviour

### DIFF
--- a/kivymd/uix/pickers/datepicker/datepicker.kv
+++ b/kivymd/uix/pickers/datepicker/datepicker.kv
@@ -94,9 +94,7 @@
                 dp(24) if not root._input_date_dialog_open else dp(168) + dp(24), \
                 root.height - self.height - dp(96) \
                 )
-            text:
-                root.set_text_full_date(root.sel_year, root.sel_month, root.sel_day, \
-                root.theme_cls.device_orientation)
+            text: root._date_label_text
             text_color:
                 root.text_toolbar_color or root.specific_text_color \
                 if root.theme_cls.device_orientation == "portrait" else \

--- a/kivymd/uix/pickers/datepicker/datepicker.py
+++ b/kivymd/uix/pickers/datepicker/datepicker.py
@@ -706,39 +706,7 @@ class DatePickerDaySelectableItem(
     is_week_end = BooleanProperty(False)
 
     def on_release(self):
-        if (
-            self.owner.mode == "range"
-            and self.owner.min_date
-            and self.owner.max_date
-        ):
-            return
-        if (
-            not self.owner._input_date_dialog_open
-            and not self.owner._select_year_dialog_open
-        ):
-            if self.owner.mode == "range" and not self.owner.min_date:
-                self.owner.min_date = date(
-                    self.owner.year, self.owner.month, int(self.text)
-                )
-            elif (
-                self.owner.mode == "range"
-                and not self.owner.max_date
-                and self.owner.min_date
-            ):
-                self.owner.max_date = date(
-                    self.owner.year, self.owner.month, int(self.text)
-                )
-                if self.owner.max_date <= self.owner.min_date:
-                    toast(self.owner.date_range_text_error)
-                    Logger.error(
-                        "`Data Picker: max_date` value cannot be less than "
-                        "or equal to 'min_date' value."
-                    )
-                    self.owner.min_date = None
-                    self.owner.max_date = None
-                self.owner.update_calendar(self.owner.year, self.owner.month)
-
-            self.owner.set_selected_widget(self)
+        self.owner.set_selected_widget(self)
 
     def on_touch_down(self, touch):
         # If year_layout is active don't dispatch on_touch_down events,
@@ -933,6 +901,7 @@ class MDDatePicker(BaseDialogPicker):
     _shift_dialog_height = NumericProperty(0)
     _input_date_dialog_open = BooleanProperty(False)
     _select_year_dialog_open = False
+    _date_label_text = StringProperty()
 
     def __init__(
         self,
@@ -971,7 +940,8 @@ class MDDatePicker(BaseDialogPicker):
         self, instance_theme_manager: ThemeManager, orientation_value: str
     ) -> None:
         """Called when the device's screen orientation changes."""
-
+        # Separators of the label text depend on the orientation.
+        self._update_date_label_text()
         if self._input_date_dialog_open:
             if orientation_value == "portrait":
                 self._shift_dialog_height = dp(250)
@@ -1121,23 +1091,14 @@ class MDDatePicker(BaseDialogPicker):
         Animation(opacity=1, d=0.15).start(self._enter_data_field)
         if self._enter_data_field_two:
             Animation(opacity=1, d=0.15).start(self._enter_data_field_two)
-        self.ids.label_full_date.text = self.set_text_full_date(
-            self.sel_year,
-            self.sel_month,
-            self.sel_day,
-            self.theme_cls.device_orientation,
-        )
+        # The label text separator in landscape orientation depends on the
+        # open dialog.
+        self._update_date_label_text()
 
     def transformation_from_dialog_input_date(
         self, interval: Union[int, float]
     ) -> None:
         self._input_date_dialog_open = False
-        self.ids.label_full_date.text = self.set_text_full_date(
-            self.sel_year,
-            self.sel_month,
-            self.sel_day,
-            self.theme_cls.device_orientation,
-        )
         self.ids.triangle.disabled = False
         self.ids.container.remove_widget(self._enter_data_field_container)
         Animation(
@@ -1180,14 +1141,7 @@ class MDDatePicker(BaseDialogPicker):
                     int(list_max_date[1]),
                     int(list_max_date[0]),
                 )
-
-            self.update_calendar_for_date_range()
-            self.ids.label_full_date.text = self.set_text_full_date(
-                int(list_max_date[2]),
-                int(list_max_date[1]),
-                int(list_max_date[0]),
-                self.theme_cls.device_orientation,
-            )
+            self.update_calendar(self.year, self.month)
 
     def compare_date_range(self) -> None:
         # TODO: Add behavior if the minimum date range exceeds the maximum
@@ -1207,28 +1161,13 @@ class MDDatePicker(BaseDialogPicker):
         Updates the title of the week, month and number day name
         in an open date input dialog.
         """
-
-        if len(list_date) == 1 and len(list_date[0]) == 2:
-            self.ids.label_full_date.text = self.set_text_full_date(
-                self.sel_year,
-                self.sel_month,
-                list_date[0],
-                self.theme_cls.device_orientation,
-            )
-        if len(list_date) == 2 and len(list_date[1]) == 2:
-            self.ids.label_full_date.text = self.set_text_full_date(
-                self.sel_year,
-                int(list_date[1]),
-                int(list_date[0]),
-                self.theme_cls.device_orientation,
-            )
-        if len(list_date) == 3 and len(list_date[2]) == 4:
-            self.ids.label_full_date.text = self.set_text_full_date(
-                int(list_date[2]),
-                int(list_date[1]),
-                int(list_date[0]),
-                self.theme_cls.device_orientation,
-            )
+        # This method no longer used, use update_calendar instead.
+        year = int(list_date[2]) if len(list_date) > 2 else self.sel_year
+        month = int(list_date[1]) if len(list_date) > 1 else self.sel_month
+        day = int(list_date[0]) if len(list_date) > 0 else self.sel_day
+        day = min(day, calendar.monthrange(year, month)[1])
+        self.sel_year, self.sel_month, self.sel_day = year, month, day
+        self.update_calendar(year, month)
 
     def update_calendar(self, year, month) -> None:
         self.year, self.month = year, month
@@ -1237,6 +1176,8 @@ class MDDatePicker(BaseDialogPicker):
             selected_dates = {selected_date}
         else:
             selected_dates = {self.min_date, self.max_date}
+        # The label text depends on the selected date or date range.
+        self._update_date_label_text()
         month_end = date(year, month, calendar.monthrange(year, month)[1])
         dates = self.calendar.itermonthdates(year, month)
         for widget, widget_date in zip_longest(self._calendar_list, dates):
@@ -1252,13 +1193,7 @@ class MDDatePicker(BaseDialogPicker):
             # I don't understand why, but this line is important. Without this
             # line, some widgets that we are trying to disable remain enabled.
             widget.disabled = False
-            widget.disabled = (
-                not visible
-                or self.mode == "range"
-                and self.min_date is not None
-                and self.max_date is not None
-                and not self.min_date <= widget_date <= self.max_date
-            )
+            widget.disabled = not visible
             widget.is_in_range = (
                 visible
                 and self.min_date is not None
@@ -1336,119 +1271,65 @@ class MDDatePicker(BaseDialogPicker):
         choose and a string like "Feb 15 - Mar 23" or "Feb 15,\nMar 23" for
         a date range.
         """
+        # In portrait orientation, the label is stretched in width, so we
+        # should not insert line breaks. When the input dialog is open, the
+        # label moves to the right and also stretches in width.
+        horizontal = orientation == "portrait" or self._input_date_dialog_open
 
-        if 12 < int(month) < 0:
-            raise ValueError(
-                "set_text_full_date:\n\t" f"Month [{month}] out of range."
-            )
-        if int(day) > calendar.monthrange(int(year), (month))[1]:
-            return ""
-        date = datetime.date(int(year), int(month), int(day))
-        separator = (
-            "\n"
-            if (orientation == "landscape" and not self._input_date_dialog_open)
-            else " "
-        )
+        def date_repr(date):
+            return date.strftime("%b").capitalize() + " " + str(date.day)
 
         if self.mode == "picker":
-            if not self.min_date and not self.max_date:
-                return (
-                    date.strftime("%a,").capitalize()
-                    + separator
-                    + date.strftime("%b ").capitalize()
-                    + str(day).lstrip("0")
-                )
-            else:
-                return (
-                    self.min_date.strftime("%b ").capitalize()
-                    + str(self.min_date.day).lstrip("0")
-                    + (
-                        " - "
-                        if orientation == "portrait"
-                        else (
-                            ",\n" if not self._input_date_dialog_open else ", "
-                        )
-                    )
-                    + self.max_date.strftime("%b ").capitalize()
-                    + str(self.max_date.day).lstrip("0")
-                )
+            selected_date = date(self.sel_year, self.sel_month, self.sel_day)
+            weekday_repr = selected_date.strftime("%a").capitalize()
+            separator = ", " if horizontal else ",\n"
+            return weekday_repr + separator + date_repr(selected_date)
         elif self.mode == "range":
-            if self.min_date and self.max_date:
-                if (
-                    orientation == "landscape"
-                    and "-" in self.ids.label_full_date.text
-                ):
-                    return (
-                        self.ids.label_full_date.text.split("-")[0].strip()
-                        + (",\n" if not self._input_date_dialog_open else " - ")
-                        + date.strftime("%b ").capitalize()
-                        + str(day).lstrip("0")
-                    )
-                else:
-                    if (
-                        orientation == "landscape"
-                        and "," in self.ids.label_full_date.text
-                    ):
-                        return (
-                            self.ids.label_full_date.text.split(",")[0].strip()
-                            + (
-                                ",\n"
-                                if not self._input_date_dialog_open
-                                else "-"
-                            )
-                            + date.strftime("%b ").capitalize()
-                            + str(day).lstrip("0")
-                        )
-                    if (
-                        orientation == "portrait"
-                        and "," in self.ids.label_full_date.text
-                    ):
-                        return (
-                            self.ids.label_full_date.text.split(",")[0].strip()
-                            + "-"
-                            + date.strftime("%b ").capitalize()
-                            + str(day).lstrip("0")
-                        )
-                    if (
-                        orientation == "portrait"
-                        and "-" in self.ids.label_full_date.text
-                    ):
-                        return (
-                            self.ids.label_full_date.text.split("-")[0].strip()
-                            + " - "
-                            + date.strftime("%b ").capitalize()
-                            + str(day).lstrip("0")
-                        )
-            elif self.min_date and not self.max_date:
-                return (
-                    (
-                        date.strftime("%b ").capitalize()
-                        + str(day).lstrip("0")
-                        + " - End"
-                    )
-                    if orientation != "landscape"
-                    else (
-                        date.strftime("%b ").capitalize()
-                        + str(day).lstrip("0")
-                        + "{}End".format(
-                            ",\n" if not self._input_date_dialog_open else " - "
-                        )
-                    )
-                )
-            elif not self.min_date and not self.max_date:
-                return (
-                    "Start - End"
-                    if orientation != "landscape"
-                    else "Start{}End".format(
-                        ",\n" if not self._input_date_dialog_open else " - "
-                    )
-                )
+            ends = [end for end in (self.min_date, self.max_date) if end]
+            if len(ends) == 0:
+                start_repr, end_repr = "Start", "End"
+            else:
+                start, end = min(ends), max(ends)
+                start_repr, end_repr = date_repr(start), date_repr(end)
+            separator = " — " if horizontal else ",\n"
+            return start_repr + separator + end_repr
+
+    def _update_date_label_text(self):
+        self._date_label_text = self.set_text_full_date(
+            self.sel_year,
+            self.sel_month,
+            self.sel_day,
+            self.theme_cls.device_orientation,
+        )
 
     def set_selected_widget(self, widget) -> None:
-        self.sel_year = self.year
-        self.sel_month = self.month
-        self.sel_day = int(widget.text)
-        self.update_calendar(self.sel_year, self.sel_month)
+        try:
+            widget_date = date(self.year, self.month, int(widget.text))
+        except ValueError:
+            return
+        if self.mode == "picker":
+            self.sel_year = widget_date.year
+            self.sel_month = widget_date.month
+            self.sel_day = widget_date.day
+            self.update_calendar(self.sel_year, self.sel_month)
+        elif self.mode == "range":
+            ends = [end for end in (self.min_date, self.max_date) if end]
+            if widget_date in ends:
+                ends = [end for end in ends if end != widget_date]
+            elif len(ends) < 2:
+                ends.append(widget_date)
+            else:
+                start, end = min(ends), max(ends)
+                if abs(widget_date - start).days < abs(widget_date - end).days:
+                    start = widget_date
+                else:
+                    end = widget_date
+                ends = [start, end]
+            if len(ends) == 0:
+                self.min_date, self.max_date = None, None
+            else:
+                self.min_date, self.max_date = min(ends), max(ends)
+            self.update_calendar(self.year, self.month)
 
     def set_month_day(self, day) -> None:
         # This method is no longer used. The code bellow repeats the behavior


### PR DESCRIPTION
The following examples will use this code:

```python
from kivymd.app import MDApp
from kivymd.uix.pickers import MDDatePicker


class Test(MDApp):
    def __init__(self):
        super().__init__()
        self.date_picker = MDDatePicker(mode='range')
        self.date_picker.open()


Test().run()
```

Previously, if we allocated a date range, we could no longer change our selection:

https://user-images.githubusercontent.com/27895729/194810684-23c16150-2a3e-4733-891d-730f54d9368a.mp4

Also, we could not select a date range lasting one day or first select the end of the range, and then the end:

https://user-images.githubusercontent.com/27895729/194813035-d484b914-9b81-442e-aacc-4872b4ffa1a6.mp4

Now, after we have selected the date range, we can still change it. Clicking on the already selected end of the range removes the selection from this end, after which we can select another date:

https://user-images.githubusercontent.com/27895729/194811352-8887b0f6-7166-452c-8f12-735c300f15cb.mp4

Clicking on another date moves the nearest end of the range to this date:

https://user-images.githubusercontent.com/27895729/194811240-ed14ae83-ef6e-45a4-a287-c05d4a3d8ae2.mp4

As you can see, selecting one end of a range means selecting a range that is one day long. This is no longer a forbidden range length. 

Also, it is no longer forbidden to select the minimum and maximum date in reverse order:

https://user-images.githubusercontent.com/27895729/194812395-a71e5220-43d9-4cad-93bc-c39d9325cf04.mp4

### Description of Changes

First of all, the logic of clicking on the day widget is no longer divided between its `on_release` method and the `set_selected_widget` method of `MDDatePicker`. Now, all this logic is in the `set_selected_widget` method.

However, a bug was found with the display of the date label text, because of which I had to refactor. Now, the text of the label is updated when `update_calendar` is called, as well as when the orientation changes and when the dialog changes. To update the text, the new `_update_date_label_text` method is now called everywhere. The `_date_label_text` property has been implemented, which controls the label text. This is necessary because when the text is to be set for the first time, there is not yet a label widget whose text needs to be set.