### PR TITLE
Support remove_widget() on MDSwitch

### DIFF
--- a/kivymd/uix/selectioncontrol/selectioncontrol.kv
+++ b/kivymd/uix/selectioncontrol/selectioncontrol.kv
@@ -58,6 +58,7 @@
         text_color:
             ( \
             ( \
+            ( \
             root.parent.icon_active_color \
             if root.parent.icon_active_color \
             else self.theme_cls.onPrimaryContainerColor \
@@ -76,7 +77,9 @@
             if root.parent.icon_active else \
             self.theme_cls.surfaceContainerHighestColor[:-1] \
             + [root.parent.switch_opacity_value_disabled_icon] \
-            )
+            ) \
+            ) \
+            if root.parent else self.theme_cls.transparentColor
 
 
 <MDSwitch>


### PR DESCRIPTION

### Description of the problem

Similar to #1646, when trying to clear MDSwitch widget an exception is raised.

### Describe the algorithm of actions that leads to the problem

Calling clear_widgets() on MDSwitch raises an exception.

### Reproducing the problem

```python
from kivy.lang import Builder
from kivy.uix.boxlayout import BoxLayout
from kivymd.app import MDApp

KV = '''
<MyView>:

    MDBoxLayout:
        orientation: 'vertical'

        Button:
            text: "Remove icon"
            on_release: root.remove()

        MDSwitch:
            id: switch
            active: True
            icon_active: "check"

MDScreen:

    MDBoxLayout:
        id: content

        MyView:
'''

class MyView(BoxLayout):
    _trailing_icon = None

    def remove(self):
        self.ids.switch.clear_widgets()
        # OR
        #thumb = self.ids.switch.ids.thumb
        #thumb.parent.remove_widget(thumb)

class Example(MDApp):

    def build(self):
        return Builder.load_string(KV)
    
Example().run()

```

### Screenshots of the problem

N/A

### Description of Changes

New condition added to avoid ` AttributeError: 'NoneType' object has no attribute 'disabled'`

### Screenshots of the solution to the problem

N/A

### Code for testing new changes

Same code below.
