### PR TITLE
Allows number verification on MDTextfield

### DIFF
--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -457,6 +457,13 @@ class Validator:
     :attr:`date_format` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `None`.
     """
+    def is_number_valid(self, text: str) -> bool:
+        """Checks the validity of a number."""
+        for i in text:
+            if not i.isdigit():
+                return True
+                break
+        return False
 
     def is_email_valid(self, text: str) -> bool:
         """Checks the validity of the email."""
@@ -1489,7 +1496,7 @@ class MDTextField(
     defaults to ''.
     """
 
-    validator = OptionProperty(None, options=["date", "email", "time", "phone"])
+    validator = OptionProperty(None, options=["date", "email", "time", "phone", "number"])
     """
     The type of text field for entering Email, time, etc.
     Automatically sets the type of the text field as "error" if the user input
@@ -2539,6 +2546,7 @@ class MDTextField(
                 "date": self.is_date_valid,
                 "email": self.is_email_valid,
                 "time": self.is_time_valid,
+                "number": self.is_number_valid,
             }[self.validator](self.text)
             return has_error
         if (


### PR DESCRIPTION

This adds number verification functionality to MDTextField. Here is a demo of the functionality:

https://github.com/user-attachments/assets/54b9e9f5-6786-4629-abb9-00a7c1720458

The code used for the demo was:

```
from kivy.lang import Builder

from kivymd.app import MDApp

KV = '''
MDScreen:
    md_bg_color: app.theme_cls.surfaceColor

    MDTextField:
        mode: "outlined"
        size_hint_x: None
        pos_hint: {"center_x": .5, "center_y": .5}
        width: "240dp"
        validator: "number"
        MDTextFieldLeadingIcon:
            icon: "numeric"
        MDTextFieldHintText:
            text: "Insert a number"

'''


class Number_validator(MDApp):
    def build(self):
        return Builder.load_string(KV)


Number_validator().run()
```

