### PR TITLE
fix(dropdownmenu): Reset menu width calculation on each open

### DIFF
--- a/kivymd/uix/menu/menu.py
+++ b/kivymd/uix/menu/menu.py
@@ -1505,28 +1505,36 @@ class MDDropdownMenu(MotionDropDownMenuBehavior, StencilBehavior, MDCard):
         self.menu = self.ids.md_menu
         self.target_height = 0
 
+        self._initial_width = self.width
+
     def adjust_width(self) -> None:
         """
         Adjust the width of the menu if the width of the menu goes beyond
         the boundaries of the parent window from  starting point.
         """
 
+        # Use the saved initial width.
+        width = self._initial_width
+
         if self._start_coords[0] >= Window.width / 2:
-            if self.width > self._start_coords[0]:
+            if width > self._start_coords[0]:
                 self.width = (
                     self._start_coords[0]
                     - self.border_margin
                     - (
-                        (self.caller.width / 2 + self.border_margin)
+                        self.caller.width / 2 + self.border_margin
                         if self.position in ["right", "left"]
                         else 0
                     )
                 )
+            else:
+                self.width = width
+        elif Window.width - self._start_coords[0] < width:
+            self.width = (
+                Window.width - self._start_coords[0] - self.border_margin
+            )
         else:
-            if Window.width - self._start_coords[0] < self.width:
-                self.width = (
-                    Window.width - self._start_coords[0] - self.border_margin
-                )
+            self.width = width
 
     def check_ver_growth(self) -> None:
         """
@@ -1830,13 +1838,15 @@ if __name__ == "__main__":
     from kivymd.uix.screen import MDScreen
 
     class Example(MDApp):
+        menu: MDDropdownMenu
+
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
             self.screen = MDScreen(md_bg_color=self.theme_cls.backgroundColor)
-            menu_items = [{"text": f"Item {i}"} for i in range(55)]
-            self.menu = MDDropdownMenu(items=menu_items, width_mult=4)
+            self.menu_items = [{"text": f"Item {i}"} for i in range(55)]
 
         def open_menu(self, caller):
+            self.menu = MDDropdownMenu(items=self.menu_items, width_mult=4)
             self.menu.caller = caller
             self.menu.open()
 


### PR DESCRIPTION
## Description of the problem

`MDDropdownMenu` loses correct positioning on subsequent opens when `position="bottom"` is set. After the first open, the menu positions correctly, but on subsequent opens it shifts to the left side of the screen instead of staying centered below the caller widget.

## Describe the algorithm of actions that leads to the problem

1. Create `MDDropdownMenu` with `position="bottom"`
2. Open the menu for the first time - it positions correctly centered below the caller
3. Close the menu
4. Open the menu again - it appears shifted to the left edge of the screen
5. Each subsequent open keeps the wrong position

## Reproducing the problem

```python
from kivymd.app import MDApp
from kivy.lang import Builder
from kivymd.uix.menu import MDDropdownMenu
from kivy.utils import hex_colormap
from kivy.metrics import dp


KV = """
MDScreen:
    md_bg_color: self.theme_cls.backgroundColor

    MDBoxLayout:
        id: root_box
        orientation: "vertical"

        MDTopAppBar:
            id: appbar
            type: "small"
            pos_hint: {"center_x": 1.3}

            MDTopAppBarTrailingButtonContainer:

                MDActionTopAppBarButton:
                    icon: "menu"
                    #on_release: app.open_menu(self)

        ScrollView:
            MDBoxLayout:
                id: root_box
                orientation: "vertical"
                adaptive_height: True
                padding: 40
                spacing: 10

                MDButton:
                    id: button_menu
                    style: "filled"
                    radius: 6
                    theme_width: "Custom"
                    size_hint: (1, None)
                    on_release: app.button_menu(self)

                    MDButtonText:
                        #id: button_menu
                        text: "Open Menu"
                        pos_hint: {"center_x": .5, "center_y": .5}
                        font_size: '60dp'

                MDButton:
                    id: button_menu2
                    style: "filled"
                    radius: 6
                    theme_width: "Custom"
                    size_hint: (1, None)
                    on_release: app.button_menu2(self)

                    MDButtonText:
                        #id: button_menu
                        text: "Open Menu"
                        pos_hint: {"center_x": .5, "center_y": .5}
                        font_size: '60dp'

"""

from kivy.core.window import Window

Window.size = (400, 600)
Window.top = 150
Window.left = 850


class Test(MDApp):
    def build(self):
        return Builder.load_string(KV)

    def on_start(self):
        super().on_start()
        available_palettes = [
            name_color.capitalize() for name_color in hex_colormap.keys()
        ]

        menu_items = []
        for name_palette in available_palettes:
            menu_items.append(
                {
                    "text": name_palette,
                    # "on_release": lambda x=name_palette: self.switch_palette(x),
                }
            )
        self.menu_down = MDDropdownMenu(
            caller=self.root.ids.button_menu,
            items=menu_items,
            max_height=dp(600),
            position="bottom",
            ver_growth="down",
        )

        self.menu_down2 = MDDropdownMenu(
            caller=self.root.ids.button_menu2,
            items=menu_items,
            position="bottom",
            ver_growth="down",
        )

    def button_menu(self, instance_from_menu):
        self.menu_down.open()

    def button_menu2(self, instance_from_menu):
        self.menu_down2.open()


Test().run()
```

## Screenshots of the problem

https://github.com/user-attachments/assets/f92fba11-86cd-4535-a3d8-501e96dd5e0a

## Description of Changes

The problem occurs because `adjust_width()` modifies self.width on the first open, and on subsequent opens this modified value is used instead of the initial width. This causes incorrect calculations in `check_hor_growth()` which then sets hor_growth="left" incorrectly.

### Changes made:

1. Added `_initial_width` attribute stored in `__init__` to preserve the original width value
2. Modified `adjust_width()` to use `_initial_width` for calculations instead of `self.width`
3. This ensures each menu open starts with the correct base width value

## Screenshots of the solution to the problem

https://github.com/user-attachments/assets/23d822c1-c4d7-4848-9eb7-21ebc287f61e

Fixed #1586