### PR TITLE
Fixed using MDExpansionPanel inside MDBottomNavigation

### DIFF
--- a/kivymd/uix/expansionpanel/expansionpanel.py
+++ b/kivymd/uix/expansionpanel/expansionpanel.py
@@ -330,7 +330,7 @@ class MDExpansionPanel(RelativeLayout):
             self.panel_cls.pos_hint = {"top": 1}
             self.panel_cls._no_ripple_effect = True
             self.panel_cls.bind(
-                on_release=lambda x: self.check_open_panel(self.panel_cls)
+                on_press=lambda x: self.check_open_panel(self.panel_cls)
             )
             if not isinstance(self.panel_cls, MDExpansionPanelLabel):
                 self.chevron = MDExpansionChevronRight()


### PR DESCRIPTION

### Description of the problem

MDExpansionPanel does not work well in MDBottomNavigationItem: it does not open and close well or even flies away. [#1457](url)

### Description of Changes

Now `check_open_panel` is called on the `on_press` event, not `on_release`