### PR TITLE
Add Navigation trail from gh-1455

### DIFF
--- a/kivymd/uix/navigationrail/navigationrail.kv
+++ b/kivymd/uix/navigationrail/navigationrail.kv
@@ -35,7 +35,7 @@
     Separator:
         canvas.before:
             Color:
-                rgba: (0.2,0.2,0.2,0.2) if root.separator else (1,1,1,1)
+                rgba: (0.2,0.2,0.2,0.7) if root.separator else (0,0,0,0)
             Line:
                 points:
                     (                                     \

--- a/kivymd/uix/navigationrail/navigationrail.kv
+++ b/kivymd/uix/navigationrail/navigationrail.kv
@@ -30,7 +30,7 @@
 
 <MDNavigationTrail>:
     orientation:"vertical"
-    spacing: "10dp"
+    spacing: "12dp"
     adaptive_size:True
     Separator:
         canvas.before:
@@ -38,9 +38,9 @@
                 rgba: (0.2,0.2,0.2,0.2) if root.separator else (1,1,1,1)
             Line:
                 points:
-                    (                    \
-                    self.x, self.y,      \
-                    self.x + 10, self.y, \
+                    (                                \
+                    self.x + 10, self.y,             \
+                    self.x + self.width -10, self.y, \
                     )
 
 <MDNavigationRailItem>

--- a/kivymd/uix/navigationrail/navigationrail.kv
+++ b/kivymd/uix/navigationrail/navigationrail.kv
@@ -25,7 +25,7 @@
             id:box_trailer
             orientation: "vertical"
             adaptive_size: True
-            pos_hint: {"center_x": .5, "center_y":0}
+            pos_hint: {"center_x": .5, "center_y":0.1}
 
 
 <MDNavigationTrail>:

--- a/kivymd/uix/navigationrail/navigationrail.kv
+++ b/kivymd/uix/navigationrail/navigationrail.kv
@@ -20,7 +20,28 @@
             spacing: "12dp"
             adaptive_size: True
             pos_hint: {"center_x": .5}
+        
+        MDBoxLayout:
+            id:box_trailer
+            orientation: "vertical"
+            adaptive_size: True
+            pos_hint: {"center_x": .5, "center_y":0}
 
+
+<MDNavigationTrail>:
+    orientation:"vertical"
+    spacing: "10dp"
+    adaptive_size:True
+    Separator:
+        canvas.before:
+            Color:
+                rgba: (0.2,0.2,0.2,0.2) if root.separator else (1,1,1,1)
+            Line:
+                points:
+                    (                    \
+                    self.x, self.y,      \
+                    self.x + 10, self.y, \
+                    )
 
 <MDNavigationRailItem>
     orientation: "vertical"

--- a/kivymd/uix/navigationrail/navigationrail.kv
+++ b/kivymd/uix/navigationrail/navigationrail.kv
@@ -30,7 +30,7 @@
 
 <MDNavigationTrail>:
     orientation:"vertical"
-    spacing: "12dp"
+    spacing: "10dp"
     adaptive_size:True
     Separator:
         canvas.before:
@@ -38,9 +38,9 @@
                 rgba: (0.2,0.2,0.2,0.2) if root.separator else (1,1,1,1)
             Line:
                 points:
-                    (                                \
-                    self.x + 10, self.y,             \
-                    self.x + self.width -10, self.y, \
+                    (                                     \
+                    self.x + 10, self.y + 10,             \
+                    self.x + self.width -10, self.y + 10, \
                     )
 
 <MDNavigationRailItem>

--- a/kivymd/uix/navigationrail/navigationrail.py
+++ b/kivymd/uix/navigationrail/navigationrail.py
@@ -560,6 +560,7 @@ from kivy.properties import (
     OptionProperty,
     StringProperty,
     VariableListProperty,
+    BoundedNumericProperty,
 )
 from kivy.uix.behaviors import ButtonBehavior
 
@@ -585,6 +586,47 @@ class PanelRoot(MDFloatLayout):
     buttons and a :class:`~Paneltems` container with menu items.
     """
 
+class Separator (MDWidget):
+    """
+    Separator
+    """
+class MDNavigationTrail (MDBoxLayout):
+    """
+    Contains a list of :class:`~MDNavigationRailItem`s at the bottom part the
+    Navigation rail.
+    """
+    _max_railitems = BoundedNumericProperty(-1, min = -1, max = 3)
+    """
+    Maximum number of :class:`~MDNavigationRailItem`s to place in the :class:`~MDNavigationTrail`.
+    _max_railitems is of type :class:`~BoundedNumericProperty` with a maximum value of 3.
+    """
+
+    separator = BooleanProperty(True)
+    """
+    choose whether to set a separator between the trailer items and the panel items. 
+    separator is a :class:`~BooleanProperty` type and defaults to `True`
+    """
+
+    navigation_rail = ObjectProperty()
+    """
+    :class:`~MDNavigationRail` object.
+
+    :attr:`navigation_rail` is an :class:`~kivy.properties.ObjectProperty`
+    and defaults to `None`.
+    """
+
+    def add_widget(self, widget, *args, **kwargs):
+
+        try:
+            self._max_railitems += 1
+        except ValueError:
+            return
+        else:
+            if isinstance(widget,Separator):
+                return super().add_widget(widget, *args, **kwargs)
+            elif isinstance(widget,MDNavigationRailItem):
+                widget.navigation_rail = self.navigation_rail
+                return super().add_widget(widget, *args, **kwargs)
 
 class PanelItems(MDBoxLayout):
     """Box for menu items."""
@@ -1270,5 +1312,8 @@ class MDNavigationRail(MDCard):
         elif isinstance(widget, MDNavigationRailItem):
             widget.navigation_rail = self
             self.ids.box_items.add_widget(widget)
+        elif isinstance(widget,MDNavigationTrail):
+            widget.navigation_rail = self
+            self.ids.box_trailer.add_widget(widget)
         elif isinstance(widget, (PanelRoot, PanelItems)):
             return super().add_widget(widget)

--- a/kivymd/uix/navigationrail/navigationrail.py
+++ b/kivymd/uix/navigationrail/navigationrail.py
@@ -545,6 +545,7 @@ __all__ = (
 
 import os
 from typing import Union
+from itertools import chain
 
 from kivy.animation import Animation
 from kivy.clock import Clock
@@ -1210,8 +1211,10 @@ class MDNavigationRail(MDCard):
         (:class:`~MDNavigationRailItem`) except the selected item.
         Called when a menu item is touched.
         """
+        trailer = self.ids.box_trailer
+        trail_items = [item for item in trailer.children[0].children] if len(trailer.children) else []
 
-        for navigation_rail_item in self.ids.box_items.children:
+        for navigation_rail_item in chain(self.ids.box_items.children,trail_items):
             if selected_navigation_rail_item is not navigation_rail_item:
                 navigation_rail_item.active = False
 

--- a/kivymd/uix/navigationrail/navigationrail.py
+++ b/kivymd/uix/navigationrail/navigationrail.py
@@ -625,6 +625,11 @@ class MDNavigationTrail (MDBoxLayout):
             if isinstance(widget,Separator):
                 return super().add_widget(widget, *args, **kwargs)
             elif isinstance(widget,MDNavigationRailItem):
+                self.parent.pos_hint = {"center_y":0}                \
+                                        if (self._max_railitems <=1) \
+                                        else {"center_y":0.07}       \
+                                        if (self._max_railitems == 2)\
+                                        else {"center_y":0.13}
                 widget.navigation_rail = self.navigation_rail
                 return super().add_widget(widget, *args, **kwargs)
 

--- a/kivymd/uix/navigationrail/navigationrail.py
+++ b/kivymd/uix/navigationrail/navigationrail.py
@@ -1245,7 +1245,11 @@ class MDNavigationRail(MDCard):
         elif self.anchor == "center":
             self.ids.box_items.pos_hint = {"center_y": 0.5}
         elif self.anchor == "bottom":
-            self.ids.box_items.y = dp(12)
+            trailer = self.ids.box_trailer
+            if len(trailer.children):
+                self.ids.box_items.y = trailer.height + 15   # use +15 to prevent panel items from crossing the separator when window is maximized
+            else:
+                self.ids.box_items.y = dp(12)
 
     def set_current_selected_item(self, interval: Union[int, float]) -> None:
         """Sets the active menu list item (:class:`~MDNavigationRailItem`)."""


### PR DESCRIPTION
### Description of the problem

This PR implements the issue described in #1455 

### Description of Changes

This PR does not implement  a solution as a described in the issue I raised since that would create a lot of breaking an unnecessary changes. The PR instead introduces an **MDNavigationTrail** widget instead of **MDNavigationGroup**. The Trailer widget contains the **MDNavigationRailItem**s that shall be displayed at the bottom of the Navigation rail. This focuses more on the issue at hand other than introducing group positions that are generic and can be misused.

The **MDNavigationTrail** widget is a box layout widget that shall be positioned at the bottom of the navigation rail. It can accomodate a maximum of **3 MDNavigationRailItem**s. This is because if the number exceeds 3, then there's no point in using the MDNaviagtionTrail, It would be better to just anchor the Items to the bottom of the **MDNavigationRail.**
The MDNavigationTrail widget has an internal `_max_railitems` property to track the number of items in the trail. It also has 2 more properties: **separator** and **navigation_rail**. Separator is a boolean attribute to decide if a separator line can be drawn above the Trailer to show separation from the rest of the icons. This would be important in cases where the **MDNavigationTrail** widget is used along with the bottom anchor position of the **MDNavgiationRail**. It would be good to show a distinction of where the different Items belong.
The **navigation_rail** attribute points to the parent navigation rail widget of the trailer widget.

### Screenshots of the solution to the problem

![image](https://user-images.githubusercontent.com/35004147/221864345-e8c40586-f1a0-4a79-b3e1-0476a288741b.png)
![image](https://user-images.githubusercontent.com/35004147/221869221-c64a3e75-fd68-4979-9508-57d24c6e151e.png)


### Code for testing new changes

```python
from kivy.lang import Builder

from kivymd.app import MDApp

KV = '''
MDBoxLayout:

    MDNavigationRail:

        MDNavigationRailItem:
            text: "Python"
            icon: "language-python"

        MDNavigationRailItem:
            text: "JavaScript"
            icon: "language-javascript"

        MDNavigationRailItem:
            text: "CPP"
            icon: "language-cpp"

        MDNavigationRailItem:
            text: "Git"
            icon: "git"
        
        MDNavigationTrail:
            MDNavigationRailItem:
                text:"Android"
                icon:"android"


    MDScreen:
'''


class Example(MDApp):
    def build(self):
        return Builder.load_string(KV)


Example().run()
```
### Bugs
I've submitted a draft PR as I'm still sorting out some bugs in the code. The bugs include:
1) [x] The separator line does not appear. The problem might be in how I've implemented it, I need to review the code again
2) [x] The more than one **MDNavigationRailItem** can be toggled on, we need to fix that. Check image below
![image](https://user-images.githubusercontent.com/35004147/221865525-c94005e6-c353-4d31-95bc-3d19f1e36612.png)
2) [x] **MDNaviagtionRailItem**s are being clipped off if they are more than 1. refer to the above image where the name "note" was 
supposed to appear below the pencil icon but it was clipped off.
4) [x] anchor bottom in navigation rail crushes into the trailer widget. We can either fix positioning or prevent bottom anchoring if trailer is used. I think the first suggestion is better.
5) [x] the hanging item problem. A single MDNavigationRailItem appears to be hanging far from the bottom of the MDNavigationRail
![up](https://user-images.githubusercontent.com/35004147/222359981-ffa190a6-4e17-42c5-aa5b-f322cc01beca.png)
![down](https://user-images.githubusercontent.com/35004147/222360054-d43146ce-005f-4250-9567-ae9eedfdc2c2.png)
