### PR TITLE
Fix MDDropdownMenu.dismiss() to dispatch on_dismiss event properly

### DIFF
--- a/kivymd/uix/menu/menu.py
+++ b/kivymd/uix/menu/menu.py
@@ -1797,7 +1797,7 @@ class MDDropdownMenu(MotionDropDownMenuBehavior, StencilBehavior, MDCard):
 
     def on_touch_down(self, touch):
         if not self.menu.collide_point(*touch.pos):
-            self.dispatch("on_dismiss")
+            self.dismiss()
             return True
         super().on_touch_down(touch)
         return True
@@ -1812,8 +1812,7 @@ class MDDropdownMenu(MotionDropDownMenuBehavior, StencilBehavior, MDCard):
 
     def dismiss(self, *args) -> None:
         """Closes the menu."""
-
-        self.on_dismiss()
+        self.dispatch("on_dismiss")
 
     def _remove_menu(self, *args):
         Window.remove_widget(self)


### PR DESCRIPTION
This pull request addresses the issue described in [#1817](https://github.com/kivymd/KivyMD/issues/1817#issue-3430634019), where calling `dismiss()` on `MDDropdownMenu` does not trigger the `on_dismiss` event handlers because `on_dismiss` is called directly instead of dispatched.

Changes made:
- Modified the `dismiss()` method to dispatch the `on_dismiss` event.
- Updated `on_touch_down` to call `dismiss()` instead of dispatching `on_dismiss` directly.

This ensures consistent and correct event dispatching whether the menu is dismissed by user interaction or programmatically.
