### PR TITLE
Update expansionpanel.py

### DIFF
--- a/kivymd/uix/expansionpanel/expansionpanel.py
+++ b/kivymd/uix/expansionpanel/expansionpanel.py
@@ -525,5 +525,5 @@ class MDExpansionPanel(DeclarativeBehavior, BoxLayout):
             return super().add_widget(widget)
 
     def _set_content_height(self, *args):
-        self._original_content_height = self._content.height - dp(88)
+        self._original_content_height = self._content.height 
         self._content.height = 0


### PR DESCRIPTION
def _set_content_height(self, *args):
        self._original_content_height = self._content.height - dp(88)
        self._content.height = 0
IN THIS LINE self._original_content_height = self._content.height - dp(88) 
dp(88) subtraction is not required .  
If we add widgets in MDExpansionPanelContent widget then there is some error for calculation and MDExpansionPanelContent's children not set in boxlayout properly ,



