### PR TITLE
Allow to add Views with more than one word with `kivymd.add_view` function

### DIFF
--- a/kivymd/tools/patterns/add_view.py
+++ b/kivymd/tools/patterns/add_view.py
@@ -155,14 +155,14 @@ def create_screens_data(
         for name in os.listdir(path_to_view):
             if os.path.isdir(os.path.join(path_to_view, name)):
                 res = re.findall("[A-Z][a-z]*", name)
-                if res and len(res) == 2 and res[-1] == "Screen":
+                if res and len(res) >= 2 and res[-1] == "Screen":
                     screens += (
                         "\n    '%s': {"
                         "\n        'model': %s,"
                         "\n        'controller': %s,"
                         "\n    },"
                         % (
-                            f"{res[0].lower()} {res[1].lower()}",
+                            f'{" ".join(res).lower()}',
                             f'{"".join(res)}Model',
                             f'{"".join(res)}Controller',
                         )


### PR DESCRIPTION

### Description of the problem

Currently when creating views via `kivymd.add_view`, only views with one word, e.g. `NotificationScreen`, will be added correctly. When you try to add a view with the name `NotificationSettingsScreen`, all classes in the folders Model, Controller and View will be added. However, it won't be added in the `screens.py`(and no error / warning is thrown).

### Describe the algorithm of actions that leads to the problem

In the file `kivymd/tools/patterns/add_view.py` (line 158ff) there is a restriction for only allowing one word screens:

```python
if res and len(res) == 2 and res[-1] == "Screen":
                    screens += (
                        "\n    '%s': {"
                        "\n        'model': %s,"
                        "\n        'controller': %s,"
                        "\n    },"
                        % (
                            f"{res[0].lower()} {res[1].lower()}",
                            f'{"".join(res)}Model',
                            f'{"".join(res)}Controller',
                        )
...
```

### Reproducing the problem

First create an kivymd MVC project. Then type in the following in commandline:

```commandline
> kivymd.add_view MVC . NotificationSettingsScreen 
```

In the end, have a look into the `screens.py`, the imports are there, but not added in the `screens` dict.

### Screenshots of the problem

Here you can see, that  NotificationSettingsScreen wasn't added to the `screens` dict in `screens.py`
![image](https://github.com/user-attachments/assets/51b5e0e3-469b-4b4c-a800-cab8b9ff93e0)

### Description of Changes

I changed above code to allow multiple words:

```python
if res and len(res) >= 2 and res[-1] == "Screen":
                    screens += (
                        "\n    '%s': {"
                        "\n        'model': %s,"
                        "\n        'controller': %s,"
                        "\n    },"
                        % (
                            f'{" ".join(res).lower()}',
                            f'{"".join(res)}Model',
                            f'{"".join(res)}Controller',
                        )
...
```

### Screenshots of the solution to the problem

Here you can see, that it is now added properly.
![image](https://github.com/user-attachments/assets/c600df49-e427-4433-a981-9865d09d73d8)

### Code for testing new changes

```commandline
> kivymd.add_view MVC . NotificationSettingsScreen 
```
