### PR TITLE
fix(textfield): update hint/helper text textures on focus (#1853)

### DIFF
--- a/kivymd/uix/textfield/textfield.py
+++ b/kivymd/uix/textfield/textfield.py
@@ -2031,6 +2031,8 @@ class MDTextField(
             self.text = re.sub("\n", " ", text) if not self.multiline else text
             self.set_max_text_length()
 
+            Clock.schedule_once(lambda x: self.on_focus(self, self.focus), 0.01)
+
             if self.text and self._get_has_error() or self._get_has_error():
                 self.error = True
             elif self.text and not self._get_has_error():


### PR DESCRIPTION
## Description of the problem

When `MDTextFieldHintText` or `MDTextFieldHelperText` changes while the text field is focused, the textures don't update correctly. The hint text texture size doesn't adjust to new text content, the outline frame doesn't resize properly, and helper text updates are incomplete or don't play the intended animation.

Describe the algorithm of actions that leads to the problem
Create an `MDTextField` with `MDTextFieldHintText` and/or `MDTextFieldHelperText`

- Bind the text of these labels to the parent text field's text property (or change them dynamically)
- Type text into the field while it's focused
- Observe that the hint/helper text textures don't update their size, position, or visibility correctly
- The visual refresh logic only triggers on on_focus events, not during active typing.

## Reproducing the problem

```python
from kivy.lang import Builder
from kivymd.app import MDApp

KV = """
MDScreen:
    MDBoxLayout:
        orientation: "vertical"
        md_bg_color: app.theme_cls.surfaceColor
        padding: "56dp"
        spacing: "56dp"

        Widget:

        MDTextField:
            text: "broken field"

            MDTextFieldHintText:
                text: self.parent.text

            MDTextFieldHelperText:
                text: self.parent.text
                mode: "persistent"

        Widget:
"""

class Example(MDApp):
    def build(self):
        return Builder.load_string(KV)

Example().run()
```

The hint text texture size remains unchanged while typing, and the outline frame doesn't adjust to the text length.

## Description of Changes

Added `Clock.schedule_once(lambda x: self.on_focus(self, self.focus))` to the set_text method of `MDTextField`. This forces a complete visual refresh on the next frame when text changes, triggering all the update logic that normally runs on focus/unfocus events.

### Changes made:

- In `MDTextField.set_text()`, schedule on_focus callback after text update
- This properly updates hint text texture size and position
- Updates helper text visibility and position
- Updates outline frame for 'outlined' mode
- Updates all color transitions and animations

**Modified file**: `kivymd/uix/textfield/textfield.py`:

```python
def set_text(self, instance, text: str) -> None:
    def set_text(*args):
        ...
        
        # Force visual refresh on next frame.
        Clock.schedule_once(lambda x: self.on_focus(self, self.focus))
        
        ...
```

## Code for testing new changes

```python
from kivy.lang import Builder

from kivymd.app import MDApp

KV = """
MDScreen:
    MDBoxLayout:
        orientation: "vertical"
        md_bg_color: app.theme_cls.surfaceColor
        padding: "56dp"
        spacing: "56dp"

        Widget:

        MDTextField:
            text: "fixed field"

            MDTextFieldHintText:
                text: self.parent.text

            MDTextFieldHelperText:
                text: self.parent.text
                mode: "persistent"

        MDTextField:
            text: "outlined mode test"
            mode: "outlined"

            MDTextFieldHintText:
                text: self.parent.text

            MDTextFieldHelperText:
                text: self.parent.text
                mode: "persistent"

        MDTextField:
            text: "filled mode test"
            mode: "filled"

            MDTextFieldHintText:
                text: self.parent.text

            MDTextFieldHelperText:
                text: self.parent.text
                mode: "persistent"

        Widget:
"""

class TestApp(MDApp):
    def build(self):
        return Builder.load_string(KV)

TestApp().run()
```

## Expected behavior:

- All hint texts update their size and position correctly while typing
- Helper texts update correctly
- Outline frames adjust to text length in 'outlined' mode
- All animations play smoothly
- No manual focus toggling required

Fixes: #1853