### PR TITLE
Allow screens with multiple uppercase words to be added to screens.py

### DIFF
--- a/kivymd/tools/patterns/add_view.py
+++ b/kivymd/tools/patterns/add_view.py
@@ -155,14 +155,14 @@ def create_screens_data(
         for name in os.listdir(path_to_view):
             if os.path.isdir(os.path.join(path_to_view, name)):
                 res = re.findall("[A-Z][a-z]*", name)
-                if res and len(res) == 2 and res[-1] == "Screen":
+                if res and res[-1] == "Screen":
                     screens += (
                         "\n    '%s': {"
                         "\n        'model': %s,"
                         "\n        'controller': %s,"
                         "\n    },"
                         % (
-                            f"{res[0].lower()} {res[1].lower()}",
+                            f"{" ".join(res).lower()}",
                             f'{"".join(res)}Model',
                             f'{"".join(res)}Controller',
                         )

--- a/kivymd/tools/patterns/add_view.py
+++ b/kivymd/tools/patterns/add_view.py
@@ -155,7 +155,7 @@ def create_screens_data(
         for name in os.listdir(path_to_view):
             if os.path.isdir(os.path.join(path_to_view, name)):
                 res = re.findall("[A-Z][a-z]*", name)
-                if res and res[-1] == "Screen":
+                if res and len(res) >= 2 and res[-1] == "Screen":
                     screens += (
                         "\n    '%s': {"
                         "\n        'model': %s,"

--- a/kivymd/tools/patterns/add_view.py
+++ b/kivymd/tools/patterns/add_view.py
@@ -162,7 +162,7 @@ def create_screens_data(
                         "\n        'controller': %s,"
                         "\n    },"
                         % (
-                            f"{" ".join(res).lower()}",
+                            f'{" ".join(res).lower()}',
                             f'{"".join(res)}Model',
                             f'{"".join(res)}Controller',
                         )


### PR DESCRIPTION
allow to add screen with multiple UpperCase words, e.g.  "NotificationSettingsScreen" to the screens.py file



### Description of the problem

Currently, when you add a view using kivymd.add_view, screens with more than two words in name won't be added properly to screens.py and need to added manually.


### Describe the algorithm of actions that leads to the problem

The problem lies in the add_view.py, which only allows name length of 2 (`len(res) == 2`)

### Reproducing the problem

```sh
kivymd.add_view MVC . DebugMenuScreen
```

### Description of Changes

the check was altered, such that it now allows screens with the minimum length of two words (`len(res) >= 2`)
Additionally the screen list key generation was changed to use all words in the screen name

### Code for testing new changes

```sh
kivymd.add_view MVC . DebugMenuScreen
```
