### PR TITLE
Added 'get_active_item' to MDNavigationBar

### DIFF
--- a/kivymd/uix/navigationbar/navigationbar.py
+++ b/kivymd/uix/navigationbar/navigationbar.py
@@ -585,6 +585,11 @@ class MDNavigationBar(CommonElevationBehavior, MDBoxLayout):
         super().__init__(*args, **kwargs)
         Clock.schedule_once(self.set_status_bar_color)
 
+    def get_active_item(self) -> MDNavigationItem | None:
+        """Returns the currently active item in the navigation bar."""
+
+        return next((child for child in self.children if child.active), None)
+
     def set_active_item(self, item: MDNavigationItem) -> None:
         """Sets the currently active element on the panel."""
 


### PR DESCRIPTION
Returns the currently active item in the navigation bar.

:return: The active :class:`~kivymd.uix.navigationbar.MDNavigationItem` instance if found, otherwise `None`.

Usage example:

```python
navigation_bar = MDNavigationBar(
        BaseMDNavigationItem(icon="gmail", text="Screen 1", active=True,),
        BaseMDNavigationItem(icon="twitter", text="Screen 2",),
        BaseMDNavigationItem(icon="linkedin", text="Screen 3",),
)
active_item = navigation_bar.get_active_item()
```


