### PR TITLE
Added missing import of FocusBehavior in kivymd.uix.behaviors.

### DIFF
--- a/kivymd/uix/behaviors/__init__.py
+++ b/kivymd/uix/behaviors/__init__.py
@@ -28,3 +28,4 @@ from .stencil_behavior import StencilBehavior
 from .touch_behavior import TouchBehavior
 
 from .hover_behavior import HoverBehavior  # isort:skip
+from .focus_behavior import FocusBehavior


### PR DESCRIPTION
This fixes import error when executing documentation example:

https://kivymd.readthedocs.io/en/1.1.1/behaviors/focus/

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>



### Description of the problem

This fixes Issue https://github.com/kivymd/KivyMD/issues/1422.

### Reproducing the problem

Running example code from documentation fails on import.

https://kivymd.readthedocs.io/en/1.1.1/behaviors/focus/

### Screenshots of the problem

```
Traceback (most recent call last):
   File "/XXX/kivy/examples/kivymd-focus_behavior-1.py", line 4, in <module>
     from kivymd.uix.behaviors import RectangularElevationBehavior, FocusBehavior
 ImportError: cannot import name 'FocusBehavior' from 'kivymd.uix.behaviors' (/XXX/lib/python3.9/site-packages/kivymd/uix/behaviors/__init__.py)
```

### Description of Changes

* Added import of missing `FocusBehavior` to the `kivymd.uix.behaviors` module.
* Note that `FocusBehavior` needs to be placed after `HoverBehavior` as first depends on the second.

### Screenshots of the solution to the problem

Works as expected presented in the documentation.

### Code for testing new changes

Example code from the documentation works fine now.
