### PR TITLE
Add `on_copy` event when `on_double_tap` dispatch and `allow_copy` flag to `MDLabel`

### DIFF
--- a/kivymd/uix/label/label.py
+++ b/kivymd/uix/label/label.py
@@ -337,14 +337,6 @@ class MDLabel(
     and defaults to `None`.
     """
 
-    on_copy = ObjectProperty()
-    """
-    Label on copy event.
-
-    :attr:`on_copy` is an :class:`~kivy.properties.ObjectProperty`
-    and defaults to `None`.
-    """
-
     _text_color_str = StringProperty()
 
     parent_background = ColorProperty(None)

--- a/kivymd/uix/label/label.py
+++ b/kivymd/uix/label/label.py
@@ -379,8 +379,8 @@ class MDLabel(
         # TODO: Add letter spacing change
         # self.letter_spacing = font_info[3]
 
-    def on_long_touch(self, *args):
-        if self.allow_copy:
+    def on_double_tap(self, touch, *args):
+        if self.allow_copy and self.collide_point(*touch.pos):
             Clipboard.copy(self.text)
             self.dispatch("on_copy")
 

--- a/kivymd/uix/label/label.py
+++ b/kivymd/uix/label/label.py
@@ -238,12 +238,13 @@ from kivy.properties import (
     StringProperty,
 )
 from kivy.uix.label import Label
+from kivy.core.clipboard import Clipboard
 
 from kivymd import uix_path
 from kivymd.theming import ThemableBehavior
 from kivymd.theming_dynamic_text import get_contrast_text_color
 from kivymd.uix import MDAdaptiveWidget
-from kivymd.uix.behaviors import DeclarativeBehavior
+from kivymd.uix.behaviors import DeclarativeBehavior, TouchBehavior
 from kivymd.uix.floatlayout import MDFloatLayout
 
 __MDLabel_colors__ = {
@@ -264,7 +265,7 @@ with open(
     Builder.load_string(kv_file.read())
 
 
-class MDLabel(DeclarativeBehavior, ThemableBehavior, Label, MDAdaptiveWidget):
+class MDLabel(DeclarativeBehavior, ThemableBehavior, TouchBehavior, Label, MDAdaptiveWidget):
     font_style = StringProperty("Body1")
     """
     Label font style.
@@ -322,6 +323,22 @@ class MDLabel(DeclarativeBehavior, ThemableBehavior, Label, MDAdaptiveWidget):
     and defaults to `None`.
     """
 
+    allow_copy = BooleanProperty(False)
+    """
+    Label allow copy flag.
+
+    :attr:`allow_copy` is an :class:`~kivy.properties.BooleanProperty`
+    and defaults to `None`.
+    """
+
+    on_copy = ObjectProperty()
+    """
+    Label on copy event.
+
+    :attr:`on_copy` is an :class:`~kivy.properties.ObjectProperty`
+    and defaults to `None`.
+    """
+
     _text_color_str = StringProperty()
 
     parent_background = ColorProperty(None)
@@ -334,6 +351,7 @@ class MDLabel(DeclarativeBehavior, ThemableBehavior, Label, MDAdaptiveWidget):
             font_style=self.update_font_style,
             can_capitalize=self.update_font_style,
         )
+        self.register_event_type('on_copy')
         self.on_theme_text_color(None, self.theme_text_color)
         self.update_font_style(None, "")
         self.on_opposite_colors(None, self.opposite_colors)
@@ -362,6 +380,14 @@ class MDLabel(DeclarativeBehavior, ThemableBehavior, Label, MDAdaptiveWidget):
 
         # TODO: Add letter spacing change
         # self.letter_spacing = font_info[3]
+
+    def on_long_touch(self, *args):
+        if self.allow_copy:
+            Clipboard.copy(self.text)
+            self.dispatch("on_copy")
+
+    def on_copy(self):
+        pass
 
     def on_theme_text_color(
         self, instance_label, theme_text_color: str

--- a/kivymd/uix/label/label.py
+++ b/kivymd/uix/label/label.py
@@ -224,6 +224,7 @@ from typing import Union
 
 from kivy.animation import Animation
 from kivy.clock import Clock
+from kivy.core.clipboard import Clipboard
 from kivy.graphics import Color, Rectangle
 from kivy.lang import Builder
 from kivy.metrics import sp
@@ -238,7 +239,6 @@ from kivy.properties import (
     StringProperty,
 )
 from kivy.uix.label import Label
-from kivy.core.clipboard import Clipboard
 
 from kivymd import uix_path
 from kivymd.theming import ThemableBehavior
@@ -265,7 +265,13 @@ with open(
     Builder.load_string(kv_file.read())
 
 
-class MDLabel(DeclarativeBehavior, ThemableBehavior, TouchBehavior, Label, MDAdaptiveWidget):
+class MDLabel(
+    DeclarativeBehavior,
+    ThemableBehavior,
+    TouchBehavior,
+    Label,
+    MDAdaptiveWidget,
+):
     font_style = StringProperty("Body1")
     """
     Label font style.
@@ -351,7 +357,7 @@ class MDLabel(DeclarativeBehavior, ThemableBehavior, TouchBehavior, Label, MDAda
             font_style=self.update_font_style,
             can_capitalize=self.update_font_style,
         )
-        self.register_event_type('on_copy')
+        self.register_event_type("on_copy")
         self.on_theme_text_color(None, self.theme_text_color)
         self.update_font_style(None, "")
         self.on_opposite_colors(None, self.opposite_colors)

--- a/kivymd/uix/label/label.py
+++ b/kivymd/uix/label/label.py
@@ -385,7 +385,11 @@ class MDLabel(
             self.dispatch("on_copy")
 
     def on_copy(self):
-        pass
+        """
+        On copy event.
+
+        .. versionadded:: 1.2.0
+        """
 
     def on_theme_text_color(
         self, instance_label, theme_text_color: str


### PR DESCRIPTION
```py
from kivymd.app import MDApp
from kivymd.uix.label import MDLabel

from kivy.lang.builder import Builder

KV = """
<CopyLabel@MDLabel>
    halign: 'center'
    allow_copy: True
    md_bg_color: (0, 0.5, 0, 1)
    on_copy: print(f'Copied {self.text}')

ScrollView:    
    MDBoxLayout:
        padding: dp(10)
        spacing: dp(10)
        adaptive_height: True
        
        MDBoxLayout:
            orientation: 'vertical'
            padding: dp(10)
            spacing: dp(50)
            adaptive_height: True
            
            CopyLabel:
                text: 'Text to copy 1'
                adaptive_height: True
            
            CopyLabel:
                text: 'Text to copy 2'
                adaptive_height: True
            
            CopyLabel:
                text: 'Text to copy 3'
                adaptive_height: True
                
        CopyLabel:
            text: 'Text to copy 4'
        
"""


class TestApp(MDApp):
    def build(self):
        return Builder.load_string(KV)


TestApp().run()
```