### PR TITLE
fix(MDNavigationRailItemIcon) unresponsive clicks on MDNavigationRail…

### DIFF
--- a/kivymd/uix/navigationrail/navigationrail.py
+++ b/kivymd/uix/navigationrail/navigationrail.py
@@ -481,14 +481,12 @@ class MDNavigationRailMenuButton(MDIconButton):
     """
 
 
-class MDNavigationRailItemIcon(RectangularRippleBehavior, MDIcon):
+class MDNavigationRailItemIcon(MDIcon):
     """
     Implements an icon for the :class:`~MDNavigationRailItem` class.
 
-    For more information, see in the
-    :class:`~kivymd.uix.behaviors.ripple_behavior.RectangularRippleBehavior` and
-    :class:`~kivymd.uix.label.label.MDIcon`
-    classes documentation.
+    For more information, see in the :class:`~kivymd.uix.label.label.MDIcon`
+    class documentation.
 
     .. versionchanged:: 2.0.0
     """
@@ -507,57 +505,6 @@ class MDNavigationRailItemIcon(RectangularRippleBehavior, MDIcon):
     _navigation_item = ObjectProperty()
     _layer_color = ColorProperty([0, 0, 0, 0])
     _selected_region_width = NumericProperty(dp(0))
-
-    def anim_complete(self, *args):
-        super().anim_complete()
-        self._navigation_rail.set_active_item(self._navigation_item)
-
-    def lay_canvas_instructions(self) -> None:
-        if not self.ripple_effect:
-            return
-
-        canvas_rectangle = self.canvas.before.get_group(
-            "navigation-rail-rounded-rectangle"
-        )[0]
-
-        with (
-            self.canvas.after
-            if self.ripple_canvas_after
-            else self.canvas.before
-        ):
-            if hasattr(self, "radius"):
-                self.radius = [
-                    canvas_rectangle.radius[0][0],
-                ]
-                self._round_rad = self.radius
-            StencilPush(group="rectangular_ripple_behavior")
-            RoundedRectangle(
-                pos=canvas_rectangle.pos,
-                size=canvas_rectangle.size,
-                radius=self._round_rad,
-                group="rectangular_ripple_behavior",
-            )
-            StencilUse(group="rectangular_ripple_behavior")
-            self.col_instruction = Color(
-                rgba=self.ripple_color, group="rectangular_ripple_behavior"
-            )
-            self.ellipse = Ellipse(
-                size=(self._ripple_rad, self._ripple_rad),
-                pos=(
-                    self.ripple_pos[0] - self._ripple_rad / 2.0,
-                    self.ripple_pos[1] - self._ripple_rad / 2.0,
-                ),
-                group="rectangular_ripple_behavior",
-            )
-            StencilUnUse(group="rectangular_ripple_behavior")
-            RoundedRectangle(
-                pos=self.pos,
-                size=self.size,
-                radius=self._round_rad,
-                group="rectangular_ripple_behavior",
-            )
-            StencilPop(group="rectangular_ripple_behavior")
-        self.bind(ripple_color=self._set_color, _ripple_rad=self._set_ellipse)
 
 
 class MDNavigationRailItemLabel(ScaleBehavior, MDLabel):


### PR DESCRIPTION
## Description of the problem

`MDNavigationRailItem` did not reliably respond to clicks when the pointer was over the item icon. While clicking outside the icon correctly triggered the on_release event, clicking directly on the icon often resulted in no response, making the widget feel unresponsive.

## Describe the algorithm of actions that leads to the problem

1. Run an application with `MDNavigationRail`.
2. Add several `MDNavigationRailItem` widgets.
3. Click directly on an item's icon.
4. Observe that the item frequently does not become active and the on_release callback is not fired.
5. Click outside the icon but still within the item bounds.
6. Observe that the item responds correctly.

## Reproducing the problem

```python
from kivy.lang import Builder
from kivy.properties import StringProperty

from kivymd.app import MDApp
from kivymd.uix.navigationrail import MDNavigationRailItem

KV = '''
<CommonNavigationRailItem>

    MDNavigationRailItemIcon:
        icon: root.icon

    MDNavigationRailItemLabel:
        text: root.text


MDBoxLayout:

    MDNavigationRail:
        type: "selected"

        MDNavigationRailMenuButton:
            icon: "menu"

        MDNavigationRailFabButton:
            icon: "home"

        CommonNavigationRailItem:
            icon: "folder-outline"
            text: "Files"

        CommonNavigationRailItem:
            icon: "bookmark-outline"
            text: "Bookmark"

        CommonNavigationRailItem:
            icon: "library-outline"
            text: "Library"

    MDScreen:
        md_bg_color: self.theme_cls.secondaryContainerColor
'''


class CommonNavigationRailItem(MDNavigationRailItem):
    text = StringProperty()
    icon = StringProperty()


class Example(MDApp):
    def build(self):
        return Builder.load_string(KV)


Example().run()
```

## Screenshots of the problem

https://github.com/user-attachments/assets/d85f8317-ec83-4135-bde5-e84a9a5390ee

## Description of Changes

Removed RectangularRippleBehavior from `MDNavigationRailItemIcon`. The icon no longer intercepts touch events, allowing `MDNavigationRailItem` to consistently receive click events across its entire area, including the icon region.

## Screenshots of the solution to the problem

https://github.com/user-attachments/assets/f1b63a81-b869-4a21-b3f8-8c1920f65a78

Fixed #1608