### PR TITLE
Feature/1871 android system theme

### DIFF
--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -40,7 +40,6 @@ from kivy.properties import (
     StringProperty,
 )
 from kivy.utils import get_color_from_hex, hex_colormap, rgba
-
 from materialyoucolor.dislike.dislike_analyzer import DislikeAnalyzer
 from materialyoucolor.dynamiccolor.color_spec import COLOR_NAMES
 from materialyoucolor.dynamiccolor.dynamic_scheme import DynamicScheme
@@ -506,11 +505,11 @@ class ThemeManager(EventDispatcher, DynamicColor):
     follow_system_theme = BooleanProperty(False)
     """
     Automatically follows the Android system theme.
-    
+
     When set to ``True``, the application automatically switches between
     ``"Light"`` and ``"Dark"`` theme styles when the Android system
     appearance changes. On other platforms, this property has no effect.
-    
+
     .. versionadded:: 2.0.0
 
     .. tabs::

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -27,7 +27,6 @@ from kivy import platform
 from kivy.app import App
 from kivy.core.window import Window
 from kivy.event import EventDispatcher
-from kivy.logger import Logger
 from kivy.properties import (
     AliasProperty,
     BooleanProperty,
@@ -58,10 +57,8 @@ set_dark_mode_listener = None
 if platform == "android":
     try:
         from android.darkmode import set_dark_mode_listener
-
-        Logger.info("DARKMODE: Import set_dark_mode_listener")
     except:
-        Logger.info("DARKMODE: ModuleNotFoundError")
+        pass
 
 
 class ThemeManager(EventDispatcher, DynamicColor):
@@ -903,10 +900,7 @@ class ThemeManager(EventDispatcher, DynamicColor):
     def on_follow_system_theme(self, instance, value) -> None:
         """Fired when the :attr:`follow_system_theme` value changes."""
 
-        Logger.info("DARKMODE: Call on_follow_system_theme method")
-
         if set_dark_mode_listener is None:
-            Logger.info("DARKMODE: Call on_follow_system_theme method. RETURN")
             return
 
         set_dark_mode_listener(self.switch_theme_system if value else None)
@@ -939,10 +933,6 @@ class ThemeManager(EventDispatcher, DynamicColor):
             otherwise ``False`` for light mode.
         """
 
-        Logger.info(
-            f"DARKMODE: Call switch_theme_system method. "
-            f"is_dark_mode - {is_dark_mode}"
-        )
         self.theme_style = "Dark" if is_dark_mode else "Light"
 
     def sync_theme_styles(self, *args) -> None:

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -59,9 +59,9 @@ if platform == "android":
     try:
         from android.darkmode import set_dark_mode_listener
 
-        Logger.debug("DARKMODE: Import set_dark_mode_listener")
-    except ImportError:
-        pass
+        Logger.info("DARKMODE: Import set_dark_mode_listener")
+    except:
+        Logger.info("DARKMODE: ModuleNotFoundError")
 
 
 class ThemeManager(EventDispatcher, DynamicColor):
@@ -903,10 +903,10 @@ class ThemeManager(EventDispatcher, DynamicColor):
     def on_follow_system_theme(self, instance, value) -> None:
         """Fired when the :attr:`follow_system_theme` value changes."""
 
-        Logger.debug("DARKMODE: Call on_follow_system_theme method")
+        Logger.info("DARKMODE: Call on_follow_system_theme method")
 
         if set_dark_mode_listener is None:
-            Logger.debug("DARKMODE: Call on_follow_system_theme method. RETURN")
+            Logger.info("DARKMODE: Call on_follow_system_theme method. RETURN")
             return
 
         set_dark_mode_listener(self.switch_theme_system if value else None)
@@ -939,7 +939,7 @@ class ThemeManager(EventDispatcher, DynamicColor):
             otherwise ``False`` for light mode.
         """
 
-        Logger.debug(
+        Logger.info(
             f"DARKMODE: Call switch_theme_system method. "
             f"is_dark_mode - {is_dark_mode}"
         )

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -23,7 +23,6 @@ has the :attr:`~kivymd.app.MDApp.theme_cls` attribute, with which you control
 the material properties of your application.
 """
 
-from kivy.logger import Logger
 from kivy import platform
 from kivy.app import App
 from kivy.core.window import Window
@@ -59,7 +58,8 @@ set_dark_mode_listener = None
 if platform == "android":
     try:
         from android.darkmode import set_dark_mode_listener
-        Logger.debug('DARKMODE: Import set_dark_mode_listener')
+
+        Logger.debug("DARKMODE: Import set_dark_mode_listener")
     except ImportError:
         pass
 
@@ -903,10 +903,10 @@ class ThemeManager(EventDispatcher, DynamicColor):
     def on_follow_system_theme(self, instance, value) -> None:
         """Fired when the :attr:`follow_system_theme` value changes."""
 
-        Logger.debug('DARKMODE: Call on_follow_system_theme method')
+        Logger.debug("DARKMODE: Call on_follow_system_theme method")
 
         if set_dark_mode_listener is None:
-            Logger.debug('DARKMODE: Call on_follow_system_theme method. RETURN')
+            Logger.debug("DARKMODE: Call on_follow_system_theme method. RETURN")
             return
 
         set_dark_mode_listener(self.switch_theme_system if value else None)
@@ -940,8 +940,8 @@ class ThemeManager(EventDispatcher, DynamicColor):
         """
 
         Logger.debug(
-            f'DARKMODE: Call switch_theme_system method. '
-            f'is_dark_mode - {is_dark_mode}'
+            f"DARKMODE: Call switch_theme_system method. "
+            f"is_dark_mode - {is_dark_mode}"
         )
         self.theme_style = "Dark" if is_dark_mode else "Light"
 

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -40,6 +40,7 @@ from kivy.properties import (
     StringProperty,
 )
 from kivy.utils import get_color_from_hex, hex_colormap, rgba
+
 from materialyoucolor.dislike.dislike_analyzer import DislikeAnalyzer
 from materialyoucolor.dynamiccolor.color_spec import COLOR_NAMES
 from materialyoucolor.dynamiccolor.dynamic_scheme import DynamicScheme
@@ -53,6 +54,14 @@ from materialyoucolor.utils.platform_utils import SCHEMES, get_dynamic_scheme
 from kivymd.dynamic_color import DynamicColor
 from kivymd.font_definitions import theme_font_styles
 from kivymd.material_resources import DEVICE_IOS
+
+set_dark_mode_listener = None
+
+if platform == "android":
+    try:
+        from android.darkmode import set_dark_mode_listener
+    except ImportError:
+        pass
 
 
 class ThemeManager(EventDispatcher, DynamicColor):
@@ -494,6 +503,75 @@ class ThemeManager(EventDispatcher, DynamicColor):
     and defaults to `0.2`.
     """
 
+    follow_system_theme = BooleanProperty(False)
+    """
+    Automatically follows the Android system theme.
+    
+    When set to ``True``, the application automatically switches between
+    ``"Light"`` and ``"Dark"`` theme styles when the Android system
+    appearance changes. On other platforms, this property has no effect.
+    
+    .. versionadded:: 2.0.0
+
+    .. tabs::
+
+        .. tab:: Declarative style with KV
+
+            .. code-block:: python
+
+                from kivy.lang import Builder
+
+                from kivymd.app import MDApp
+
+                KV = '''
+                MDScreen:
+                    md_bg_color: self.theme_cls.backgroundColor
+
+                    MDLabel:
+                        text: "Change the system theme on your device."
+                        pos_hint: {"center_x": .5, "center_y": .5}
+                        adaptive_size: True
+                '''
+
+
+                class Example(MDApp):
+                    def build(self):
+                        self.theme_cls.follow_system_theme = True
+                        return Builder.load_string(KV)
+
+
+                Example().run()
+
+        .. tab:: Declarative python style
+
+            .. code-block:: python
+
+                from kivymd.app import MDApp
+                from kivymd.uix.label import MDLabel
+                from kivymd.uix.screen import MDScreen
+
+
+                class Example(MDApp):
+                    def build(self):
+                        self.theme_cls.follow_system_theme = True
+                        return (
+                            MDScreen(
+                                MDLabel(
+                                    text="Change the system theme on your device.",
+                                    pos_hint={"center_x": .5, "center_y": .5},
+                                    adaptive_size=True,
+                                ),
+                                md_bg_color=self.theme_cls.backgroundColor
+                            )
+                        )
+
+
+                Example().run()
+
+    :attr:`follow_system_theme` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
+
     theme_style = OptionProperty("Light", options=["Light", "Dark"])
     """
     App theme style.
@@ -822,6 +900,14 @@ class ThemeManager(EventDispatcher, DynamicColor):
 
         self.set_colors()
 
+    def on_follow_system_theme(self, instance, value) -> None:
+        """Fired when the :attr:`follow_system_theme` value changes."""
+
+        if set_dark_mode_listener is None:
+            return
+
+        set_dark_mode_listener(self.switch_theme_system if value else None)
+
     def on_dynamic_scheme_name(self, *args) -> None:
         """Fired when the :attr:`dynamic_scheme_name` value changes."""
 
@@ -841,6 +927,16 @@ class ThemeManager(EventDispatcher, DynamicColor):
         """Switches the theme from light to dark."""
 
         self.theme_style = "Dark" if self.theme_style == "Light" else "Light"
+
+    def switch_theme_system(self, is_dark_mode: bool) -> None:
+        """
+        Updates the application theme style according to the system theme.
+
+        :param is_dark_mode: ``True`` if the system is using dark mode,
+            otherwise ``False`` for light mode.
+        """
+
+        self.theme_style = "Dark" if is_dark_mode else "Light"
 
     def sync_theme_styles(self, *args) -> None:
         # Syncs the values from self.font_styles to theme_font_styles

--- a/kivymd/theming.py
+++ b/kivymd/theming.py
@@ -23,7 +23,7 @@ has the :attr:`~kivymd.app.MDApp.theme_cls` attribute, with which you control
 the material properties of your application.
 """
 
-
+from kivy.logger import Logger
 from kivy import platform
 from kivy.app import App
 from kivy.core.window import Window
@@ -59,6 +59,7 @@ set_dark_mode_listener = None
 if platform == "android":
     try:
         from android.darkmode import set_dark_mode_listener
+        Logger.debug('DARKMODE: Import set_dark_mode_listener')
     except ImportError:
         pass
 
@@ -902,7 +903,10 @@ class ThemeManager(EventDispatcher, DynamicColor):
     def on_follow_system_theme(self, instance, value) -> None:
         """Fired when the :attr:`follow_system_theme` value changes."""
 
+        Logger.debug('DARKMODE: Call on_follow_system_theme method')
+
         if set_dark_mode_listener is None:
+            Logger.debug('DARKMODE: Call on_follow_system_theme method. RETURN')
             return
 
         set_dark_mode_listener(self.switch_theme_system if value else None)
@@ -935,6 +939,10 @@ class ThemeManager(EventDispatcher, DynamicColor):
             otherwise ``False`` for light mode.
         """
 
+        Logger.debug(
+            f'DARKMODE: Call switch_theme_system method. '
+            f'is_dark_mode - {is_dark_mode}'
+        )
         self.theme_style = "Dark" if is_dark_mode else "Light"
 
     def sync_theme_styles(self, *args) -> None:


### PR DESCRIPTION
### Description of the problem

`KivyMD` does not provide a built-in way to follow the `Android` system theme changes.

`Python-for-Android` already provides the `android.darkmode` API, but `KivyMD` has no integration with it.

### Describe the algorithm of actions that leads to the problem

1. Run a `KivyMD` app on `Android`.
2. Change system theme (Light/Dark).
3. `KivyMD` theme does not update automatically.

### Description of Changes

Added `KivyMD` integration with the existing `Python-for-Android` android.darkmode `API`.

**Implemented**:

1. `follow_system_theme` property.
2. Automatic switching of `theme_style` when `Android` system theme changes.
3. Internal `Android` dark mode listener handling.

### Code for testing new changes

```python
from kivymd.app import MDApp
from kivymd.uix.label import MDLabel
from kivymd.uix.screen import MDScreen


class Example(MDApp):
    def build(self):
        self.theme_cls.follow_system_theme = True
        return (
            MDScreen(
                MDLabel(
                    text="Change the system theme on your device.",
                    pos_hint={"center_x": .5, "center_y": .5},
                    adaptive_size=True,
                ),
                md_bg_color=self.theme_cls.backgroundColor
            )
        )


Example().run()
```
