### PR TITLE
Fix Enabling/Disabling MDTextField

### DIFF
--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -1691,49 +1691,54 @@ class MDTextField(
         error_color = self._get_error_color()
         on_surface_variant_color = self.theme_cls.onSurfaceVariantColor
 
-        schedule_set_texture_color(
-            self._max_length_label,
-            max_length_label_group[0],
-            self._max_length_label.color[:-1] + [1]
-            if not self.error
-            else error_color,
-        )
-        schedule_set_texture_color(
-            self._helper_text_label,
-            helper_text_label_group[0],
-            on_surface_variant_color
-            if not self._helper_text_label.text_color_focus
-            else self._helper_text_label.text_color_focus
-            if not self.error
-            else error_color,
-        )
-        schedule_set_texture_color(
-            self._hint_text_label,
-            hint_text_label_group[0],
-            on_surface_variant_color
-            if not self._hint_text_label.text_color_normal
-            else self._hint_text_label.text_color_normal
-            if not self.error
-            else error_color,
-        )
-        schedule_set_texture_color(
-            self._leading_icon,
-            leading_icon_group[0],
-            on_surface_variant_color
-            if self._leading_icon.theme_icon_color == "Primary"
-            or not self._leading_icon.icon_color_normal
-            else self._leading_icon.icon_color_normal,
-        )
-        schedule_set_texture_color(
-            self._trailing_icon,
-            trailing_icon_group[0],
-            on_surface_variant_color
-            if self._trailing_icon.theme_icon_color == "Primary"
-            or not self._trailing_icon.icon_color_normal
-            else self._trailing_icon.icon_color_normal
-            if not self.error
-            else error_color,
-        )
+        if self._max_length_label:
+            schedule_set_texture_color(
+                self._max_length_label,
+                max_length_label_group[0],
+                self._max_length_label.color[:-1] + [1]
+                if not self.error
+                else error_color,
+            )
+        if self._helper_text_label:
+            schedule_set_texture_color(
+                self._helper_text_label,
+                helper_text_label_group[0],
+                on_surface_variant_color
+                if not self._helper_text_label.text_color_focus
+                else self._helper_text_label.text_color_focus
+                if not self.error
+                else error_color,
+            )
+        if self._hint_text_label:   
+            schedule_set_texture_color(
+                self._hint_text_label,
+                hint_text_label_group[0],
+                on_surface_variant_color
+                if not self._hint_text_label.text_color_normal
+                else self._hint_text_label.text_color_normal
+                if not self.error
+                else error_color,
+            )
+        if self._leading_icon:
+            schedule_set_texture_color(
+                self._leading_icon,
+                leading_icon_group[0],
+                on_surface_variant_color
+                if self._leading_icon.theme_icon_color == "Primary"
+                or not self._leading_icon.icon_color_normal
+                else self._leading_icon.icon_color_normal,
+            )
+        if self._trailing_icon:
+            schedule_set_texture_color(
+                self._trailing_icon,
+                trailing_icon_group[0],
+                on_surface_variant_color
+                if self._trailing_icon.theme_icon_color == "Primary"
+                or not self._trailing_icon.icon_color_normal
+                else self._trailing_icon.icon_color_normal
+                if not self.error
+                else error_color,
+            )
 
     def _set_disabled_colors(self):
         def schedule_set_texture_color(widget, group_name, color, opacity):
@@ -1757,36 +1762,41 @@ class MDTextField(
 
         disabled_color = self.theme_cls.disabledTextColor[:-1]
 
-        schedule_set_texture_color(
-            self._max_length_label,
-            max_length_label_group[0],
-            disabled_color,
-            self.text_field_opacity_value_disabled_max_length_label,
-        )
-        schedule_set_texture_color(
-            self._helper_text_label,
-            helper_text_label_group[0],
-            disabled_color,
-            self.text_field_opacity_value_disabled_helper_text_label,
-        )
-        schedule_set_texture_color(
-            self._hint_text_label,
-            hint_text_label_group[0],
-            disabled_color,
-            self.text_field_opacity_value_disabled_hint_text_label,
-        )
-        schedule_set_texture_color(
-            self._leading_icon,
-            leading_icon_group[0],
-            disabled_color,
-            self.text_field_opacity_value_disabled_leading_icon,
-        )
-        schedule_set_texture_color(
-            self._trailing_icon,
-            trailing_icon_group[0],
-            disabled_color,
-            self.text_field_opacity_value_disabled_trailing_icon,
-        )
+        if self._max_length_label:
+            schedule_set_texture_color(
+                self._max_length_label,
+                max_length_label_group[0],
+                disabled_color,
+                self.text_field_opacity_value_disabled_max_length_label,
+            )
+        if self._helper_text_label:
+            schedule_set_texture_color(
+                self._helper_text_label,
+                helper_text_label_group[0],
+                disabled_color,
+                self.text_field_opacity_value_disabled_helper_text_label,
+            )
+        if self._hint_text_label:
+            schedule_set_texture_color(
+                self._hint_text_label,
+                hint_text_label_group[0],
+                disabled_color,
+                self.text_field_opacity_value_disabled_hint_text_label,
+            )
+        if self._leading_icon:
+            schedule_set_texture_color(
+                self._leading_icon,
+                leading_icon_group[0],
+                disabled_color,
+                self.text_field_opacity_value_disabled_leading_icon,
+            )
+        if self._trailing_icon:
+            schedule_set_texture_color(
+                self._trailing_icon,
+                trailing_icon_group[0],
+                disabled_color,
+                self.text_field_opacity_value_disabled_trailing_icon,
+            )
 
     def _get_has_error(self) -> bool:
         """


### PR DESCRIPTION

### Description of the problem

An exception is raised when enabling or disabling MDTextField. See #1643

### Describe the algorithm of actions that leads to the problem

See #1643 

### Reproducing the problem

```python
from kivy.lang import Builder
from kivy.uix.boxlayout import BoxLayout
from kivymd.app import MDApp

KV = '''
<MyView>:

    MDBoxLayout:
        orientation: 'vertical'

        Button:
            text: "Toggle state"
            on_release: root.toggle()

        MDTextField:
            id: field

            MDTextFieldHintText:
                text: "Hint text"

MDScreen:

    MDBoxLayout:
        id: content

        MyView:
'''

class MyView(BoxLayout):

    def toggle(self):
        self.ids['field'].disabled = not self.ids['field'].disabled 

class Example(MDApp):

    def build(self):
        return Builder.load_string(KV)
    
Example().run()

"""


class MainApp(App):
    def build(self):
        self.root = Builder.load_string(kv)


if __name__ == '__main__':
    MainApp().run()
```

### Screenshots of the problem

N/A

### Description of Changes

The exception is raised because the function `_set_enabled_colors` and `_set_disabled_colors` tried to update the colors of every individual child widget of the MDTextField regardless if the the widget exists or not.

I've added new condition to check if the widget exists before updating the color of it.

### Screenshots of the solution to the problem

N/A

### Code for testing new changes

Same as above.
