### PR TITLE
Added icon color property to `right_action_items`/`left_action_items` in `MDTopAppBar` class

### DIFF
--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -1333,21 +1333,17 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             if len(item) == 3:
                 if isinstance(item[2], tuple):
                     item.insert(2, "")
-                    item.insert(3, "")
-            elif len(item) == 4:
-                if isinstance(item[2], str) and isinstance(item[3], tuple):
-                    item.insert(2, "")
 
             instance_box_layout.add_widget(
                 ActionTopAppBarButton(
                     icon=item[0],
                     on_release=item[1],
                     tooltip_text=item[2],
-                    overflow_text=item[3] if len(item) == 4 else "",
+                    overflow_text=item[3] if (len(item) == 4 and isinstance(item[3], str)) else "",
                     theme_text_color="Custom"
                     if not self.opposite_colors
                     else "Primary",
-                    text_color=self.specific_text_color if not (len(item) == 5 and item[4]) else item[4],
+                    text_color=self.specific_text_color if not (len(item) == 4 and isinstance(item[3], tuple)) else item[3],
                     opposite_colors=self.opposite_colors,
                 )
             )

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -366,9 +366,7 @@ from kivymd.uix.menu import MDDropdownMenu
 from kivymd.uix.tooltip import MDTooltip
 from kivymd.utils.set_bars_colors import set_bars_colors
 
-with open(
-    os.path.join(uix_path, "toolbar", "toolbar.kv"), encoding="utf-8"
-) as kv_file:
+with open(os.path.join(uix_path, "toolbar", "toolbar.kv"), encoding="utf-8") as kv_file:
     Builder.load_string(kv_file.read())
 
 
@@ -478,12 +476,8 @@ class NotchedBox(
             right_circle_pos,
         )
 
-        left_vertices, left_indices = self._make_vertices_indices(
-            raw_vertices_left
-        )
-        right_vertices, right_indices = self._make_vertices_indices(
-            raw_vertices_right
-        )
+        left_vertices, left_indices = self._make_vertices_indices(raw_vertices_left)
+        right_vertices, right_indices = self._make_vertices_indices(raw_vertices_right)
 
         self._update_mesh(left_vertices, left_indices, "left")
         self._update_mesh(right_vertices, right_indices, "right")
@@ -988,10 +982,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
     def set_headline_font_style(self, interval: Union[int, float]) -> None:
         if self.type_height in ("medium", "large"):
-            self.ids.label_headline.font_style = {
-                "medium": "H6",
-                "large": "H5",
-            }[self.type_height]
+            self.ids.label_headline.font_style = {"medium": "H6", "large": "H5",}[
+                self.type_height
+            ]
 
     def on_width(self, instance_toolbar, width: float) -> None:
         """
@@ -1042,9 +1035,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
         self.ids.right_actions.add_widget(
             ActionOverFlowButton(
-                theme_text_color="Custom"
-                if not self.opposite_colors
-                else "Primary",
+                theme_text_color="Custom" if not self.opposite_colors else "Primary",
                 text_color=self.specific_text_color,
                 opposite_colors=self.opposite_colors,
                 on_release=lambda x: self.overflow_cls.open(),
@@ -1058,10 +1049,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
         overflow.
         """
 
-        if (
-            not self.ids.right_actions.children[0].__class__
-            is ActionOverFlowButton
-        ):
+        if not self.ids.right_actions.children[0].__class__ is ActionOverFlowButton:
             return False
         return True
 
@@ -1103,9 +1091,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             self.action_button.bind(
                 on_release=lambda x: self.dispatch("on_action_button")
             )
-            self.action_button.x = (
-                Window.width / 2 - self.action_button.width / 2
-            )
+            self.action_button.x = Window.width / 2 - self.action_button.width / 2
             self.action_button.y = (
                 (self.center[1] - self.height / 2)
                 + self.theme_cls.standard_increment / 2
@@ -1157,9 +1143,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
                 self.md_bg_color = [0, 0, 0, 0]
             else:
                 if self.set_bars_color:
-                    set_bars_colors(
-                        color_value, None, self.theme_cls.theme_style
-                    )
+                    set_bars_colors(color_value, None, self.theme_cls.theme_style)
 
         Clock.schedule_once(on_md_bg_color)
 
@@ -1174,9 +1158,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
         Clock.schedule_once(on_left_action_items)
 
-    def on_right_action_items(
-        self, instance_toolbar, items_value: list
-    ) -> None:
+    def on_right_action_items(self, instance_toolbar, items_value: list) -> None:
         """
         Called when the value of the  :attr:`right_action_items` attribute
         changes.
@@ -1199,9 +1181,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
         self.action_button.md_bg_color = icon_name
 
-    def on_md_bg_bottom_color(
-        self, instance_toolbar, color_value: list
-    ) -> None:
+    def on_md_bg_bottom_color(self, instance_toolbar, color_value: list) -> None:
         """
         Called when the value of the  :attr:`md_bg_bottom_color` attribute
         changes.
@@ -1263,9 +1243,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
                 x = Window.width / 2 - self.action_button.width / 2
                 y = self.action_button.height + self.action_button.height / 2
             self.remove_shadow()
-            anim = Animation(
-                scale_value_x=0, scale_value_y=0, scale_value_z=0, d=0.1
-            )
+            anim = Animation(scale_value_x=0, scale_value_y=0, scale_value_z=0, d=0.1)
             anim.bind(on_complete=set_button_pos)
             anim.start(self.action_button)
 
@@ -1277,8 +1255,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
     def set_notch(self) -> None:
         anim = Animation(d=0.1) + Animation(
-            notch_radius=self.action_button.width / 2 + dp(8),
-            d=0.1,
+            notch_radius=self.action_button.width / 2 + dp(8), d=0.1,
         )
         anim.start(self)
 
@@ -1313,9 +1290,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             self.anchor_title = "left"
         return self.anchor_title
 
-    def update_action_bar(
-        self, instance_box_layout, action_bar_items: list
-    ) -> None:
+    def update_action_bar(self, instance_box_layout, action_bar_items: list) -> None:
         instance_box_layout.clear_widgets()
         new_width = 0
 
@@ -1339,11 +1314,15 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
                     icon=item[0],
                     on_release=item[1],
                     tooltip_text=item[2],
-                    overflow_text=item[3] if (len(item) == 4 and isinstance(item[3], str)) else "",
+                    overflow_text=item[3]
+                    if (len(item) == 4 and isinstance(item[3], str))
+                    else "",
                     theme_text_color="Custom"
                     if not self.opposite_colors
                     else "Primary",
-                    text_color=self.specific_text_color if not (len(item) == 4 and isinstance(item[3], tuple)) else item[3],
+                    text_color=self.specific_text_color
+                    if not (len(item) == 4 and isinstance(item[3], tuple))
+                    else item[3],
                     opposite_colors=self.opposite_colors,
                 )
             )
@@ -1372,9 +1351,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             [0.0, 0.0, 0.0, 1.0],
             [1.0, 1.0, 1.0, 1.0],
         ):
-            self.specific_text_color = text_colors[
-                self.theme_cls.primary_palette
-            ][self.theme_cls.primary_hue]
+            self.specific_text_color = text_colors[self.theme_cls.primary_palette][
+                self.theme_cls.primary_hue
+            ]
 
 
 class MDBottomAppBar(DeclarativeBehavior, FloatLayout):

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -366,7 +366,9 @@ from kivymd.uix.menu import MDDropdownMenu
 from kivymd.uix.tooltip import MDTooltip
 from kivymd.utils.set_bars_colors import set_bars_colors
 
-with open(os.path.join(uix_path, "toolbar", "toolbar.kv"), encoding="utf-8") as kv_file:
+with open(
+    os.path.join(uix_path, "toolbar", "toolbar.kv"), encoding="utf-8"
+) as kv_file:
     Builder.load_string(kv_file.read())
 
 
@@ -476,8 +478,12 @@ class NotchedBox(
             right_circle_pos,
         )
 
-        left_vertices, left_indices = self._make_vertices_indices(raw_vertices_left)
-        right_vertices, right_indices = self._make_vertices_indices(raw_vertices_right)
+        left_vertices, left_indices = self._make_vertices_indices(
+            raw_vertices_left
+        )
+        right_vertices, right_indices = self._make_vertices_indices(
+            raw_vertices_right
+        )
 
         self._update_mesh(left_vertices, left_indices, "left")
         self._update_mesh(right_vertices, right_indices, "right")
@@ -1036,7 +1042,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
         self.ids.right_actions.add_widget(
             ActionOverFlowButton(
-                theme_text_color="Custom" if not self.opposite_colors else "Primary",
+                theme_text_color="Custom"
+                if not self.opposite_colors
+                else "Primary",
                 text_color=self.specific_text_color,
                 opposite_colors=self.opposite_colors,
                 on_release=lambda x: self.overflow_cls.open(),
@@ -1050,7 +1058,10 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
         overflow.
         """
 
-        if not self.ids.right_actions.children[0].__class__ is ActionOverFlowButton:
+        if (
+            not self.ids.right_actions.children[0].__class__
+            is ActionOverFlowButton
+        ):
             return False
         return True
 
@@ -1092,7 +1103,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             self.action_button.bind(
                 on_release=lambda x: self.dispatch("on_action_button")
             )
-            self.action_button.x = Window.width / 2 - self.action_button.width / 2
+            self.action_button.x = (
+                Window.width / 2 - self.action_button.width / 2
+            )
             self.action_button.y = (
                 (self.center[1] - self.height / 2)
                 + self.theme_cls.standard_increment / 2
@@ -1144,7 +1157,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
                 self.md_bg_color = [0, 0, 0, 0]
             else:
                 if self.set_bars_color:
-                    set_bars_colors(color_value, None, self.theme_cls.theme_style)
+                    set_bars_colors(
+                        color_value, None, self.theme_cls.theme_style
+                    )
 
         Clock.schedule_once(on_md_bg_color)
 
@@ -1159,7 +1174,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
         Clock.schedule_once(on_left_action_items)
 
-    def on_right_action_items(self, instance_toolbar, items_value: list) -> None:
+    def on_right_action_items(
+        self, instance_toolbar, items_value: list
+    ) -> None:
         """
         Called when the value of the  :attr:`right_action_items` attribute
         changes.
@@ -1182,7 +1199,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
         self.action_button.md_bg_color = icon_name
 
-    def on_md_bg_bottom_color(self, instance_toolbar, color_value: list) -> None:
+    def on_md_bg_bottom_color(
+        self, instance_toolbar, color_value: list
+    ) -> None:
         """
         Called when the value of the  :attr:`md_bg_bottom_color` attribute
         changes.
@@ -1244,7 +1263,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
                 x = Window.width / 2 - self.action_button.width / 2
                 y = self.action_button.height + self.action_button.height / 2
             self.remove_shadow()
-            anim = Animation(scale_value_x=0, scale_value_y=0, scale_value_z=0, d=0.1)
+            anim = Animation(
+                scale_value_x=0, scale_value_y=0, scale_value_z=0, d=0.1
+            )
             anim.bind(on_complete=set_button_pos)
             anim.start(self.action_button)
 
@@ -1292,7 +1313,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             self.anchor_title = "left"
         return self.anchor_title
 
-    def update_action_bar(self, instance_box_layout, action_bar_items: list) -> None:
+    def update_action_bar(
+        self, instance_box_layout, action_bar_items: list
+    ) -> None:
         instance_box_layout.clear_widgets()
         new_width = 0
 
@@ -1353,9 +1376,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             [0.0, 0.0, 0.0, 1.0],
             [1.0, 1.0, 1.0, 1.0],
         ):
-            self.specific_text_color = text_colors[self.theme_cls.primary_palette][
-                self.theme_cls.primary_hue
-            ]
+            self.specific_text_color = text_colors[
+                self.theme_cls.primary_palette
+            ][self.theme_cls.primary_hue]
 
 
 class MDBottomAppBar(DeclarativeBehavior, FloatLayout):

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -1326,10 +1326,14 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             if len(item) > 1 and not item[1]:
                 item[1] = lambda x: None
             if len(item) == 2:
-                if type(item[1]) is str:
+                if isinstance(item[1], str):
                     item.insert(1, lambda x: None)
                 else:
                     item.append("")
+            if len(item) == 3:
+                if isinstance(item[2], tuple):
+                    item.insert(2, "")
+                    item.insert(3, "")
 
             instance_box_layout.add_widget(
                 ActionTopAppBarButton(

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -1326,7 +1326,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
             if len(item) > 1 and not item[1]:
                 item[1] = lambda x: None
             if len(item) == 2:
-                if isinstance(item[1], str):
+                if isinstance(item[1], str) or isinstance(item[1], tuple):
                     item.insert(1, lambda x: None)
                 else:
                     item.append("")
@@ -1334,6 +1334,9 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
                 if isinstance(item[2], tuple):
                     item.insert(2, "")
                     item.insert(3, "")
+            elif len(item) == 4:
+                if isinstance(item[2], str) and isinstance(item[3], tuple):
+                    item.insert(2, "")
 
             instance_box_layout.add_widget(
                 ActionTopAppBarButton(

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -626,8 +626,15 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/toolbar-overflow-text.png
         :align: center
+        
+    ``icon color`` - icon color:
 
-    Both the ``callback`` and ``tooltip text`` and ``overflow text`` are
+    .. code-block:: kv
+
+        MDTopAppBar:
+            right_action_items: [["dots-vertical", callback, "tooltip text", "overflow text", (1, 1, 1, 1)]]
+
+    Both the ``callback`` and ``tooltip text`` and ``overflow text`` and ``icon color`` are
     optional but the order must be preserved.
 
     :attr:`left_action_items` is an :class:`~kivy.properties.ListProperty`
@@ -1333,7 +1340,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
                     theme_text_color="Custom"
                     if not self.opposite_colors
                     else "Primary",
-                    text_color=self.specific_text_color,
+                    text_color=self.specific_text_color if not (len(item) == 5 and item[4]) else item[4],
                     opposite_colors=self.opposite_colors,
                 )
             )

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -982,9 +982,10 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
     def set_headline_font_style(self, interval: Union[int, float]) -> None:
         if self.type_height in ("medium", "large"):
-            self.ids.label_headline.font_style = {"medium": "H6", "large": "H5",}[
-                self.type_height
-            ]
+            self.ids.label_headline.font_style = {
+                "medium": "H6",
+                "large": "H5",
+            }[self.type_height]
 
     def on_width(self, instance_toolbar, width: float) -> None:
         """
@@ -1255,7 +1256,8 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
     def set_notch(self) -> None:
         anim = Animation(d=0.1) + Animation(
-            notch_radius=self.action_button.width / 2 + dp(8), d=0.1,
+            notch_radius=self.action_button.width / 2 + dp(8),
+            d=0.1,
         )
         anim.start(self)
 

--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -626,7 +626,7 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
 
     .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/toolbar-overflow-text.png
         :align: center
-        
+
     ``icon color`` - icon color:
 
     .. code-block:: kv


### PR DESCRIPTION
Added the ability to set the icon color in `MDTopAppBar` yourself

```py
from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.toolbar import MDTopAppBar

KV = '''
MDBoxLayout:
    orientation: "vertical"

    MDTopAppBar:
        id: app_bar
        title: "MDTopAppBar"

    MDLabel:
        text: "Content"
        halign: "center"
'''


class Test(MDApp):
    def build(self):
        return Builder.load_string(KV)

    def on_start(self):
        app_bar = self.root.ids.app_bar
        app_bar.left_action_items = [
            ["github", lambda x: print('Callback'), "tooltip text", "overflow text", (1, 0, 0, 1)],
            ["github", lambda x: print('Callback'), (0, 0, 0.5, 1)],
            ["arrow-right", "Tooltip text"],
            ["arrow-up", (1, 0.41, 0.55, 1)],

        ]

        app_bar.right_action_items = [
            ["menu", lambda x: print('Callback'), "tooltip text", "overflow text", (1, 0.5, 0.45, 1)],
            ["menu", lambda x: print('Callback'), "menu", (1, 1, 0, 1)],
            ["twitter"]
        ]


Test().run()
```

![image](https://user-images.githubusercontent.com/40869738/195898516-ef5434ac-900f-4265-b560-2cf2beb2c5a1.png)