### PR TITLE
Support remove_widget() on MDListItem

### DIFF
--- a/kivymd/uix/list/list.kv
+++ b/kivymd/uix/list/list.kv
@@ -76,7 +76,7 @@
         size_hint_x: None
         width: 0
         on_children:
-            if text_container.children: \
+            if text_container.children and self.children: \
             self.children[0].pos_hint = {"top": 1} \
             if len(text_container.children) == 3 else {"center_y": .5}
 


### PR DESCRIPTION

### Description of the problem

When trying to remove the MDListItemTrailingIcon from a MDListItem an exception is raised.
See #1644.

### Describe the algorithm of actions that leads to the problem

See #1644.

### Description of Changes

Add extra condition to avoid raising KeyError.

I did not write unit test since I did not see any testing done for MDList in general.

### Screenshots of the solution to the problem

N/A

### Code for testing new changes

N/A
