### PR TITLE
MDTabsPrimary: Add `remove_widget` method to handle tab and carousel cleanup

### DIFF
--- a/kivymd/_version.py
+++ b/kivymd/_version.py
@@ -1,5 +1,5 @@
 release = False
 __version__ = "2.0.1.dev0"
-__hash__ = "f7bde69707ac708a758a02d89f14997ee468d1ee"
-__short_hash__ = "f7bde69"
-__date__ = "2024-02-27"
+__hash__ = "fd07ff627560af0b3a33d174789e5ef9f4c4fd38"
+__short_hash__ = "fd07ff6"
+__date__ = "2026-02-10"

--- a/kivymd/tests/tab/add_remove_tab.py
+++ b/kivymd/tests/tab/add_remove_tab.py
@@ -1,0 +1,122 @@
+from kivy.lang import Builder
+from kivymd.app import MDApp
+from kivymd.uix.button import MDButton, MDButtonText
+from kivymd.uix.label import MDLabel
+from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.tab import (
+    MDTabsPrimary,
+    MDTabsItem,
+    MDTabsItemText,
+    MDTabsCarousel
+)
+from kivymd.uix.appbar import MDTopAppBarTitle
+KV = '''
+MDScreen:
+    md_bg_color: self.theme_cls.backgroundColor
+
+    MDBoxLayout:
+        orientation: "vertical"
+
+        MDTopAppBar:
+            type: "small"
+            MDTopAppBarTitle:
+                text: "Tab Manager Test"
+
+        MDTabsPrimary:
+            id: tabs_manager
+            # Ensure the tabs component takes up the remaining vertical space
+            size_hint_y: 1
+
+            MDDivider:
+
+            MDTabsCarousel:
+                id: content_carousel
+
+        MDBoxLayout:
+            adaptive_height: True
+            padding: "10dp"
+            spacing: "10dp"
+            # md_bg_color: self.theme_cls.surfaceContainerColor
+
+            MDButton:
+                style: "filled"
+                on_release: app.add_custom_tab()
+                MDButtonText:
+                    text: "Add Tab"
+            
+            MDButton:
+                style: "filled"
+                on_release: app.remove_tab()
+                MDButtonText:
+                    text: "Remove Tab"
+'''
+
+
+class TabContent(MDBoxLayout):
+    """Custom content widget that knows how to remove itself."""
+
+    def __init__(self, tab_title, **kwargs):
+        super().__init__(**kwargs)
+        self.orientation = "vertical"
+        self.padding = "20dp"
+        self.spacing = "20dp"
+        # Ensure content fills the carousel slide
+        self.size_hint = (1, 1)
+
+        self.add_widget(MDLabel(
+            text=f"Content for {tab_title}",
+            halign="center",
+            theme_text_color="Primary"
+        ))
+
+        btn = MDButton(
+            MDButtonText(text="Remove this Tab"),
+            style="tonal",
+            pos_hint={"center_x": .5},
+            on_release=lambda x: self.remove_me()
+        )
+        self.add_widget(btn)
+
+    def remove_me(self):
+        app = MDApp.get_running_app()
+        app.root.ids.tabs_manager.remove_widget(self)
+
+
+class TabManagementApp(MDApp):
+    index = 0
+
+    def build(self):
+        self.theme_cls.primary_palette = "Olive"
+        self.theme_cls.theme_style = "Light"
+        return Builder.load_string(KV)
+
+    def on_start(self):
+        for i in range(2):
+            self.add_custom_tab()
+
+    def add_custom_tab(self):
+        self.index += 1
+        title = f"Tab {self.index}"
+
+        # 1. Create the Header
+        tab_header = MDTabsItem(
+            MDTabsItemText(text=title)
+        )
+
+        # 2. Create the Content
+        tab_content = TabContent(tab_title=title)
+
+        # 3. Add widgets
+        self.root.ids.tabs_manager.add_widget(tab_header)
+        self.root.ids.content_carousel.add_widget(tab_content)
+
+        # 4. Switch to the new tab
+        self.root.ids.tabs_manager.switch_tab(instance=tab_header)
+
+    def remove_tab(self):
+        tab_item = self.root.ids.content_carousel.current_slide.tab_item
+        self.root.ids.tabs_manager.remove_widget(tab_item)
+
+
+if __name__ == "__main__":
+    TabManagementApp().run()

--- a/kivymd/uix/splitter/__init__.py
+++ b/kivymd/uix/splitter/__init__.py
@@ -1,0 +1,2 @@
+# NOQA F401
+from .splitter import MDSplitter, MDSplitterStrip

--- a/kivymd/uix/splitter/splitter.kv
+++ b/kivymd/uix/splitter/splitter.kv
@@ -1,0 +1,12 @@
+#:import Factory kivy.factory.Factory
+
+<MDSplitterStrip>:
+    background_normal: ''
+    background_down: ''
+    background_color:
+        self.theme_cls.primaryColor if self.state == 'normal' else \
+        self.theme_cls.secondaryColor
+
+<MDSplitter>:
+    strip_cls: Factory.MDSplitterStrip
+    strip_size: '4dp'

--- a/kivymd/uix/splitter/splitter.py
+++ b/kivymd/uix/splitter/splitter.py
@@ -1,0 +1,36 @@
+"""
+Components/Splitter
+===================
+
+.. versionadded:: 2.0.0
+
+The MDSplitter widget is a container that allows its children to be resized
+by dragging a separator line.
+"""
+
+__all__ = ("MDSplitter", "MDSplitterStrip")
+
+import os
+
+from kivy.lang import Builder
+from kivy.uix.splitter import Splitter, SplitterStrip
+
+from kivymd import uix_path
+from kivymd.theming import ThemableBehavior
+
+with open(
+    os.path.join(uix_path, "splitter", "splitter.kv"), encoding="utf-8"
+) as kv_file:
+    Builder.load_string(kv_file.read())
+
+
+class MDSplitterStrip(ThemableBehavior, SplitterStrip):
+    """
+    A custom splitter strip for MDSplitter.
+    """
+
+
+class MDSplitter(ThemableBehavior, Splitter):
+    """
+    A material design splitter.
+    """

--- a/kivymd/uix/tab/tab.py
+++ b/kivymd/uix/tab/tab.py
@@ -1664,7 +1664,7 @@ class MDTabsPrimary(DeclarativeBehavior, ThemableBehavior, BoxLayout):
             for tab in self.ids.container.children:
                 tab.width = width / number_tabs
 
-        if self._tabs_carousel:
+        if self._tabs_carousel and self._tabs_carousel.current_slide is not None:
             Clock.schedule_once(
                 lambda x: self._tabs_carousel.current_slide.tab_item.dispatch(
                     "on_release"

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
             "pillow",
             "materialyoucolor>=2.0.7",
             "materialshapes>=0.3",
-            "asynckivy>=0.6,<0.7",
+            "asynckivy>=0.6",
         ],
         setup_requires=[],
         python_requires=">=3.7",


### PR DESCRIPTION
…abs`

### Description of the problem

Removing a widget from the tab required insight into the internal working of MDTabsPrimary.

### Description of Changes

Implemented remove_widget. This widget can receive an MDTabsItem as well as the related_content widget and will correctly remove the MDTabsItem and the related_content

### Screenshots of the solution to the problem
[Screencast_20251223_111512.webm](https://github.com/user-attachments/assets/9a49c871-74c9-4357-85f6-123c6617d1e2)

### Code for testing new changes

An app for manual testing has been added into kivymd/tests/tab/add_remove_tab.py
I do realise this should ideally be a pytest, but do not have experience how to really automate gui testing.
