### PR TITLE
fix(slider): Handle zero step value in update_points

### DIFF
--- a/kivymd/uix/slider/slider.py
+++ b/kivymd/uix/slider/slider.py
@@ -288,9 +288,11 @@ class MDSlider(DeclarativeBehavior, ThemableBehavior, Slider):
             ) - self.track_active_width / 2
             slider_length = (
                 self.width if self.orientation == "horizontal" else self.height
-            ) - (self.padding * 2)
+            ) - self.padding * 2
             slider_max_value = int(self.max)
-            multiplier = slider_length / slider_max_value
+            multiplier = (
+                slider_length / slider_max_value if slider_max_value > 0 else 0
+            )
             active_track_width = (
                 (
                     self.width
@@ -300,23 +302,22 @@ class MDSlider(DeclarativeBehavior, ThemableBehavior, Slider):
                 - self.padding * 2
             ) * self.value_normalized
 
-            for i in range(0, slider_max_value + 1, step):
-                x = i * multiplier
+            step_int = max(1, int(step)) if step > 0 else 1
 
+            for i in range(0, slider_max_value + 1, step_int):
+                x = i * multiplier
                 if x < active_track_width:
                     points = self._inactive_points
                 else:
                     points = self._active_points
-
                 if self.orientation == "vertical":
                     points.append(y)
-
                 points.append(
                     (self.x if self.orientation == "horizontal" else self.y)
                     + x
                     + self.padding
                     + (
-                        (self.ids.handle_container.width / 2)
+                        self.ids.handle_container.width / 2
                         if i != self.max and i
                         else 0
                     )


### PR DESCRIPTION
### Description of the problem

When step property of `MDSlider` is set to a value less than 1, the application crashes with `ValueError: range() arg 3 must not be zero` because the step value is converted to 0 when used in `range()`.

### Describe the algorithm of actions that leads to the problem

1. Create an `MDSlider` with `step=0.5` or any value less than `1`
2. The slider tries to render step points in update_points method
3. The step is converted to integer using `int(step)` which returns 0
4. `range(0, slider_max_value + 1, 0)` raises `ValueError`

### Reproducing the problem

```python
from kivymd.app import MDApp
from kivymd.uix.screen import MDScreen
from kivymd.uix.slider import MDSlider

class Example(MDApp):
    def build(self):
        self.theme_cls.follow_system_theme = True
        return (
            MDScreen(
                MDSlider(
                    step=0.5,  # this causes crash
                    value=50,
                    pos_hint={"center_x": .5, "center_y": .5},
                ),
                md_bg_color=self.theme_cls.backgroundColor
            )
        )

Example().run()
```

### Description of Changes

Added validation in update_points method to ensure step is never zero:

```python
step_int = max(1, int(step)) if step > 0 else 1
```

This guarantees that `step_int` is always at least 1, preventing the `ValueError` when `step < 1`.

Fixes #1598