### PR TITLE
Fixed shadow appearing before main widget appears

### DIFF
--- a/kivymd/uix/behaviors/elevation.py
+++ b/kivymd/uix/behaviors/elevation.py
@@ -388,7 +388,7 @@ Builder.load_string(
             axis: tuple(self.rotate_value_axis)
             origin: self.center
         Color:
-            rgba: root.shadow_color
+            rgba: self.shadow_color[:3] + [self.shadow_color[3]*(1/(1+100*(.8**((self.opacity-.7)*100))))]
         BoxShadow:
             pos: self.pos if not isinstance(self, RelativeLayout) else (0, 0)
             size: self.size


### PR DESCRIPTION

### Fade Effect of Widget that inherits from `CommonElevationBehavior` class

Widgets that inherit from `CommonElevationBehavior` class (eg. `MDButton` and `MDCard`) produce bad look when their opacity is set low. It happens because their shadow color merges with main widget and gives a darker shade look. As to why it doesn't look good when using fade effect to show the widget. This has been fixed in this version.

### Method to solve the problem

I wanted shadow start fading when opacity of the widget is more than by 70-80% and then by the time opacity of the widget reaches 100%, it's shadow opacity reaches 100% as well. That's why I used logistic function with shadow color opacity that increases very low at first and after a certain point it starts increasing faster.

### Reproducing the problem

```python
from kivymd.app import MDApp
from kivy.lang.builder import Builder
from kivy.animation import Animation

KV = '''
MDScreen:
    md_bg_color: self.theme_cls.backgroundColor
    MDButton:
        pos_hint: {'center_x': .5}
        on_press: app.show_widget(card)
        MDButtonText:
            text: 'Show'
    MDCard:
        id: card
        style: 'elevated'
        size_hint: .75, .75
        pos_hint: {'center_x': .5, 'center_y': .5}
        RelativeLayout:
            MDButton:
                pos_hint: {'center_x': .5, 'center_y': .5}
                on_press: app.hide_widget(card)
                MDButtonText:
                    text: 'Hide'
'''

class MyApp(MDApp):
    def build(self):
        return Builder.load_string(KV)
    
    def show_widget(self, widget):
        Animation(opacity=1, d=2, t='out_quad').start(widget)

    def hide_widget(self, widget):
        Animation(opacity=0, d=2, t='out_quad').start(widget)

MyApp().run()
```

### Showing the problem

![fade_effect_problem](https://github.com/kivymd/KivyMD/assets/69778616/db77e956-8faa-444f-b015-d4535f21ac80)

### Changes to code

in `kivymd/uix/behaviors/elevation.py` file on line `391`
solution code
```
rgba: self.shadow_color[:3] + [self.shadow_color[3]*(1/(1+100*(.8**((self.opacity-.7)*100))))]
```
instead of
```
rgba: self.shadow_color
```

### After applying the solution

![fade_effect_solution](https://github.com/kivymd/KivyMD/assets/69778616/4765c16d-3701-4275-b97b-9c03baf6a336)