### PR TITLE
Fix #1524 - MDColorPicker does not open

### DIFF
--- a/kivymd/uix/pickers/colorpicker/colorpicker.py
+++ b/kivymd/uix/pickers/colorpicker/colorpicker.py
@@ -562,6 +562,8 @@ class MDColorPicker(BaseDialog):
             self._current_tab = self.gradient_tab
             self.ids.bottom_navigation_gradient.add_widget(self.gradient_tab)
 
+        super().on_open()
+
     def on_select_color(self, color: list) -> None:
         """Called when a gradient image is clicked."""
 


### PR DESCRIPTION

### Description of the problem

Fix #1524

### Describe the algorithm of actions that leads to the problem

MDColorPicker not open on call open()

### Reproducing the problem


```python
from typing import Union

from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.pickers import MDColorPicker

KV = '''
MDScreen:

    MDTopAppBar:
        id: toolbar
        title: "MDTopAppBar"
        pos_hint: {"top": 1}

    MDRaisedButton:
        text: "OPEN PICKER"
        pos_hint: {"center_x": .5, "center_y": .5}
        md_bg_color: toolbar.md_bg_color
        on_release: app.open_color_picker()
'''


class MyApp(MDApp):
    def build(self):
        return Builder.load_string(KV)

    def open_color_picker(self):
        color_picker = MDColorPicker(size_hint=(0.45, 0.85))
        color_picker.open()
        color_picker.bind(
            on_select_color=self.on_select_color,
            on_release=self.get_selected_color,
        )

    def update_color(self, color: list) -> None:
        self.root.ids.toolbar.md_bg_color = color

    def get_selected_color(
        self,
        instance_color_picker: MDColorPicker,
        type_color: str,
        selected_color: Union[list, str],
    ):
        '''Return selected color.'''

        print(f"Selected color is {selected_color}")
        self.update_color(selected_color[:-1] + [1])

    def on_select_color(self, instance_gradient_tab, color: list) -> None:
        '''Called when a gradient image is clicked.'''


MyApp().run()
```

### Description of Changes

add super() call to MDColorPicker.on_open()

### Screenshots of the solution to the problem

![image](https://github.com/kivymd/KivyMD/assets/41635420/9d07e210-51b9-4c5e-9cf2-f16cbf68e7e7)

### Code for testing new changes
same from reproduce
