### PR TITLE
Prevent triggering events on load

### DIFF
--- a/kivymd/uix/navigationrail/navigationrail.py
+++ b/kivymd/uix/navigationrail/navigationrail.py
@@ -1225,8 +1225,9 @@ class MDNavigationRail(MDCard):
             else:
                 index = self.current_selected_item
 
-            items[index].dispatch("on_press")
-            items[index].dispatch("on_release")
+            items[index].active = True
+            items[index]._release = True
+            items[index].animation_size_ripple_area(0)
 
     def set_pos_menu_fab_buttons(self, *args) -> None:
         """


### PR DESCRIPTION
### Description of the problem

The dispatch calls in the set_current_selected_item method to the triggers on_press and on_release are triggering these events as soon as the widget is added to the navigation rail. To fix this I propose only running the relevant code for highlighting the navigation item contained in those methods. The bug is found on lines 1228 and 1229 of the current version.

### Describe the algorithm of actions that leads to the problem

Bind callback to on_press or on_release during creation of layout. The same is true when binding a callback to on_item_release or on_item_press of the MDNavigationRail widget.

### Reproducing the problem

```python
# Minimal code example that reproduces the problem:
self.item = MDNavigationRailItem(
                        text= "Patient",
                        icon='account-search',
                        id='pat',
                        on_release=self.callback
                    )
or

self.rail = MDNavigationRail(on_item_release=self.callback)
```

### Description of Changes

Replace the dispatch calls on lines 1228 and 1229 with code that only highlights the first item in the rail instead of using the on_press or on_release triggers of the navigation item to achieve that.

### Code for testing new changes

```python
# Code that demonstrates the correctness of the new changes:

Same as above.

```
