### PR TITLE
fix(MDButton): Clear hover shadow when mouse leaves filled style button

### DIFF
--- a/kivymd/uix/behaviors/state_layer_behavior.py
+++ b/kivymd/uix/behaviors/state_layer_behavior.py
@@ -382,7 +382,7 @@ class StateLayerBehavior(StateFocusBehavior):
                 self._bg_color = self.md_bg_color
         elif not self._state:
             if hasattr(self, "elevation_level"):
-                if hasattr(self, "style") and self.style == "tonal":
+                if hasattr(self, "style") and self.style in ["tonal", "filled"]:
                     self.elevation_level = 0
                 else:
                     self.elevation_level = self._elevation_level


### PR DESCRIPTION
### Description of the problem

`MDButton` with `filled` style creates a persistent shadow effect when the mouse cursor hovers over the button. After moving the cursor away, the shadow remains visible and is not cleared.

This causes the button to appear as if it is still in the hover state, even though the mouse is no longer over the widget.

### Describe the algorithm of actions that leads to the problem

1. Create an `MDButton` with `style="tonal"`
2. Move the mouse cursor over the button
3. The hover animation is triggered and a soft shadow appears
4. Move the mouse cursor away from the button
5. The shadow remains visible instead of being removed

### Reproducing the problem

```python
from kivy.lang import Builder
from kivymd.app import MDApp

KV = '''
MDScreen:
    md_bg_color: self.theme_cls.backgroundColor

    MDButton:
        style: "filled"
        pos_hint: {"center_x": .5, "center_y": .5}

        MDButtonText:
            text: "Hover me"
'''


class TestApp(MDApp):
    def build(self):
        self.theme_cls.primary_palette = "Blue"
        return Builder.load_string(KV)


TestApp().run()
```

### Screenshots of the problem

https://github.com/user-attachments/assets/35d991c3-81db-464f-9eff-eeaeb6fb903a

### Description of Changes

- Fixed by properly restoring properties when the mouse leaves the button:
- For filled and tonal styles, elevation_level is now reset to 0 when not hovered

### Code for testing new changes

```python
from kivy.lang import Builder
from kivymd.app import MDApp

KV = '''
MDScreen:
    md_bg_color: self.theme_cls.backgroundColor

    MDButton:
        style: "filled"
        pos_hint: {"center_x": .5, "center_y": .5}

        MDButtonText:
            text: "Hover me"
'''


class TestApp(MDApp):
    def build(self):
        self.theme_cls.primary_palette = "Blue"
        return Builder.load_string(KV)


TestApp().run()
```

After running, hover the button and verify the shadow clears when the mouse leaves.

Fixed #1880