### PR TITLE
Update windowcontroller.py

### DIFF
--- a/kivymd/uix/controllers/windowcontroller.py
+++ b/kivymd/uix/controllers/windowcontroller.py
@@ -34,7 +34,10 @@ Controlling the resizing direction of the application window
 """
 
 from kivy.core.window import Window
-from kivy.core.window.window_sdl2 import WindowSDL
+try:
+    from kivy.core.window.window_sdl2 import WindowSDL
+except (ModuleNotFoundError, ImportError):
+    from kivy.core.window.window_sdl3 import WindowSDL
 from kivy.metrics import dp
 
 


### PR DESCRIPTION

### Description of the problem
Window controller imports from window_sdl2 but new changes in Kivy introduces sdl3 so maintaining compatibility to both sdl2 and sdl3 for time being is good.

### Error logs

```python
   File "C:\Users\karta\AppData\Local\Programs\Python\Python313\Lib\site-packages\kivymd\uix\controllers\windowcontroller.py", line 37, in <module>
     from kivy.core.window.window_sdl2 import WindowSDL
 ModuleNotFoundError: No module named 'kivy.core.window.window_sdl2'
```

### Description of Changes
Simple try except block.
```python
try:
    from kivy.core.window.window_sdl2 import WindowSDL
except (ModuleNotFoundError, ImportError):
    from kivy.core.window.window_sdl3 import WindowSDL
```
