### PR TITLE
Add Missing Navigation Bar Flags

### DIFF
--- a/kivymd/utils/set_bars_colors.py
+++ b/kivymd/utils/set_bars_colors.py
@@ -113,6 +113,7 @@ def set_bars_colors(
             if icons_color == "Dark":
                 window.getDecorView().setSystemUiVisibility(
                     View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                    | View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
                 )
             elif icons_color == "Light":
                 window.getDecorView().setSystemUiVisibility(0)


### PR DESCRIPTION
- Added a missing android UI flag to change navigation bar icons color when requested for dark icons.
- Minimum api level required is 26.

```python
set_bars_colors(
    self.theme_cls.primaryColor,  # status bar color
    self.theme_cls.primaryColor,  # navigation bar color
    "Dark",  # icons color of status and navigation bar
)
```


Earlier with icons dark only status bar icon color changes;

![Screenshot_20250423_184728_Pydroid 3.jpg](https://github.com/user-attachments/assets/280f8262-62e9-4593-9851-4f5c6243667a)

Afterwards both works fine;

![Screenshot_20250423_184959_Pydroid 3.jpg](https://github.com/user-attachments/assets/9b163cd2-0e4f-4243-ba3e-86a5a3836206)

