### PR TITLE
Migrate to new datetime API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from time import time
 
@@ -33,7 +33,7 @@ def update_version_info():
 
     filename = os.path.join(os.path.dirname(__file__), "kivymd", "_version.py")
     epoch = int(os.environ.get("SOURCE_DATE_EPOCH", time()))
-    date = datetime.utcfromtimestamp(epoch).strftime("%Y-%m-%d")
+    date = datetime.fromtimestamp(epoch, timezone.utc).strftime("%Y-%m-%d")
     try:
         git_revision = (
             subprocess.check_output(["git", "rev-parse", "HEAD"])


### PR DESCRIPTION
### Description of the problem
The code uses `datetime.datetime.utcfromtimestamp()`, which is deprecated and scheduled for removal in future Python versions:
```python
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```

### Describe the algorithm of actions that leads to the problem
- The script attempts to generate a version date from a timestamp using `datetime.utcfromtimestamp()`.
- This triggers a deprecation warning in modern Python versions.

### Reproducing the problem

### Screenshots of the problem

### Description of Changes

This small PR resolves the deprecation warnings by migrating to `datetime.fromtimestamp()`.

### Screenshots of the solution to the problem

### Code for testing new changes