### PR TITLE
Remove scroll_timeout for MDTabs when lock_swiping

### DIFF
--- a/kivymd/uix/tab/tab.kv
+++ b/kivymd/uix/tab/tab.kv
@@ -70,6 +70,7 @@
             anim_move_duration: root.anim_duration
             on_index: root.on_carousel_index(*args)
             on__offset: tab_bar.android_animation(*args)
+            scroll_timeout: 0 if root.lock_swiping else 200
 
     MDTabsBar:
         id: tab_bar


### PR DESCRIPTION
### Description of the problem
Based on https://github.com/kivymd/KivyMD/issues/561

This would make a scrollview inside of a tab more responsive to touch.
Otherwise you have to touch the screen and wait 200 milliseconds before scrolling which I think is unnecessary if lock_swiping is set to true.
