### PR TITLE
Fixed Docs generation for v2.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,19 +7,19 @@ repos:
 
   # Format Python
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.12.1
     hooks:
       - id: black
 
   # Sort imports
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         additional_dependencies: ["toml"]
 
   # Lint Python
-  - repo: https://gitlab.com/PyCQA/flake8
-    rev: 4.0.1
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
     hooks:
       - id: flake8

--- a/docs/sources/_extensions/autoapi_kivymd.py
+++ b/docs/sources/_extensions/autoapi_kivymd.py
@@ -16,11 +16,14 @@ import re
 import autoapi
 import sphinx
 import unidecode
+from autoapi.directives import NestedParse
 from autoapi.extension import LOGGER
 from autoapi.extension import setup as autoapi_setup
 from autoapi.mappers.python.mapper import PythonSphinxMapper
 from autoapi.mappers.python.objects import PythonPythonMapper
+from docutils import nodes
 from sphinx.util.console import bold, darkgreen
+from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.osutil import ensuredir
 
 
@@ -128,7 +131,21 @@ def extension_build_finished(app, exception):
                     break
 
 
+def patched_nested_parse_run(self):
+    node = nodes.container()
+    node.document = self.state.document
+    nested_parse_with_titles(self.state, self.content, node)
+    try:
+        title_node = node[0][0]
+        if isinstance(title_node, nodes.title):
+            title_node.children.pop(0)
+    except IndexError:
+        pass
+    return node.children
+
+
 def setup(app):
+    NestedParse.run = patched_nested_parse_run
     PythonPythonMapper.pathname = property(PythonPythonMapper_pathname)
     PythonPythonMapper.include_dir = PythonPythonMapper_include_dir
     PythonSphinxMapper.output_rst = PythonSphinxMapper_output_rst


### PR DESCRIPTION
### Description of the problem

The PRs fixes #1581 

### Describe the algorithm of actions that leads to the problem

The current implementation of third-party sphinx-extension `sphinx-autoapi` can break sometimes. 

### Description of Changes

We monkey patch the `autoapi.directive.NestedParser.run` 

### Code for testing new changes

```bash
make clean && make html
```
closes #1581 

### how I found the error
when going through the memory in the debugger I noticed that the extension does not decrement the "node" level in some edge cases, so Sphinx keeps trying to go one level up even when we are at root

## Future considerations 
in v2.1.0  it can be discussed if its possible to migrate `sphinx-autoapi` to `sphinx.ext.autosummary` as `autosummary` now supports recursive docs generation, or even ditching sphinx altogether for something like hugo. 
 
