### PR TITLE
Fix TimePicker self.am_pm not properly setting _am_pm_selector

### DIFF
--- a/kivymd/uix/pickers/timepicker/timepicker.py
+++ b/kivymd/uix/pickers/timepicker/timepicker.py
@@ -694,26 +694,44 @@ class MDBaseTimePicker(ThemableBehavior, MotionTimePickerBehavior, BoxLayout):
             am_pm=self._set_current_time,
         )
         Clock.schedule_once(
-            lambda x: self.set_time(
-                datetime.time(hour=int(self.hour), minute=int(self.minute))
-            )
+                lambda x: self._set_time_init()
         )  # default time
+
+    def _set_time_init(self):
+        """Sets time dialog to current hour/minute/am_pm values at init"""
+
+        if int(self.hour) > 12:
+            self.am_pm = 'pm'
+            self.hour = str(int(self.hour) - 12)
+        elif int(self.hour) == 0: 
+            self.am_pm = 'am'
+            self.hour = '12'
+
+        self._set_time_input(self.hour, self.minute)
+        self._set_dial_time(self.hour, self.minute)
+        self._set_am_pm(self.am_pm)
+        self._set_current_time()
 
     def set_time(self, time_obj: datetime.time) -> None:
         """Manually set time dialog with the specified time."""
-
+         
         hour = time_obj.hour
         minute = time_obj.minute
-
-        if hour > 12:
-            hour -= 12
-            mode = "pm"
+        
+        self._set_time_input(hour, minute)
+        
+        if hour < 12:
+            mode = 'am'
         else:
-            mode = "am"
+            mode = 'pm'
+        
+        if hour == 0:
+            hour = 12
+        elif hour > 12:
+            hour -= 12
 
         hour = str(hour)
         minute = str(minute)
-        self._set_time_input(hour, minute)
         self._set_dial_time(hour, minute)
         self._set_am_pm(mode)
         self._set_current_time()


### PR DESCRIPTION
### Description of the problem

When opening the timepicker, the _am_pm_selector button always defaults to AM, even if one sets `self.am_pm = 'pm'`.

### Describe the algorithm of actions that leads to the problem

Upon the end of initialization of the timepicker, self.set_time() is run with the current self.hour and self.minute.
self.set_time() correctly assigns the am_pm selector if one gives the self.hour in 24 hour time (such as `self.hour = '14'`), but appears to break in most other situations.
For example, if one tries to set `self.hour = '9'` and `self.am_pm = 'pm'` before or after self.open(), the time will be in AM.
One could fix this by doing `self.hour = '21'`, but this is unintuitive, and the self.am_pm variable still has no impact.
Additionally, if one tries to use `self.hour = '12'` or `self.set_time(datetime.time(12, 0))`, self.set_time() will treat this as 12 AM and not 12 PM.
Further, anytime one runs `self.set_time()', the time will show in AM.

There are a few root causes for this issue.
Firstly, if one uses `self.hour = '9'` (or some other number < 13) and `self.am_pm = 'pm'`, when the time picker finishes initializing, self.set_time() is run. self.set_time() does not consider self.am_pm at all anywhere in the function, so it treats self.hour as the sole determinant of the starting setting of the am_pm selector, which is unintuitive.  It just uses the variable `mode` to determine AM vs PM.
Secondly, when one attempts to set the time to 12 PM using any method, self.set_time() checks if `hour > 12`, and since this is always not true, the else statement runs, setting `mode = "am"`.  
Thirdly, when the user uses self.set_time() to set the time, the self.hour and self.am_pm variables are initially set correctly (with self.hour set to a number not greater than 12). However, since self.set_time() runs again when the timepicker finishes initializing, it uses the self.hour variables again, and since self.hour is not greater than 12, mode is always set to "am", and self.am_pm is set back to "am".

### Reproducing the problem

```python
import kivy
from kivy.app import App
from kivy.uix.widget import Widget
from kivy.uix.floatlayout import FloatLayout
from kivymd.app import MDApp
from kivymd.uix.pickers import MDTimePickerDialVertical
import datetime

class Demo(FloatLayout):

    def __init__(self, **kwargs):
        super(Demo, self).__init__(**kwargs)
        
        time_picker = MDTimePickerDialVertical()
        time_picker.set_time(datetime.time(13, 0))
        time_picker.am_pm = 'pm'
        time_picker.open()

class DemoApp(MDApp):
    def build(self):
        return Demo()

if __name__ == '__main__':
    DemoApp().run()
```
And here is the old timepicker.py code:
```python
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.bind(
            hour=self._set_current_time,
            minute=self._set_current_time,
            am_pm=self._set_current_time,
        )
        Clock.schedule_once(
            lambda x: self.set_time(
                datetime.time(hour=int(self.hour), minute=int(self.minute))
            )
        )  # default time

    def set_time(self, time_obj: datetime.time) -> None:
        """Manually set time dialog with the specified time."""

        hour = time_obj.hour
        minute = time_obj.minute

        if hour > 12:
            hour -= 12
            mode = "pm"
        else:
            mode = "am"

        hour = str(hour)
        minute = str(minute)
        self._set_time_input(hour, minute)
        self._set_dial_time(hour, minute)
        self._set_am_pm(mode)
        self._set_current_time()
```
### Screenshots of the problem

Screenshot taken just after initialization of the demo code. Note AM is selected, when the demo code suggests PM should be suggested.
<img width="355" height="545" alt="image" src="https://github.com/user-attachments/assets/6fa05718-7a8c-4e18-ae38-b05dd0922936" />

### Description of Changes

Instead of __init__ running self.set_time(), it runs a new function, _set_time_init, which is similar to self.set_time() but does not incorrectly set `self.am_pm = 'am'`  after correcting self.hour.
self._set_time_input(hour, minute) is moved before the if statement so that the hour is properly set.
The if statement in self.set_time() is changed to have better casing so that when hour is 12, mode is set to 'pm', and hour is set to 12 if it is initially set to 0.

### Screenshots of the solution to the problem

Screenshot taken just after initialization of the demo code, using the updated timepicker.py file. Note PM is selected, which is the intended behavior.
<img width="350" height="545" alt="image" src="https://github.com/user-attachments/assets/50c919fa-7b29-42c4-899a-4365360183ca" />

### Code for testing new changes

The exact same demo code is used. Here is the new timepicker.py code:
```python
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.bind(
            hour=self._set_current_time,
            minute=self._set_current_time,
            am_pm=self._set_current_time,
        )
        Clock.schedule_once(
                lambda x: self._set_time_init()
        )  # default time

    def _set_time_init(self):
        """Sets time dialog to current hour/minute/am_pm values at init"""

        if int(self.hour) > 12:
            self.am_pm = 'pm'
            self.hour = str(int(self.hour) - 12)
        elif int(self.hour) == 0: 
            self.am_pm = 'am'
            self.hour = '12'

        self._set_time_input(self.hour, self.minute)
        self._set_dial_time(self.hour, self.minute)
        self._set_am_pm(self.am_pm)
        self._set_current_time()

    def set_time(self, time_obj: datetime.time) -> None:
        """Manually set time dialog with the specified time."""
         
        hour = time_obj.hour
        minute = time_obj.minute
        
        self._set_time_input(hour, minute)
        
        if hour < 12:
            mode = 'am'
        else:
            mode = 'pm'
        
        if hour == 0:
            hour = 12
        elif hour > 12:
            hour -= 12

        hour = str(hour)
        minute = str(minute)
        self._set_dial_time(hour, minute)
        self._set_am_pm(mode)
        self._set_current_time()

```
