### PR TITLE
Fix-Pillow-Update-Version

### DIFF
--- a/.ci/macos_dependencies.sh
+++ b/.ci/macos_dependencies.sh
@@ -75,6 +75,6 @@ python -m pip install --upgrade pip setuptools wheel
 python -m pip install --upgrade \
   cython \
   pytest pytest-cov pytest_asyncio pytest-timeout coveralls \
-  pillow docutils pygments pyinstaller[hook_testing] \
+  pillow==9.4.0 docutils pygments pyinstaller[hook_testing] \
   sphinx sphinxcontrib-blockdiag sphinxcontrib-seqdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag
 python -m pip install --upgrade kivy==$KIVY_VERSION

--- a/.ci/ubuntu_dependencies.sh
+++ b/.ci/ubuntu_dependencies.sh
@@ -20,7 +20,7 @@ python -m pip install --upgrade pip setuptools wheel
 python -m pip install --upgrade \
   cython \
   pytest pytest-cov pytest_asyncio pytest-timeout coveralls \
-  pillow docutils pygments pyinstaller[hook_testing] \
+  pillow==9.4.0 docutils pygments pyinstaller[hook_testing] \
   sphinx sphinxcontrib-blockdiag sphinxcontrib-seqdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag
 python -m pip install --upgrade kivy==$KIVY_VERSION
 

--- a/.ci/windows_dependencies.ps1
+++ b/.ci/windows_dependencies.ps1
@@ -9,6 +9,6 @@ python -m pip install --upgrade pip setuptools wheel
 python -m pip install --upgrade `
   cython `
   pytest pytest-cov pytest_asyncio pytest-timeout coveralls `
-  pillow pyinstaller[hook_testing] `
+  pillow==9.4.0 pyinstaller[hook_testing] `
   pypiwin32 kivy_deps.sdl2 kivy_deps.glew kivy_deps.angle kivy_deps.gstreamer
 python -m pip install --upgrade kivy==$Env:KIVY_VERSION

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
                 "sphinx-tabs",
             ],
         },
-        install_requires=["kivy>=2.0.0", "pillow"],
+        install_requires=["kivy>=2.0.0", "pillow==9.4.0"],
         setup_requires=[],
         python_requires=">=3.7",
         entry_points={


### PR DESCRIPTION
### Description of the problem

Kivy MD internally uses Pillow for drawings and it was working fine.
Pillow team has updated the pillow to version 9.5.0 which seems to be not compatible with Kivy MD so until we change implementation we can specify the previous Pillow stable version for installation.
[Pillow Release Notes:](https://pillow.readthedocs.io/en/stable/releasenotes/9.5.0.html)

### Describe the algorithm of actions that leads to the problem

Description of the algorithm of actions

### Reproducing the problem
Just try to run any kivy md application without updating the pillow version.

### Screenshots of the problem

![kivymdIssue](https://user-images.githubusercontent.com/48254958/230903221-c6e0b88a-9e81-4ae8-ba2a-66736ba3ee7a.PNG)

### Description of Changes

Fixed Pillow version to 9.4.0 which is a previous stable version of Pillow and works well with Kivy MD

