### PR TITLE
Fix/1896 disabled text color mdlabel

### DIFF
--- a/kivymd/uix/button/button.kv
+++ b/kivymd/uix/button/button.kv
@@ -328,6 +328,7 @@
         )
     disabled_color:
         ( \
+        ( \
         { \
         "elevated": self.theme_cls.onSurfaceColor[:-1] + \
         [self.button_elevated_opacity_value_disabled_text], \
@@ -341,7 +342,10 @@
         [self.button_text_opacity_value_disabled_text], \
         }[self._button.style] \
         ) \
-        if self._button else self.theme_cls.transparentColor
+        if self._button else self.theme_cls.transparentColor \
+        ) \
+        if not self.text_color_disabled \
+        else self.text_color_disabled
 
 
 <MDButtonIcon>

--- a/kivymd/uix/fitimage/fitimage.py
+++ b/kivymd/uix/fitimage/fitimage.py
@@ -172,25 +172,25 @@ class FitImage(DeclarativeBehavior, StencilBehavior, MaterialShape, AsyncImage):
     defaults to `None`.
 
     .. tabs::
-    
+
         .. tab:: Imperative Python Styles
-    
+
             .. code-block:: python
 
                 from kivy.lang import Builder
                 from kivy.metrics import dp
-                
+
                 from kivymd.app import MDApp
                 from kivymd.uix.boxlayout import MDBoxLayout
                 from kivymd.uix.fitimage import FitImage
                 from kivymd.uix.label import MDLabel
-                
+
                 KV = '''
                 MDScreen:
                     md_bg_color: app.theme_cls.surfaceColor
-                
+
                     MDScrollView:
-                
+
                         MDGridLayout:
                             id: shape_grid
                             cols: 6
@@ -278,11 +278,11 @@ class FitImage(DeclarativeBehavior, StencilBehavior, MaterialShape, AsyncImage):
                     ExampleApp().run()
 
         .. tab:: Declarative Python Styles
-    
+
             .. code-block:: python
 
                 from kivy.metrics import dp
-                
+
                 from kivymd.app import MDApp
                 from kivymd.uix.boxlayout import MDBoxLayout
                 from kivymd.uix.fitimage import FitImage

--- a/kivymd/uix/label/label.kv
+++ b/kivymd/uix/label/label.kv
@@ -11,8 +11,12 @@
         if self.text_color else \
         self.theme_cls.onSurfaceColor
     disabled_color:
+        ( \
         app.theme_cls.onSurfaceColor[:-1] + \
-        [self.label_opacity_value_disabled_text]
+        [self.label_opacity_value_disabled_text] \
+        ) \
+        if not self.text_color_disabled \
+        else self.text_color_disabled
     font_size:
         self.theme_cls.font_styles[self.font_style][self.role]["font-size"] \
         if self.theme_font_size == "Primary" else self.font_size

--- a/kivymd/uix/label/label.py
+++ b/kivymd/uix/label/label.py
@@ -988,6 +988,16 @@ class MDLabel(
     and defaults to `None`.
     """
 
+    text_color_disabled = ColorProperty(None)
+    """
+    Label text color in (r, g, b, a) or string format.
+
+    .. versionadded:: 2.0.1
+
+    :attr:`text_color_disabled` is an :class:`~kivy.properties.ColorProperty`
+    and defaults to `None`.
+    """
+
     allow_copy = BooleanProperty(False)
     """
     Allows you to copy text to the clipboard by double-clicking on the label.


### PR DESCRIPTION
### Description of the problem

`MDButtonText` (which inherits from `MDLabel`) ignores the custom disabled text color property set on the widget. When a user passes a custom color for the disabled state (e.g., `text_color_disabled/disabled_color`), the widget falls back to the default `Material Design 3` theme disabled opacity color values instead of respecting the explicitly set color.

### Describe the algorithm of actions that leads to the problem

1. Create an `MDButtonText` widget instance inside an `MDButton`.
2. Pass a custom color to `text_color_disabled` (or `disabled_color`) and set `theme_text_color="Custom"`.
3. Set `disabled=True` on the parent `MDButton` or the `MDButtonText` widget itself.
    Observe that the text color when disabled does not change to the custom color and instead uses the default `MD3` surface color with opacity.

### Reproducing the problem

```python
from kivymd.app import MDApp
from kivymd.uix.button import MDButton, MDButtonText


class MainApp(MDApp):
    def build(self):
        return MDButton(
            MDButtonText(
                text="hello",
                text_color_disabled="yellow",
                text_color="red",
                theme_text_color="Custom",
            ),
            theme_bg_color="Custom",
            md_bg_color=[1, 0, 1, 1],
            pos_hint={"center_x": 0.5, "center_y": 0.5},
            disabled=True,
        )


if __name__ == "__main__":
    MainApp().run()
```

### Screenshots of the problem

<img width="391" height="327" alt="Снимок экрана — 2026-09-03 в 22 00 15" src="https://github.com/user-attachments/assets/74020c10-8bd9-464f-8a1d-ecaec1d89ada" />

### Description of Changes

- Updated KV-bindings for ``<MDLabel> and `<MDButtonText>` in l`abel.kv` and `button.kv`.
- Added a conditional check for `self.text_color_disabled` in the `disabled_color` property evaluation: `if self.text_color_disabled` is set, it takes priority over the default `MD3` theme-calculated disabled opacity color map.

### Code for testing new changes

```python
from kivymd.app import MDApp
from kivymd.uix.button import MDButton, MDButtonText


class MainApp(MDApp):
    def build(self):
        return MDButton(
            MDButtonText(
                text="hello",
                text_color_disabled="yellow",
                text_color="red",
                theme_text_color="Custom",
            ),
            theme_bg_color="Custom",
            md_bg_color=[1, 0, 1, 1],
            pos_hint={"center_x": 0.5, "center_y": 0.5},
            disabled=True,
        )


if __name__ == "__main__":
    MainApp().run()
```

Closes #1896