### PR TITLE
fix(slider): Correct handle state layer centering and label positioning

### DIFF
--- a/kivymd/uix/slider/slider.kv
+++ b/kivymd/uix/slider/slider.kv
@@ -94,7 +94,7 @@
         size: self.minimum_size
         pos:
             handle_container.center_x - self.width / 2, \
-            root._value_container_y
+            handle_container.top + dp(10)
 
     # Handle container.
     BoxLayout:
@@ -134,6 +134,12 @@
 
     MDSliderHandleStateLayer:
         id: state_layer
+        size: root.state_layer_size
+        pos:
+            root.x + (root.size[0] - root.state_layer_size[0]) / 2, \
+            root.y + (root.size[1] - root.state_layer_size[1]) / 2
+        scale_value_center:
+            root.state_layer_size[0] / 2, root.state_layer_size[1] / 2
 
         canvas.before:
             Color:
@@ -145,10 +151,8 @@
                     )[:-1] + [0.38]
             SmoothRoundedRectangle:
                 radius: [root.state_layer_size[0] / 2, ]
-                size:  root.state_layer_size
-                pos:
-                    root.x - root.state_layer_size[0] / 4, \
-                    root.y - root.state_layer_size[1] / 4
+                size: root.state_layer_size
+                pos: self.pos
 
 
 <MDSliderValueContainer>
@@ -160,12 +164,15 @@
             pos: self.pos
             size: self.size
 
+        # The triangle is proportional to the size of the container.
+        Color:
+            rgba: app.theme_cls.primaryColor
         SmoothTriangle:
             points:
-                [ \
-                self.x + 18, self.y - 6, \
-                self.x + 32, self.y + 9, \
-                self.x + 5, self.y + 8 \
+                [
+                self.center_x, self.y - self.size[1] * 0.15,
+                self.center_x + self.size[0] * 0.35, self.y + self.size[1] * 0.25,
+                self.center_x - self.size[0] * 0.35, self.y + self.size[1] * 0.25,
                 ]
 
         # Label texture.
@@ -179,23 +186,8 @@
                 None
             pos:
                 ( \
-                ( \
-                # X.
-                self._slider.value_pos[0] \
-                - (self._slider._value_label.texture_size[0] / 2) + dp(10), \
-                # Y.
-                self._slider.center_y + dp(28) \
-                ) \
-                if self._slider.orientation == "horizontal" else \
-                ( \
-                # X.
-                self._slider.center_x \
-                - (self._slider._value_label.texture_size[0] / 2) - dp(2), \
-                # Y.
-                self._slider.value_pos[1] + \
-                self._slider._value_label.texture_size[1] \
-                + self._slider._handle.state_layer_size[1] / 2, \
-                ) \
+                self.center_x - self._slider._value_label.texture_size[0] / 2, \
+                self.center_y - self._slider._value_label.texture_size[1] / 2 \
                 ) \
                 if self._slider and self._slider._value_label else (0, 0)
             size:


### PR DESCRIPTION
### Description of the problem
When customizing the MDSliderHandle size, the MDSliderHandleStateLayer (the ripple/pulse effect) does not center correctly relative to the handle. Additionally, the MDSliderValueLabel position does not update dynamically based on the handle size, causing it to overlap or misalign with the handle.

### Describe the algorithm of actions that leads to the problem

1. Create an MDSlider with a custom MDSliderHandle size (e.g., size=(dp(36), dp(36))).
2. Set a larger state_layer_size (e.g., state_layer_size=(dp(46), dp(46))).
3. Observe that the state layer (pulse effect) is not centered relative to the handle.
4. Observe that the value label does not follow the handle properly when it changes size.

### Reproducing the problem

#### Example 1

```python
from kivy.metrics import dp

from kivymd.app import MDApp
from kivymd.uix.screen import MDScreen
from kivymd.uix.slider import MDSlider, MDSliderHandle, MDSliderValueLabel


class Example(MDApp):
    def build(self):
        self.theme_cls.follow_system_theme = True
        return (
            MDScreen(
                MDSlider(
                    MDSliderHandle(),
                    MDSliderValueLabel(),
                    step=10,
                    value=50,
                    pos_hint={"center_x": .5, "center_y": .5},
                ),
                md_bg_color=self.theme_cls.backgroundColor
            )
        )


Example().run()
```

<img width="792" height="162" alt="444" src="https://github.com/user-attachments/assets/7682e790-b803-4b5a-b5d2-4a6e62248ed3" />

#### Example 2

```python
from kivy.metrics import dp

from kivymd.app import MDApp
from kivymd.uix.screen import MDScreen
from kivymd.uix.slider import MDSlider, MDSliderHandle, MDSliderValueLabel


class Example(MDApp):
    def build(self):
        self.theme_cls.follow_system_theme = True
        return (
            MDScreen(
                MDSlider(
                    MDSliderHandle(
                        size=(dp(36), dp(36)),
                        state_layer_size=(dp(52), dp(52)),
                        radius=dp(18)
                    ),
                    MDSliderValueLabel(

                    ),
                    step=10,
                    value=50,
                    pos_hint={"center_x": .5, "center_y": .5},
                ),
                md_bg_color=self.theme_cls.backgroundColor
            )
        )


Example().run()
```

<img width="787" height="155" alt="Снимок экрана — 2026-07-18 в 20 04 25" src="https://github.com/user-attachments/assets/c15750e3-3155-43f4-aeec-a22681b481b5" />

### Description of Changes

1. **Fixed `MDSliderHandleStateLayer` centering:**

- Updated the positioning formula in `slider.kv` `from root.x - root.state_layer_size[0] / 4` to `root.x + (root.size[0] - root.state_layer_size[0]) / 2`
- This ensures the state layer is always centered relative to the handle regardless of handle size.

2. **Fixed `MDSliderValueLabel` positioning:**

- Changed the label position binding from `root._value_container_y` to `handle_container.top + dp(10)`
- This makes the label position dynamic and always places it above the handle.

3. Updated scale_value_center property:

- Set the scale center to `root.state_layer_size[0] / 2, root.state_layer_size[1] / 2` for proper scaling from the center.

### Screenshots of the solution to the problem

<img width="790" height="200" alt="Снимок экрана — 2026-07-18 в 19 36 10" src="https://github.com/user-attachments/assets/e149bead-6597-478e-a1eb-ad62c2f02e8b" />

<img width="790" height="200" alt="Снимок экрана — 2026-07-18 в 19 35 42" src="https://github.com/user-attachments/assets/c3c5c5ba-cb42-4e5b-bf3c-ee7eb1fd5c49" />

Fixes #1695