### PR TITLE
fix(mdbottomappbar): manually for declarative `MDFabBottomAppBarButton`

### DIFF
--- a/kivymd/uix/appbar/appbar.py
+++ b/kivymd/uix/appbar/appbar.py
@@ -1289,6 +1289,7 @@ class MDBottomAppBar(
             self.button_centering_animation(widget)
         elif isinstance(widget, MDFabBottomAppBarButton):
             widget.bind(icon=self.set_fab_icon)
+            self.set_fab_icon(widget, widget.icon)
             self._fab_bottom_app_bar_button = widget
             Clock.schedule_once(self.set_fab_opacity)
             widget.scale_value_x = int(not self.animation)


### PR DESCRIPTION
## Description of the problem

`MDFabBottomAppBarButton` is not initialized correctly when using `Declarative Python Style`.

The icon property is already assigned before `widget.bind(icon=self.set_fab_icon)` is registered inside `MDBottomAppBar.add_widget()`. As a result, the initial icon change event is never dispatched, `set_fab_icon()` is never called, and the `FAB` is not properly initialized. The button remains invisible, although it still receives hover events and responds to clicks.

The same code works correctly in `KV` style because the property initialization order is different.

## Describe the algorithm of actions that leads to the problem

`. Create an `MDBottomAppBar`.
2. Add an `MDFabBottomAppBarButton` declaratively

```python
from kivymd.app import MDApp
from kivymd.uix.appbar import (
    MDBottomAppBar, MDFabBottomAppBarButton, MDActionBottomAppBarButton
)
from kivymd.uix.screen import MDScreen


class Example(MDApp):
    screen: MDScreen

    def change_actions_items(self, *args):
        self.screen.get_ids().bottom_appbar.action_items = [
            MDActionBottomAppBarButton(icon="magnify"),
            MDActionBottomAppBarButton(icon="trash-can-outline"),
            MDActionBottomAppBarButton(icon="download-box-outline"),
        ]

    def build(self):
        self.theme_cls.theme_style = "Dark"
        self.screen = (
            MDScreen(
                MDBottomAppBar(
                    MDFabBottomAppBarButton(
                        icon="plus",
                        on_release=self.change_actions_items,
                    ),
                    id="bottom_appbar",
                ),
                md_bg_color=self.theme_cls.backgroundColor,
            )
        )
        self.screen.get_ids().bottom_appbar.action_items = [
            MDActionBottomAppBarButton(icon="gmail"),
            MDActionBottomAppBarButton(icon="bookmark"),
        ]
        return self.screen


Example().run()
```

3. Run the application.
4. The `FAB` is invisible, while its hover effect and click events still work.

## Screenshots of the problem

<img width="795" height="81" alt="22" src="https://github.com/user-attachments/assets/fb0c5495-8dbf-40e5-b2e0-072f71190a21" />

## Description of Changes

Initialize the `FAB` immediately after binding the icon property.

**Modified file:** `kivymd/uix/appbar/appbar.py`:

```python
widget.bind(icon=self.set_fab_icon)
self.set_fab_icon(widget, widget.icon)
```

This ensures that the initial icon state is processed even when the icon property has already been assigned before the binding is created.

Subsequent icon changes continue to work through the existing property binding.

Fixes: #1853