### PR TITLE
Implement bitmap scale down

### DIFF
--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -39,6 +39,7 @@ from kivy.properties import (
     OptionProperty,
     StringProperty,
 )
+from kivy import platform
 from kivy.utils import get_color_from_hex, rgba, hex_colormap
 
 from kivymd.dynamic_color import DynamicColor
@@ -147,7 +148,7 @@ class ThemeManager(EventDispatcher, DynamicColor):
     and defaults to `None`.
     """
 
-    dynamic_color_quality = NumericProperty(10)
+    dynamic_color_quality = NumericProperty(1 if platform == "android" else 10)
     """
     The quality of the generated color scheme from the system wallpaper.
 
@@ -157,7 +158,7 @@ class ThemeManager(EventDispatcher, DynamicColor):
         generation time of the color scheme.
 
     :attr:`dynamic_color_quality` is an :class:`~kivy.properties.NumericProperty`
-    and defaults to `10`.
+    and defaults to `10` if platform is not Android else `1`.
     """
 
     dynamic_color = BooleanProperty(False)

--- a/kivymd/utils/get_wallpaper.py
+++ b/kivymd/utils/get_wallpaper.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import math
 
 from kivy import platform, Logger
 
@@ -16,9 +17,31 @@ def get_wallpaper(
             CompressFormat = autoclass("android.graphics.Bitmap$CompressFormat")
             FileOutputStream = autoclass("java.io.FileOutputStream")
             WallpaperManager = autoclass("android.app.WallpaperManager")
+            Bitmap = autoclass("android.graphics.Bitmap")
+            
             Context = mActivity.getApplicationContext()
             mWallpaperManager = WallpaperManager.getInstance(Context)
-            mWallpaperManager.getBitmap().compress(
+            bitmap = mWallpaperManager.getBitmap()
+
+            # Scale the bitmap down as needed
+            # Taken from:
+            # https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/palette/palette/src/main/java/androidx/palette/graphics/Palette.java#890
+            DEFAULT_RESIZE_BITMAP_AREA = 112 * 112 # Android default
+            bitmapArea = bitmap.getWidth() * bitmap.getHeight()
+            scaleRatio = -1
+
+            if bitmapArea > DEFAULT_RESIZE_BITMAP_AREA:
+                    scaleRatio = math.sqrt(DEFAULT_RESIZE_BITMAP_AREA / bitmapArea)
+
+            if scaleRatio >= 0:
+                bitmap = Bitmap.createScaledBitmap(
+                    bitmap,
+                    math.ceil(bitmap.getWidth() * scaleRatio),
+                    math.ceil(bitmap.getHeight() * scaleRatio),
+                    False
+                )
+
+            bitmap.compress(
                 CompressFormat.PNG,
                 100,
                 FileOutputStream(f"{user_data_dir}/wallpaper.png"),


### PR DESCRIPTION

### Description of the problem

This PR implements the default android [bitmap scale down algorithm](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/palette/palette/src/main/java/androidx/palette/graphics/Palette.java#890) which is used before color generation.
