### PR TITLE
Add documentation for dialog's content_cls

### DIFF
--- a/kivymd/uix/dialog/dialog.py
+++ b/kivymd/uix/dialog/dialog.py
@@ -563,7 +563,8 @@ class MDDialog(BaseDialog):
         :align: center
 
     :attr:`content_cls` is an :class:`~kivy.properties.ObjectProperty`
-    and defaults to `'None'`.
+    and defaults to `'None'`. This attribute is only available when
+    :attr:`type` is set to `'custom'`.
     """
 
     md_bg_color = ColorProperty(None)

--- a/kivymd/uix/dialog/dialog.py
+++ b/kivymd/uix/dialog/dialog.py
@@ -422,7 +422,8 @@ class MDDialog(BaseDialog):
 
     content_cls = ObjectProperty()
     """
-    Custom content class.
+    Custom content class. This attribute is only available when :attr:`type` is
+    set to `'custom'`.
 
     .. tabs::
 
@@ -563,8 +564,7 @@ class MDDialog(BaseDialog):
         :align: center
 
     :attr:`content_cls` is an :class:`~kivy.properties.ObjectProperty`
-    and defaults to `'None'`. This attribute is only available when
-    :attr:`type` is set to `'custom'`.
+    and defaults to `'None'`.
     """
 
     md_bg_color = ColorProperty(None)


### PR DESCRIPTION
The `content_cls` attribute of the dialog component is only used when
the `type` attribute is set to `'custom'`. This was not specified in
the documentation. I spent some time to understand that the `type` attribute was the issue. I hope this change will help others who will try to use this attribute.

This is my first pull request to this project, please let me know if you would prefer I made something different.

Thanks!