### PR TITLE
MDTopAppBar - Trailing Items positioning and hover behaviour

### DIFF
--- a/kivymd/uix/appbar/appbar.kv
+++ b/kivymd/uix/appbar/appbar.kv
@@ -1,13 +1,13 @@
 <MDTopAppBarLeadingButtonContainer>
     size_hint_x: None
     width: self.minimum_width
-    padding: "8dp", 0, "16dp", 0
+    padding: "8dp", 0, 0, 0
 
 
 <MDTopAppBarTrailingButtonContainer>
     size_hint_x: None
     width: self.minimum_width
-    padding: "16dp", 0, "16dp", 0
+    padding: 0, 0, "8dp", 0
     spacing: "4dp"
 
 
@@ -20,13 +20,10 @@
 
 
 <MDTopAppBarTitle>
-    padding:
-        [
-        self._appbar._left_padding if self._appbar else 0,
-        0,
-        self._appbar._right_padding if self._appbar else 0,
-        0,
-        ]
+    text_size: self.size
+    halign: "left"
+    valign: "center"
+    padding: 0, "5dp", 0, 0
     font_style:
         { \
         "small": "Title", \
@@ -39,20 +36,8 @@
         "medium": "small", \
         "large": "medium", \
         }[self._appbar.type if self._appbar else "large"]
-    adaptive_width:
-        ( \
-        True \
-        if self._appbar.type == "small" else \
-        False \
-        ) \
-        if self._appbar else True
-    size_hint_x:
-        ( \
-        None \
-        if self._appbar.type == "small" else \
-        1 \
-        ) \
-        if self._appbar else None
+    adaptive_width: True
+    size_hint_x: 1
 
 
 <MDTopAppBar>
@@ -82,9 +67,17 @@
     BoxLayout:
         id: root_box
 
+        BoxLayout:
+            id: text_box
+            padding: "16dp", 0, "16dp", 0
+
     BoxLayout:
         id: title_box
         padding: "16dp", 0, "16dp", 0
+        size_hint:
+            (0, 0) \
+            if self.parent.type == "small" else \
+            (1, 1)
 
 
 <MDFabBottomAppBarButton>

--- a/kivymd/uix/appbar/appbar.py
+++ b/kivymd/uix/appbar/appbar.py
@@ -566,7 +566,7 @@ class BaseTopAppBarButtonContainer(DeclarativeBehavior, BoxLayout):
         return super().add_widget(widget)
 
     def _check_icon_color(self, widget):
-        if widget.theme_icon_color == "Primary" and widget.icon_color == None:
+        if widget.theme_icon_color == "Primary" and widget.icon_color is None:
             widget.theme_icon_color = "Custom"
             widget.icon_color = widget.theme_cls.onSurfaceColor
 
@@ -625,25 +625,6 @@ class MDTopAppBarTitle(MDLabel):
     """
 
     _appbar = ObjectProperty()
-    _title_width = NumericProperty(0)
-
-    # FIXME: When changing the text, the texture_size property returns an
-    #  incorrect value, which causes the panel title to shift.
-    def on_text(self, instance, value) -> None:
-        """Fired when the :attr:`text` value changes."""
-
-        def set_title_width(*args) -> None:
-            self._title_width = self.texture_size[0]
-
-        Clock.schedule_once(set_title_width)
-
-    def on_pos_hint(self, instance, value) -> None:
-        """Fired when the :attr:`pos_hint` value changes."""
-
-        if self._appbar:
-            Clock.schedule_once(
-                lambda x: self._appbar._set_padding_title(value)
-            )
 
 
 class MDTopAppBarLeadingButtonContainer(BaseTopAppBarButtonContainer):
@@ -672,11 +653,6 @@ class MDTopAppBarTrailingButtonContainer(BaseTopAppBarButtonContainer):
     """
 
 
-# FIXME: The on_enter/on_leave event is not triggered for
-#  MDActionTopAppBarButton buttons in the MDTopAppBarTrailingButtonContainer
-#  container.
-#  When the screen size is changed on desktop devices, the position of the
-#  trailing container is shifted until the screen size change is completed.
 class MDTopAppBar(
     DeclarativeBehavior,
     ThemableBehavior,
@@ -731,149 +707,31 @@ class MDTopAppBar(
     _trailing_button_container = ObjectProperty()
     _leading_button_container = ObjectProperty()
     _appbar_title = ObjectProperty()
-    _right_padding = NumericProperty(0)
-    _left_padding = NumericProperty(0)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        Clock.schedule_once(lambda x: self.on_size(self, (0, 0)))
-
-    def on_type(self, instance, value) -> None:
-        def on_type(*args):
-            if value in ("medium", "large"):
-                self.ids.root_box.add_widget(Widget(), index=1)
-
-        Clock.schedule_once(on_type, 0.5)
-
-    def on_size(self, instance, size) -> None:
-        """Fired when the application screen size changes."""
-
-        if self._appbar_title:
-            if not self._appbar_title._title_width:
-                self._appbar_title._title_width = (
-                    self._appbar_title.texture_size[0]
-                )
-            self._right_padding = 0
-            self._left_padding = 0
-            self._appbar_title.on_pos_hint(
-                self._appbar_title, self._appbar_title.pos_hint
-            )
 
     def add_widget(self, widget, *args, **kwargs):
         if isinstance(widget, MDTopAppBarTitle):
             widget._appbar = self
             self._appbar_title = widget
-            widget.bind(text=lambda *x: self.on_size(*x))
             Clock.schedule_once(lambda x: self._add_title(widget))
         elif isinstance(widget, MDTopAppBarTrailingButtonContainer):
             self._trailing_button_container = widget
             widget._appbar = self
             Clock.schedule_once(lambda x: self.ids.root_box.add_widget(widget))
         elif isinstance(widget, MDTopAppBarLeadingButtonContainer):
-            widget._appbar = self
             self._leading_button_container = widget
-            Clock.schedule_once(lambda x: self.ids.root_box.add_widget(widget))
+            widget._appbar = self
+            Clock.schedule_once(lambda x: self.ids.root_box.add_widget(widget, len(self.ids.root_box.children)))
         else:
             return super().add_widget(widget)
 
     def _add_title(self, widget):
         if self.type == "small":
-            self.ids.root_box.add_widget(widget)
+            self.ids.text_box.add_widget(widget)
         else:
             self.ids.title_box.add_widget(widget)
-
-    def _set_padding_title(self, value):
-        if value.get("center_x", 0) == 0.5 and self.type == "small":
-            if (
-                not self._trailing_button_container
-                and self._leading_button_container
-            ):
-                self._left_padding = (
-                    (self.width // 2)
-                    - (
-                        self._leading_button_container.width
-                        + (self._appbar_title._title_width // 2)
-                    )
-                ) - self._left_padding
-            elif (
-                self._trailing_button_container
-                and not self._leading_button_container
-            ):
-                self._left_padding = (
-                    (self.width // 2) - (self._appbar_title._title_width // 2)
-                ) - self._left_padding
-                self._right_padding = (
-                    (self.width // 2)
-                    - (
-                        self._trailing_button_container.width
-                        + (self._appbar_title._title_width // 2)
-                    )
-                ) - self._right_padding
-            elif (
-                not self._trailing_button_container
-                and not self._leading_button_container
-            ):
-                self._left_padding = (
-                    (self.width // 2) - (self._appbar_title._title_width // 2)
-                ) - self._left_padding
-                self._right_padding = (
-                    (self.width // 2) - (self._appbar_title._title_width // 2)
-                ) - self._right_padding
-            elif (
-                self._trailing_button_container
-                and self._leading_button_container
-            ):
-                self._left_padding = (
-                    (self.width // 2)
-                    - (
-                        self._leading_button_container.width
-                        + (self._appbar_title._title_width // 2)
-                    )
-                ) - self._left_padding
-                self._right_padding = (
-                    (self.width // 2)
-                    - (
-                        self._trailing_button_container.width
-                        + (self._appbar_title._title_width // 2)
-                    )
-                ) - self._right_padding
-        elif (
-            not value
-            and self._trailing_button_container
-            and self._leading_button_container
-        ):
-            if self.type == "small":
-
-                self._right_padding = (
-                    self.width
-                    - (
-                        self._trailing_button_container.width
-                        + self._leading_button_container.width
-                        + self._appbar_title._title_width
-                    )
-                    - self._right_padding
-                )
-        elif (
-            not value
-            and self._trailing_button_container
-            and not self._leading_button_container
-        ):
-            if self.type == "small":
-                self._right_padding = (
-                    self.width
-                    - (
-                        self._trailing_button_container.width
-                        + self._appbar_title._title_width
-                    )
-                    - self._right_padding
-                )
-                self._left_padding = dp(16)
-        elif (
-            not value
-            and not self._trailing_button_container
-            and not self._leading_button_container
-        ):
-            self._left_padding = dp(16)
 
 
 class MDBottomAppBar(

--- a/kivymd/uix/appbar/appbar.py
+++ b/kivymd/uix/appbar/appbar.py
@@ -52,7 +52,7 @@ Usage
 
         MDTopAppBarTitle:
             text: "AppBar Center-aligned"
-            pos_hint: {"center_x": .5}
+            halign: "center"
 
         MDTopAppBarTrailingButtonContainer:
 
@@ -88,7 +88,7 @@ Configurations
 
             MDTopAppBarTitle:
                 text: "AppBar small"
-                pos_hint: {"center_x": .5}
+                halign: "center"
 
             MDTopAppBarTrailingButtonContainer:
 


### PR DESCRIPTION
### Description of the problem

All of these problems only occur when using the "small" type of the TopAppBar:
1. The hover behaviour of the trailing container items does not work. 
    #1550

2. Incorrect positioning of the trailing container items, especially while resizing the window. 
    #1708
    #1700
    #1678
    #1660

3. The alignment of the TopAppBar title cannot be changed from "left" to "center" or "right",
    #1700

Here is a video of the first two issues, using the "examples\appbar.py" test program:
https://github.com/user-attachments/assets/1a8da5d3-7e5f-4097-9dc2-4198f86b397e
<br></br>

### Describe the cause of the issue

#### 1. Hover Behaviour
The hover behaviour of the trailing container is being blocked by the `title_box` widget, which in "_small_" mode is positioned in front of the right-half of the app bar. The hover detection sees that the items are being covered, so it does not activate. Here is an image of the `title_box` widget highlighted using the Kivy Inspector tool:
![image](https://github.com/user-attachments/assets/b3f2c0b3-f91d-4a62-bdc0-cf206ecfd963)


#### 2. Incorrect Positioning, 3. Title Alignment
The positioning of the trailing items container is controlled by changing the padding of the title text. For example, if the window size in increased, the right padding of the title would also need to be increased. While this implementation might be able to work, it is prone to errors, does not allow the title alignment to be changed, and does not work if there is no title. For example, currently while resizing the window, the padding is not being updated correctly and is set to 0, meaning the trailing items move to the left:
![image](https://github.com/user-attachments/assets/ccd1015f-75ca-4d6c-817c-6bf65e395dd1)

<br></br>

### Reproducing the problem
This code is taken from "examples\appbar.py", modified to show the "small", "medium" and "large" Top App Bar types:
```python
from kivy.lang import Builder

from kivymd.app import MDApp

from examples.common_app import CommonApp

KV = """
MDScreen:
    md_bg_color: self.theme_cls.secondaryContainerColor

    MDIconButton:
        on_release: app.open_menu(self)
        pos_hint: {"top": .98}
        x: "12dp"
        icon: "menu"

    MDBoxLayout:
        orientation: "vertical"
        adaptive_height: True
        size_hint_x: .8
        spacing: "12dp"
        pos_hint: {"center_x": .5, "center_y": .5}

        MDTopAppBar:
            id: appbar
            type: "small"
    
            MDTopAppBarLeadingButtonContainer:
    
                MDActionTopAppBarButton:
                    icon: "arrow-left"
    
            MDTopAppBarTitle:
                text: "AppBar small"
    
            MDTopAppBarTrailingButtonContainer:
    
                MDActionTopAppBarButton:
                    icon: "attachment"
    
                MDActionTopAppBarButton:
                    icon: "calendar"
    
                MDActionTopAppBarButton:
                    icon: "dots-vertical"

        MDTopAppBar:
            id: appbar
            type: "medium"
    
            MDTopAppBarLeadingButtonContainer:
    
                MDActionTopAppBarButton:
                    icon: "arrow-left"
    
            MDTopAppBarTitle:
                text: "AppBar small"
    
            MDTopAppBarTrailingButtonContainer:
    
                MDActionTopAppBarButton:
                    icon: "attachment"
    
                MDActionTopAppBarButton:
                    icon: "calendar"
    
                MDActionTopAppBarButton:
                    icon: "dots-vertical"
        
        MDTopAppBar:
            id: appbar
            type: "large"
    
            MDTopAppBarLeadingButtonContainer:
    
                MDActionTopAppBarButton:
                    icon: "arrow-left"
    
            MDTopAppBarTitle:
                text: "AppBar small"
    
            MDTopAppBarTrailingButtonContainer:
    
                MDActionTopAppBarButton:
                    icon: "attachment"
    
                MDActionTopAppBarButton:
                    icon: "calendar"
    
                MDActionTopAppBarButton:
                    icon: "dots-vertical"
"""


class Example(MDApp, CommonApp):
    def build(self):
        return Builder.load_string(KV)

    def disabled_widgets(self):
        self.root.ids.appbar.disabled = not self.root.ids.appbar.disabled
        self.root.ids.appbar_custom.disabled = self.root.ids.appbar.disabled


Example().run()

"""


class Example(MDApp, CommonApp):
    def build(self):
        return Builder.load_string(KV)

    def disabled_widgets(self):
        self.root.ids.appbar.disabled = not self.root.ids.appbar.disabled
        self.root.ids.appbar_custom.disabled = self.root.ids.appbar.disabled


Example().run()

```
<br></br>


### Description of Changes
#### 1. Hover Behaviour
The solution is to reduce the `size_hint` of the `title_box` container to 0 when in "_small_" mode as it is not being used. The `title_box` widget is only used in "_medium_" and "_large_" modes:
```
BoxLayout:
    id: title_box
    padding: "16dp", 0, "16dp", 0
    size_hint:
        (0, 0) \
        if self.parent.type == "small" else \
        (1, 1)
```

#### 2. Incorrect Positioning
My solution is to remove this "padding" implementation entirely, and instead add an extra `text_box` _box layout_ widget to the `root_box` container. The TopAppBarTitle gets inserted into this new widget, while the leading and trailing item containers are always inserted to the left and right of this widget, respectively. The `text_box` uses the default Kivy Widget behaviour to fill the window, meaning the Trailing items container is always automatically pushed to the right of the screen; all without any additional Python code! This implementation works even if any of the TopAppBar "leading", "trailing" and "title" elements are missing. Here is the new `text_box` widget highlighted using Kivy Inspector:
![image](https://github.com/user-attachments/assets/1391d836-147e-4a0a-89e2-f77194fd3aa4)


#### 3. Title Alignment
With the new `text_box` widget, the title area now fills the full width between the leading and trailing containers. This means the "_halign_" property of MDTopAppBarTitle can be used to change the position of the text, as is standard expected behaviour for Kivy label alignment. Here is an image of the three title alignments:
![image](https://github.com/user-attachments/assets/3e5e142e-30e1-4fae-85f7-0403c49c9651)

Example code:
```
MDTopAppBarTitle:
    text: "AppBar small"
    halign: "center"
```
<br></br>


### Code for testing new changes
Same code as above in the "Reproducing the problem" section.
