### PR TITLE
fix(MDNavigationDrawerItem): selected property not updating item colo…

### DIFF
--- a/kivymd/uix/navigationdrawer/navigationdrawer.py
+++ b/kivymd/uix/navigationdrawer/navigationdrawer.py
@@ -977,6 +977,10 @@ class MDNavigationDrawerItem(
         """
 
         self.selected = not self.selected
+
+    def on_selected(self, instance, value):
+        """Fired when the :attr:`selected` value changes"""
+
         self._drawer_menu.update_items_color(self)
 
 


### PR DESCRIPTION
## Description of the problem

`MDNavigationDrawerItem.selected` does not update the visual state of the navigation drawer item when its value is changed programmatically.

The property value changes successfully, but the active/inactive indicator and item colors remain unchanged until the user manually clicks another item.

## Describe the algorithm of actions that leads to the problem

1. Create an `MDNavigationDrawer` with multiple `MDNavigationDrawerItem` widgets.
2. Set the selected property of one of the items in `Python` code.
3. Observe that the property value changes, but the item's appearance is not updated.

## Reproducing the problem

```python
from kivy.lang import Builder

from kivymd.app import MDApp


class TestApp(MDApp):
    def build(self):
        return Builder.load_string("""
MDScreen:
    md_bg_color: self.theme_cls.backgroundColor

    MDNavigationLayout:

        MDScreenManager:

            MDScreen:

                MDButton:
                    pos_hint: {"center_x": .5, "center_y": .5}
                    on_release: nav_drawer.set_state("toggle")

                    MDButtonText:
                        text: "Open Drawer"

        MDNavigationDrawer:
            id: nav_drawer
            radius: 0, dp(16), dp(16), 0

            MDNavigationDrawerMenu:

                MDNavigationDrawerLabel:
                    text: "Mail"

                MDNavigationDrawerItem:

                    MDNavigationDrawerItemLeadingIcon:
                        icon: "account"

                    MDNavigationDrawerItemText:
                        text: "Inbox"

                    MDNavigationDrawerItemTrailingText:
                        text: "24"

                MDNavigationDrawerDivider:
                
                MDNavigationDrawerItem:
                    selected: True

                    MDNavigationDrawerItemLeadingIcon:
                        icon: "account"

                    MDNavigationDrawerItemText:
                        text: "Inbox"

                    MDNavigationDrawerItemTrailingText:
                        text: "24"

                MDNavigationDrawerDivider:

""")
```

## Screenshots of the problem

<img width="912" height="744" alt="Снимок экрана — 2026-07-15 в 08 54 31" src="https://github.com/user-attachments/assets/80fa3af2-4053-4d89-ae94-08cd5e4ef81d" />

## Description of Changes

Added an `on_selected()` handler to `MDNavigationDrawerItem`.

Whenever the selected property changes, the item now requests the parent `MDNavigationDrawerMenu` to refresh the visual state by calling:

```python
self._drawer_menu.update_items_color(self)
```

This ensures that programmatic changes to selected immediately update the item's colors and active indicator, matching the behavior when the item is selected via user interaction.

Fixes: #1839