### PR TITLE
MDLabel: Fix mro

### DIFF
--- a/kivymd/uix/label/label.py
+++ b/kivymd/uix/label/label.py
@@ -552,9 +552,9 @@ with open(
 class MDLabel(
     DeclarativeBehavior,
     ThemableBehavior,
-    TouchBehavior,
     Label,
     MDAdaptiveWidget,
+    TouchBehavior,
 ):
     """
     Label class.


### PR DESCRIPTION
### Description of Changes

Fix #1405. Now, `TouchBehavior` follows `EventDispatcher`, so we don't get the `TypeError` when we create `DatePickerWeekdayLabel`.

### Code for testing new changes

```python
from kivymd.uix.pickers import MDDatePicker
```
