### PR TITLE
Added `on_pre_dismiss`, `on_open`, `on_pre_open` events fix `on_dismiss`

### DIFF
--- a/kivymd/uix/menu/menu.py
+++ b/kivymd/uix/menu/menu.py
@@ -858,7 +858,10 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
             on_restore=self.set_menu_properties,
         )
         Clock.schedule_once(self.adjust_radius)
+        self.register_event_type("on_pre_dismiss")
         self.register_event_type("on_dismiss")
+        self.register_event_type("on_pre_open")
+        self.register_event_type("on_open")
         self.menu = self.ids.md_menu
         self.target_height = 0
 
@@ -1064,6 +1067,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
 
     def open(self) -> None:
         """Animate the opening of a menu window."""
+        self.dispatch("on_pre_open")
 
         def open(interval):
             if not self._calculate_complete:
@@ -1103,6 +1107,8 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
             self._calculate_process = True
             Clock.schedule_interval(open, 0)
 
+        self.dispatch("on_open")
+
     def set_elevation(self, *args) -> None:
         Animation(
             _elevation=self.elevation,
@@ -1123,7 +1129,7 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
 
     def on_touch_down(self, touch):
         if not self.menu.collide_point(*touch.pos):
-            self.dispatch("on_dismiss")
+            self.dismiss()
             return True
         super().on_touch_down(touch)
         return True
@@ -1136,8 +1142,10 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
         super().on_touch_up(touch)
         return True
 
-    def on_dismiss(self) -> None:
-        """Called when the menu is closed."""
+    def dismiss(self, *args) -> None:
+        """Closes the menu."""
+
+        self.dispatch("on_pre_dismiss")
 
         Window.remove_widget(self)
         self.menu.width = 0
@@ -1145,10 +1153,19 @@ class MDDropdownMenu(ThemableBehavior, FloatLayout):
         self.menu.opacity = 0
         self._elevation = 0
 
-    def dismiss(self, *args) -> None:
-        """Closes the menu."""
+        self.dispatch("on_dismiss")
 
-        self.on_dismiss()
+    def on_pre_dismiss(self) -> None:
+        pass
+
+    def on_dismiss(self) -> None:
+        pass
+
+    def on_pre_open(self) -> None:
+        pass
+
+    def on_open(self) -> None:
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```py
from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.menu import MDDropdownMenu

KV = '''
MDScreen:

    MDRaisedButton:
        id: button
        text: "Open"
        pos_hint: {"center_x": .5, "center_y": .5}
        on_release: app.menu.open()
'''


class Test(MDApp):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.screen = Builder.load_string(KV)
        menu_items = [
            {
                "text": f"Item {i}",
                "viewclass": "OneLineListItem",
                "on_release": lambda x=f"Item {i}": self.menu_callback(x),
            } for i in range(5)
        ]
        self.menu = MDDropdownMenu(
            caller=self.screen.ids.button,
            items=menu_items,
            width_mult=4,
        )
        self.menu.bind(on_open=lambda *args: print('on_open'))
        self.menu.bind(on_pre_open=lambda *args: print('on_pre_open'))
        self.menu.bind(on_dismiss=lambda *args: print('on_dismiss'))
        self.menu.bind(on_pre_dismiss=lambda *args: print('on_pre_dismiss'))

    def menu_callback(self, text_item):
        print(text_item)
        self.menu.dismiss()

    def build(self):
        return self.screen


Test().run()
```

https://user-images.githubusercontent.com/40869738/205523984-f9a3776e-2110-4ebc-97a6-80da8d4777ab.mp4

