### PR TITLE
feat(selectioncontrol): add disable_animation property to MDCheckbox  and MDSwitch

### DIFF
--- a/kivymd/uix/selectioncontrol/selectioncontrol.py
+++ b/kivymd/uix/selectioncontrol/selectioncontrol.py
@@ -685,6 +685,26 @@ class MDCheckbox(
     and defaults to `None`.
     """
 
+    disable_animation = BooleanProperty(False)
+    """
+    Disable the checkbox animation.
+
+    .. versionadded:: 2.0.0
+
+    .. code-block:: kv
+
+        MDCheckbox:
+            focus_behavior: False
+            ripple_effect: False
+            disable_animation: True
+
+    .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/checkbox-disable-animation.gif
+        :align: center
+
+    :attr:`disable_animation` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
+
     _current_color = ColorProperty([0.0, 0.0, 0.0, 0.0])
 
     __events__ = ("on_active",)
@@ -753,19 +773,25 @@ class MDCheckbox(
     def on_state(self, *args) -> None:
         """Fired when the values of :attr:`state` change."""
 
-        if self.state == "down":
-            self.check_anim_in.cancel(self)
-            self.check_anim_out.start(self)
-            self.update_icon()
-            if self.group:
-                self._release_group(self)
-            self.active = True
+        is_down = self.state == "down"
+
+        # Without animation.
+        if self.disable_animation:
+            self.scale_value_x = 1
+            self.scale_value_y = 1
+        # With animation.
         else:
             self.check_anim_in.cancel(self)
-            if not self.group:
+
+            if is_down or not self.group:
                 self.check_anim_out.start(self)
-            self.update_icon()
-            self.active = False
+
+        self.update_icon()
+
+        if is_down and self.group:
+            self._release_group(self)
+
+        self.active = is_down
 
     def on_active(self, *args) -> None:
         """Fired when the values of :attr:`active` change."""
@@ -1065,6 +1091,26 @@ class MDSwitch(
     and defaults to `None`.
     """
 
+    disable_animation = BooleanProperty(False)
+    """
+    Disable the switch animation.
+
+    .. versionadded:: 2.0.0
+
+    .. code-block:: kv
+
+        MDSwitch:
+            focus_behavior: False
+            ripple_effect: False
+            disable_animation: True
+
+    .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/switch-disable-animation.gif
+        :align: center
+
+    :attr:`disable_animation` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+    """
+
     _thumb_pos = ListProperty([0, 0])
     _line_color = ColorProperty(None)
 
@@ -1093,6 +1139,11 @@ class MDSwitch(
         if not self.disabled:
             self._line_color = value
 
+    def on_ripple_effect(self, instance, value) -> None:
+        """Fired when the values of :attr:`ripple_effect` change."""
+
+        self.ids.thumb.ripple_effect = value
+
     def on_active(self, *args) -> None:
         """Fired when the values of :attr:`active` change."""
 
@@ -1113,7 +1164,13 @@ class MDSwitch(
         elif self.icon_inactive and not active_value:
             icon = self.icon_inactive
 
-        Animation(size=size, t="out_quad", d=0.2).start(self.ids.thumb)
+        # Without animation.
+        if self.disable_animation:
+            self.ids.thumb.size = size
+        # With animation.
+        else:
+            Animation(size=size, t="out_quad", d=0.2).start(self.ids.thumb)
+
         self.set_icon(self, icon)
         self._update_thumb_pos()
 
@@ -1132,7 +1189,12 @@ class MDSwitch(
         else:
             size = (dp(24), dp(24))
 
-        Animation(size=size, t="out_quad", d=0.2).start(self.ids.thumb)
+        # Without animation.
+        if self.disable_animation:
+            self.ids.thumb.size = size
+        # With animation.
+        else:
+            Animation(size=size, t="out_quad", d=0.2).start(self.ids.thumb)
 
     def _update_thumb_pos(self, *args, animation=True):
         if self.active:
@@ -1145,11 +1207,17 @@ class MDSwitch(
                 0 if not self.icon_inactive else dp(-14),
                 self.height / 2 - dp(16),
             )
+
         Animation.cancel_all(self, "_thumb_pos")
 
-        if animation:
-            Animation(_thumb_pos=_thumb_pos, duration=0.2, t="out_quad").start(
-                self
-            )
-        else:
+        # Without animation.
+        if self.disable_animation:
             self._thumb_pos = _thumb_pos
+        # With animation.
+        else:
+            if animation:
+                Animation(
+                    _thumb_pos=_thumb_pos, duration=0.2, t="out_quad"
+                ).start(self)
+            else:
+                self._thumb_pos = _thumb_pos


### PR DESCRIPTION
## Description of the problem

`MDCheckbox` and `MDSwitch` have built-in transition animations that play when the user interacts with them:

- `MDCheckbox`: scale animation (shrinks and expands) when clicked
- `MDSwitch`: thumb movement and size animations when toggled

There is currently no way to disable these animations. This is problematic for:

- Applications requiring instant visual feedback
- Performance optimization in large lists with many selection controls
- Users who prefer or need reduced motion (accessibility)
- Scenarios where animations cause visual lag or flickering

## Describe the algorithm of actions that leads to the problem

1. Create an `MDCheckbox` or `MDSwitch`
2. Click or toggle the control
3. An animation plays:

- `MDCheckbox`: checkbox scales down to 0 then back to 1
- `MDSwitch`: thumb moves smoothly and changes size

4. There is no `API` to disable or customize these animations

## Reproducing the problem

```python
from kivy.lang import Builder

from kivymd.app import MDApp


KV = '''
MDFloatLayout:

    MDCheckbox:
        size_hint: None, None
        size: "48dp", "48dp"
        pos_hint: {'center_x': .5, 'center_y': .4}

    MDSwitch:
        pos_hint: {'center_x': .5, 'center_y': .6}
'''


class Example(MDApp):
    def build(self):
        self.theme_cls.primary_palette = "Green"
        self.theme_cls.theme_style = "Dark"
        return Builder.load_string(KV)


Example().run()
```

https://github.com/user-attachments/assets/9dadff33-0804-477b-86d9-0b88b8334d04

### Animation is always present:

- `MDCheckbox`: clicking shows a scale animation (shrinking then expanding)
- `MDSwitch`: toggling shows a smooth transition of the thumb position and size

## Description of Changes

Added disable_animation property to both `MDCheckbox` and `MDSwitch` classes.

### `MDCheckbox` changes:

- Added `disable_animation` `BooleanProperty` (default: `False`)
- Modified `on_state()` method to skip animation when `disable_animation` is `True`
- Scale value is set directly to 1 without animation

### `MDSwitch` changes:

- Added `disable_animation` `BooleanProperty` (default: `False`)
- Modified `on_active()` to skip thumb size animation
- Modified `on_thumb_down()` to skip thumb size animation on press
- Modified `_update_thumb_pos()` to skip position animation

### Behavior when `disable_animation` is `True`:

- State changes are applied instantly
- No visual transitions or animations
- Performance improves in lists with many controls

### Behavior when `disable_animation` is `False` (default):

- All animations play as before
- Full backward compatibility

## Screenshots of the solution to the problem

https://github.com/user-attachments/assets/0adf37b6-22ce-4101-b463-1c280b698212

## Code for testing new changes

```python
from kivy.lang import Builder

from kivymd.app import MDApp


KV = '''
MDFloatLayout:

    MDCheckbox:
        size_hint: None, None
        size: "48dp", "48dp"
        pos_hint: {'center_x': .5, 'center_y': .4}
        focus_behavior: False
        ripple_effect: False
        disable_animation: True

    MDSwitch:
        pos_hint: {'center_x': .5, 'center_y': .6}
        focus_behavior: False
        ripple_effect: False
        disable_animation: True
'''


class Example(MDApp):
    def build(self):
        self.theme_cls.primary_palette = "Green"
        self.theme_cls.theme_style = "Dark"
        return Builder.load_string(KV)


Example().run()
```

Fixed #1794