### PR TITLE
Fixed icon color property of right_action_items/left_action_items in MDTopAppBar class

### DIFF
--- a/kivymd/uix/toolbar/toolbar.py
+++ b/kivymd/uix/toolbar/toolbar.py
@@ -1725,14 +1725,14 @@ class MDTopAppBar(DeclarativeBehavior, NotchedBox, WindowController):
                     on_release=item[1],
                     tooltip_text=item[2],
                     overflow_text=item[3]
-                    if (len(item) == 4 and isinstance(item[3], str))
+                    if (len(item) >= 4 and isinstance(item[3], str))
                     else "",
                     theme_text_color="Custom"
                     if not self.opposite_colors
                     else "Primary",
                     text_color=self.specific_text_color
-                    if not (len(item) == 4 and isinstance(item[3], tuple))
-                    else item[3],
+                    if not (len(item) == 5 and isinstance(item[4], tuple))
+                    else item[4],
                     opposite_colors=self.opposite_colors,
                 )
             )


### PR DESCRIPTION
Fixed icon color property of right_action_items/left_action_items in MDTopAppBar class

### Description of the problem

The current implementation does not allow for both an overflow text and icon color.
Implementation of icon color like specified in the documentation is not possible @Neizvestnyj @HeaTTheatR :
```kv
MDTopAppBar:
    right_action_items:
        [
        [
        "dots-vertical",
        callback,
        "tooltip text",
        "overflow text",
        (1, 1, 1, 1),
        ]
        ]
```
Screenshot of the documentation page:
![image](https://github.com/kivymd/KivyMD/assets/17033906/d6f04f44-d2c8-44ce-aa78-80b8ed3c379d)


### Describe the algorithm of actions that leads to the problem

Try to implement the MDTopAppBar Icon color property as described in the documentation.


### Reproducing the problem

```python
from kivymd.app import MDApp
from kivy.lang import Builder

app_lang = """
MDBoxLayout:
    orientation: 'vertical'
    MDTopAppBar:
        use_overflow: True
        title: "TestTitle"
        right_action_items:
            [
            ["qrcode-scan", lambda x: x, "tooltip text", "overflow text", (1,0,0,1)],
            ["bluetooth-off", lambda x: x, "tooltip text", "overflow text", (0,1,0,1)],
            ["qrcode-scan", lambda x: x, "tooltip text", "overflow text", (0,1,0,1)],
            ["bluetooth-off", lambda x: x, "tooltip text", "overflow text", (0,1,0,1)],
            ["qrcode-scan", lambda x: x, "tooltip text", "overflow text", (0,1,0,1)],
            ["bluetooth-off", lambda x: x, "tooltip text", "overflow text", (0,1,0,1)],
            ]
    Widget:
"""


class App(MDApp):
    def build(self):
        return Builder.load_string(app_lang)


App().run()
```

### Screenshots of the problem

![image](https://github.com/kivymd/KivyMD/assets/17033906/05943ebd-d7c6-4668-8a7f-9a991eb773f1)

### Description of Changes

![image](https://github.com/kivymd/KivyMD/assets/17033906/97b055ba-f757-4f64-8910-2662318ba89a)

### Screenshots of the solution to the problem

![image](https://github.com/kivymd/KivyMD/assets/17033906/deb70636-be51-41dd-ace4-903379cb6191)

### Code for testing new changes

Same as the code that reproduces the problem
