### PR TITLE
Fix documentation link in PYPI installation since it's pointing to an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ may be offered to you without asking too.
 ## Installation
 
 ```bash
-pip install kivymd==2.0.0
+pip install kivymd2
 ```
 
 ### Dependencies:
@@ -57,7 +57,7 @@ pip install kivymd==2.0.0
 ### How to install
 
 Command [above](#installation) will install latest release version of KivyMD from 
-[PyPI](https://pypi.org/project/kivymd).
+[PyPI](https://pypi.org/project/kivymd2/).
 
 If you want to install development version from 
 [master](https://github.com/kivymd/KivyMD/tree/master/)


### PR DESCRIPTION
… old version: kivymd 1.2.0 instead of kivymd2.

I'm a newbie and I just want to explore creating apps using the language and the framework. Apologies if I actually don't know much about forking yet. Thank you.



### Description of the problem
Older version of the package was linked on the docs and PYPI has a different package reference for the latest version

### Describe the algorithm of actions that leads to the problem

I tried installing using pip install and "kivymd=2.0.0" was not available.

### Reproducing the problem

```bash
pip install kivymd==2.0.0
```

### Screenshots of the problem
![image](https://github.com/user-attachments/assets/0fea2677-b79a-4572-a656-6be9911d2a1f)

### Description of Changes
Tried installing the package following the instructions and the console said there was no matching version. Latest was 1.2.0 so I went along with it. Only kivymd1.2.0 was installed on my machine so, I tried working on with that and had issues with following docs for kivymd2.0.0. So, I tried searching PYPI for the kivymd keyword and found that there's this kivymd2 package with exactly the same docs with this github repo.

### Screenshots of the solution to the problem

![image](https://github.com/user-attachments/assets/51c86675-820d-42b2-b53d-026438af04cc)

### Code for testing new changes

```bash
pip install kivymd2
```
