### PR TITLE
Fix/1857 mdbutton tonal hover shadow

### DIFF
--- a/kivymd/_version.py
+++ b/kivymd/_version.py
@@ -1,5 +1,5 @@
 release = False
 __version__ = "2.0.1.dev0"
-__hash__ = "f7bde69707ac708a758a02d89f14997ee468d1ee"
-__short_hash__ = "f7bde69"
-__date__ = "2024-02-27"
+__hash__ = "1be0b27c78e332b11999e163ecd8fd9695f4c40b"
+__short_hash__ = "1be0b2"
+__date__ = "2026-07-14"

--- a/kivymd/uix/behaviors/state_layer_behavior.py
+++ b/kivymd/uix/behaviors/state_layer_behavior.py
@@ -382,7 +382,10 @@ class StateLayerBehavior(StateFocusBehavior):
                 self._bg_color = self.md_bg_color
         elif not self._state:
             if hasattr(self, "elevation_level"):
-                self.elevation_level = self._elevation_level
+                if hasattr(self, "style") and self.style == "tonal":
+                    self.elevation_level = 0
+                else:
+                    self.elevation_level = self._elevation_level
             if hasattr(self, "shadow_softness"):
                 self.shadow_softness = self._shadow_softness
             if hasattr(self, "bg_color"):


### PR DESCRIPTION
## Description of the problem

`MDButton` with `tonal` style creates a soft shadow effect when the mouse cursor hovers over the button. After moving the cursor away, the shadow remains visible and is not cleared.

This causes the button to appear as if it is still in the hover state, even though the mouse is no longer over the widget.

---

## Describe the algorithm of actions that leads to the problem

1. Run an application containing an `MDButton` with `style="tonal"`.
2. Move the mouse cursor over the button.
3. The hover animation is triggered and a soft shadow appears.
4. Move the mouse cursor away from the button.
5. The shadow remains visible instead of being removed.

---

## Reproducing the problem

```python
from kivy.lang import Builder

from kivymd.app import MDApp


KV = """
MDScreen:
    md_bg_color: app.theme_cls.onBackgroundColor

    MDButton:
        style: "tonal"
        pos_hint: {"center_x": 0.5, "center_y": 0.5}

        MDButtonText:
            text: "Tonal"
"""


class Example(MDApp):
    def build(self):
        self.theme_cls.theme_style = "Dark"
        return Builder.load_string(KV)


Example().run()
```

## Screenshots of the problem

Before fix:

1. Cursor hovering over `MDButton`.
3. Cursor moved away.
4. Shadow remains visible.

## Description of Changes

The hover shadow state handling for `MDButton` was fixed.

The button now correctly resets its visual state when the mouse leaves the widget. The temporary hover elevation/shadow effect is removed, preventing the shadow from persisting after the hover event ends.

Changes:

- Fixed cleanup of hover-related visual state.
- Ensured that `MDButton` returns to its normal appearance after leaving the hover area.
- Preserved existing hover behavior while preventing stale shadow rendering.

Fixes #1857

