### PR TITLE
Fix AttributeError on segmented button created in declarative python

### DIFF
--- a/kivymd/uix/segmentedbutton/segmentedbutton.kv
+++ b/kivymd/uix/segmentedbutton/segmentedbutton.kv
@@ -52,13 +52,15 @@
         "12dp", \
         0, \
         0 \
-        if self.parent.parent.ids.container.parent._label else \
+        if self.parent and self.parent.parent and \
+        self.parent.parent.ids.container.parent._label else \
         "12dp", \
         0
     icon_color:
         ( \
         self.theme_cls.onSecondaryContainerColor \
-        if self.parent.parent.ids.container.parent.active else \
+        if self.parent and self.parent.parent and \
+        self.parent.parent.ids.container.parent.active else \
         self.theme_cls.onSurfaceColor \
         ) \
         if self.theme_icon_color == "Primary" else self.icon_color


### PR DESCRIPTION
### Description of the problem

See #1735

### Describe the algorithm of actions that leads to the problem

In segmentedbutton.kv, some code tries to access a MDSegmentedButtonIcon object parent's parent object without first checking if the MDSegmentedButtonIcon object actually has a parent's parent

### Reproducing the problem

See #1735

### Screenshots of the problem

See #1735

### Description of Changes

In segmentedbutton.kv, we need to check if the MDSegmentButtonIcon object actually has a parent.parent before checking container's parent _label, otherwise you may get the following error: AttributeError: 'NoneType' object has no attribute 'parent'

### Screenshots of the solution to the problem

Now the example code in #1735 works:

![immagine](https://github.com/user-attachments/assets/cd0c336d-035b-4f03-ad80-01d57ca39b2d)

### Code for testing new changes

The same example code found in #1735