### PR TITLE
better touch behaviour

### DIFF
--- a/kivymd/uix/behaviors/touch_behavior.py
+++ b/kivymd/uix/behaviors/touch_behavior.py
@@ -68,6 +68,9 @@ class TouchBehavior:
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.register_event_type("on_long_touch")
+        self.register_event_type("on_double_tap")
+        self.register_event_type("on_triple_tap")
         self.bind(
             on_touch_down=self.create_clock, on_touch_up=self.delete_clock
         )
@@ -75,14 +78,14 @@ class TouchBehavior:
     def create_clock(self, widget, touch, *args):
         if self.collide_point(touch.x, touch.y):
             if "event" not in touch.ud:
-                callback = partial(self.on_long_touch, touch)
+                callback = partial(self.dispatch, "on_long_touch", touch)
                 Clock.schedule_once(callback, self.duration_long_touch)
                 touch.ud["event"] = callback
 
         if touch.is_double_tap:
-            self.on_double_tap(touch, *args)
+            Clock.schedule_once(partial(self.dispatch, "on_double_tap", touch, *args))
         if touch.is_triple_tap:
-            self.on_triple_tap(touch, *args)
+            Clock.schedule_once(partial(self.dispatch, "on_triple_tap", touch, *args))
 
     def delete_clock(self, widget, touch, *args):
         if self.collide_point(touch.x, touch.y):


### PR DESCRIPTION

### Description of the problem

unable to bind outer `on_long_touch` method (and simmilar ones)

### Describe the algorithm of actions that leads to the problem

calling on_long_touch() itself whithout dispatching

### Reproducing the problem

```python
from kivy.uix.button import Button
from kivymd.app import MDApp
from kivymd.uix.behaviors import TouchBehavior


class MainApp(MDApp):
    def build(self):
        btn = MyButton()
        btn.text = 'Hello world'
        btn.bind(on_long_touch=self.long_touch)
        return btn

    def long_touch(self, *args):
        print('outer long touch')


class MyButton(Button, TouchBehavior):
    def on_long_touch(self, touch, *args):
        print('inner long touch')


MainApp().run()
```

### Description of Changes

calling methods via dispatcher
