### PR TITLE
Improvements in `MDExpansionChevronRight`

### DIFF
--- a/kivymd/uix/expansionpanel/expansionpanel.kv
+++ b/kivymd/uix/expansionpanel/expansionpanel.kv
@@ -1,7 +1,5 @@
 <MDExpansionChevronRight>:
     icon: "chevron-right"
-    disabled: True
-    md_bg_color_disabled: 0, 0, 0, 0
 
     canvas.before:
         PushMatrix
@@ -15,4 +13,3 @@
 
 <MDExpansionPanel>
     size_hint_y: None
-    # height: dp(68)

--- a/kivymd/uix/expansionpanel/expansionpanel.py
+++ b/kivymd/uix/expansionpanel/expansionpanel.py
@@ -334,6 +334,10 @@ class MDExpansionPanel(RelativeLayout):
             )
             if not isinstance(self.panel_cls, MDExpansionPanelLabel):
                 self.chevron = MDExpansionChevronRight()
+                self.chevron._no_ripple_effect = True
+                self.chevron.bind(
+                    on_release=lambda x: self.check_open_panel(self.panel_cls)
+                )
                 self.panel_cls.add_widget(self.chevron)
                 if self.icon:
                     if self.icon in md_icons.keys():


### PR DESCRIPTION
I've always been infuriated that I can't open MDExpansionPanel by clicking on the arrow (chevron), and so I decided to eliminate this glaring flaw 😁