### PR TITLE
Use `mActivity` provided by `android`

### DIFF
--- a/kivymd/toast/androidtoast.py
+++ b/kivymd/toast/androidtoast.py
@@ -48,10 +48,10 @@ if platform != "android":
         f"{platform.capitalize()} platform does not support Android Toast"
     )
 
+from android import mActivity
 from android.runnable import run_on_ui_thread
 from jnius import autoclass
 
-activity = autoclass("org.kivy.android.PythonActivity").mActivity
 Toast = autoclass("android.widget.Toast")
 String = autoclass("java.lang.String")
 
@@ -77,6 +77,6 @@ def toast(text, length_long=False, gravity=0, y=0, x=0):
     """
 
     duration = Toast.LENGTH_SHORT if length_long else Toast.LENGTH_LONG
-    t = Toast.makeText(activity, String(text), duration)
+    t = Toast.makeText(mActivity, String(text), duration)
     t.setGravity(gravity, x, y)
     t.show()

--- a/kivymd/utils/get_wallpaper.py
+++ b/kivymd/utils/get_wallpaper.py
@@ -11,19 +11,12 @@ def get_wallpaper(
     if platform == "android":
         try:
             from jnius import autoclass, cast
+            from android import mActivity
 
-            PythonActivity = autoclass("org.kivy.android.PythonActivity")
             CompressFormat = autoclass("android.graphics.Bitmap$CompressFormat")
             FileOutputStream = autoclass("java.io.FileOutputStream")
-            CurrentActivity = cast(
-                "android.app.Activity", PythonActivity.mActivity
-            )
             WallpaperManager = autoclass("android.app.WallpaperManager")
-            Context = cast(
-                "android.content.Context",
-                CurrentActivity.getApplicationContext(),
-            )
-
+            Context = mActivity.getApplicationContext() 
             mWallpaperManager = WallpaperManager.getInstance(Context)
             mWallpaperManager.getBitmap().compress(
                 CompressFormat.PNG,


### PR DESCRIPTION
Because `org.kivy.android.PythonActivity` is not same in every app and `android` module selects name itself. 

See:
https://github.com/kivy/buildozer/blob/079101d9086846c3fc5066de40506742bc044c9a/buildozer/default.spec#L145-L153