### PR TITLE
fix(datatables): fix get_row_checks() to work with pagination and scr…

### DIFF
--- a/kivymd/uix/datatables/datatables.py
+++ b/kivymd/uix/datatables/datatables.py
@@ -404,6 +404,18 @@ class TableHeader(ThemableBehavior, ScrollView):
 class TableData(RecycleView):
     """Implements a list of table data."""
 
+    checked_row_indices = ListProperty()
+    """
+    Indices of rows with checked checkboxes across all pages of the table.
+
+    Unlike `current_selection_check`, this property stores a single flat
+    list of selected row indices, allowing you to retrieve all checked rows
+    regardless of the current pagination page or scroll position.
+
+    :attr:`checked_row_indices` is an :class:`~kivy.properties.ListProperty`
+    and defaults to `[]`.
+    """
+
     recycle_data = ListProperty()
     """
     See :attr:`~kivy.uix.recycleview.RecycleView.data`.
@@ -649,21 +661,28 @@ class TableData(RecycleView):
             full_pages = len(self.row_data) // self.rows_num
             left_over_rows = len(self.row_data) % self.rows_num
             new_checks = {}
+            all_indices = []
 
             for page in range(full_pages):
-                new_checks[page] = list(range(0, rows_num * columns, columns))
+                page_indices = list(range(0, rows_num * columns, columns))
+                new_checks[page] = page_indices
+                all_indices.extend(page_indices)
 
             if left_over_rows:
-                new_checks[full_pages] = list(
-                    range(0, left_over_rows * columns, columns)
-                )
+                page_indices = list(range(0, left_over_rows * columns, columns))
+                new_checks[full_pages] = page_indices
+                all_indices.extend(page_indices)
 
             self.current_selection_check = new_checks
+            self.checked_row_indices = (
+                all_indices  # updated checked_row_indices
+            )
             self._update_cell_selection_state()
 
             return
 
         self.current_selection_check = {}  # esets all checks on all pages
+        self.checked_row_indices = []
         self._update_cell_selection_state()
 
     def check_all(self, state: str) -> bool:
@@ -723,6 +742,7 @@ class TableData(RecycleView):
 
         self.set_row_data()
         self.set_text_from_of(direction)
+        self._restore_check_states()
 
         if self._to_value == len(self.row_data):
             self.pagination.ids.button_forward.disabled = True
@@ -786,33 +806,38 @@ class TableData(RecycleView):
         for i in range(0, len(lst), parts):
             yield lst[i : i + parts]
 
+    def _restore_check_states(self):
+        """Restores the state of checkboxes on the current page."""
+
+        for i in range(0, len(self.recycle_data), self.total_col_headings):
+            cell_row_obj = self.view_adapter.get_visible_view(i)
+
+            if cell_row_obj:
+                # We check whether this index is selected in
+                # `checked_row_indices`.
+                is_checked = i in self.checked_row_indices
+
+                if is_checked:
+                    cell_row_obj.change_check_state_no_notify("down")
+                else:
+                    cell_row_obj.change_check_state_no_notify("normal")
+
     def _get_row_checks(self):
         """Returns all rows that are checked."""
 
-        tmp = []
+        checked_rows = []
 
-        for i in range(0, len(self.recycle_data), self.total_col_headings):
-            if self.cell_row_obj_dict.get(i, None):
-                cell_row_obj = self.cell_row_obj_dict[i]
-            else:
-                cell_row_obj = self.view_adapter.get_visible_view(i)
-                if cell_row_obj:
-                    self.cell_row_obj_dict[i] = cell_row_obj
+        for idx in self.checked_row_indices:
+            row_data = []
 
-            if cell_row_obj and cell_row_obj.ids.check.state == "down":
-                idx = cell_row_obj.index
-                row = []
-                for data in self.recycle_data:
-                    if idx in data["range"]:
-                        row.append(data["text"])
+            for data in self.recycle_data:
+                if idx in data["range"]:
+                    row_data.append(data["text"])
 
-                tmp.append(row)
+            if row_data:
+                checked_rows.append(row_data)
 
-        return tmp
-
-    # def on_pagination(self, instance_table, instance_pagination):
-    #    if len(self._row_data_parts) <= self._to_value:
-    #        instance_pagination.ids.button_forward.disabled = True
+        return checked_rows
 
 
 class TablePagination(BoxLayout):
@@ -2063,6 +2088,13 @@ class CellRow(
         self, instance_table_data: MDDataTable, active: bool
     ) -> None:
         """Called upon activation/deactivation of the checkbox."""
+
+        if active:
+            if self.index not in self.table.checked_row_indices:
+                self.table.checked_row_indices.append(self.index)
+        else:
+            if self.index in self.table.checked_row_indices:
+                self.table.checked_row_indices.remove(self.index)
 
         if active:
             if (


### PR DESCRIPTION
### Description of the problem

`MDDataTable.get_row_checks()` returns incorrect results when the table is scrolled or when pagination is used. The method relies on visible widgets (`get_visible_view()`) instead of the actual data state, causing rows that are scrolled out of view to be excluded from the results. When scrolling back to the top, duplicate entries appear in the output.

### Describe the algorithm of actions that leads to the problem

1. Create an `MDDataTable` with checkboxes enabled and more rows than can fit on screen
2. Select multiple checkboxes across the table
3. Scroll down so some selected rows are no longer visible
4. Call `get_row_checks()` - only visible selected rows are returned (selected rows outside viewport are missing)
5. Scroll back to the top
6. Call `get_row_checks()` - duplicate entries appear for some rows

### Reproducing the problem

```python
from kivy.lang import Builder
from kivymd.app import MDApp
from kivymd.uix.datatables import MDDataTable
from kivymd.uix.screen import MDScreen
from kivymd.uix.card import MDCard

from kivymd.uix.anchorlayout import MDAnchorLayout
from kivy.metrics import dp
from kivy.properties import ObjectProperty

kv = """
<TableScreen>:
    tablebox:tablebox

    MainCard:
        TableBox:
            id: tablebox

        MDBoxLayout:
            padding: '5dp'
            adaptive_height: True

            MDIconButton:
                icon: 'send'
                on_press: self.parent.parent.parent.print_checked()

<TableBox>
    padding: '5dp'


<MainCard>
    size_hint: None, None
    size: "300dp", "500dp"
    pos_hint: {"center_x": 0.5, "center_y": 0.5}
    elevation: 3
    padding: "10dp"
    spacing: "25dp"
    orientation: 'vertical'
"""

Builder.load_string(kv)


class MainCard(MDCard):
    pass


class TableBox(MDAnchorLayout):
    table: MDDataTable

    def add_table(
        self,
        column_fields,
        table_data,
        refresh=False,
        use_pagination=True,
        use_check=True,
        rows_num=20,
    ):
        if refresh:
            self.clear_widgets()

        data_table = MDDataTable(
            use_pagination=use_pagination,
            check=use_check,
            rows_num=rows_num,
            column_data=column_fields,
            row_data=table_data,
        )

        self.table = data_table
        self.add_widget(data_table)


class TableScreen(MDScreen):
    tablebox = ObjectProperty(None)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        col_fields = ["field1", "field2"]
        col_data = [(f, dp(30)) for f in col_fields]
        table_data = [(f"col1_{i}", f"col2_{i}") for i in range(30)]
        self.tablebox.add_table(col_data, table_data)

    def print_checked(self):
        print(self.tablebox.table.get_row_checks())


class MainApp(MDApp):
    def build(self):
        return TableScreen()


if __name__ == "__main__":
    MainApp().run()
```

### Screenshots of the problem

<img width="919" height="830" alt="11" src="https://github.com/user-attachments/assets/9d79f95c-fe7f-4061-8402-e02b9fdd46b7" />
<img width="919" height="830" alt="22" src="https://github.com/user-attachments/assets/6b42fd6b-f021-46c9-9f62-5dd7d11619ac" />
<img width="1284" height="826" alt="33" src="https://github.com/user-attachments/assets/4a1d87aa-d1d6-40bb-955c-66fe83634c23" />

### Description of Changes

The root cause is that `_get_row_checks()` in `TableData` relies on `get_visible_view()` to get checkbox states, which only returns widgets currently visible on screen. This leads to:

- Selected rows outside the viewport being ignored
- Widgets being recreated when scrolling back, causing duplicates

## Changes made:

- Added checked_row_indices property to TableData - stores a flat list of all checked row indices across all pages, independent of scroll position
- Rewrote `_get_row_checks()` - now uses checked_row_indices instead of visible widgets to get checked rows
- Updated `select_check()` in `CellRow` - now updates checked_row_indices in addition to current_selection_check
- Updated `select_all()` in `TableData` - now synchronizes checked_row_indices when selecting/deselecting all rows
- Added `_restore_check_states()` in `TableData` - restores checkbox states when switching pagination pages
- Updated `set_next_row_data_parts()` - now calls `_restore_check_states()` after changing pages

### Screenshots of the solution to the problem

<img width="1470" height="886" alt="Снимок экрана — 2026-07-27 в 13 13 53" src="https://github.com/user-attachments/assets/8c2d51a5-8e41-4a3d-8349-307ca1b3dc11" />
<img width="1470" height="886" alt="Снимок экрана — 2026-07-27 в 13 14 05" src="https://github.com/user-attachments/assets/6ebc8504-1dff-479e-bac4-12ae9dca713e" />

Fixed #1442