### PR TITLE
feat(menu): add scrim overlay color support for MDDropdownMenu (#1898)

### DIFF
--- a/kivymd/uix/behaviors/motion_behavior.py
+++ b/kivymd/uix/behaviors/motion_behavior.py
@@ -126,7 +126,6 @@ class MotionDropDownMenuBehavior(MotionBase):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.set_scale()
-        # self.set_opacity()
 
     def set_opacity(self) -> None:
         self._opacity = 0
@@ -136,20 +135,42 @@ class MotionDropDownMenuBehavior(MotionBase):
         self._scale_y = 0
 
     def on_dismiss(self) -> None:
+        """Fired when a menu closed."""
+
+        def remove_menu(*args):
+            Window.remove_widget(self)
+
+            if self._scrim:
+                Window.remove_widget(self._scrim)
+
+        if self._scrim:
+            Animation(alpha=0, d=self.hide_duration).start(self._scrim)
+
         anim = Animation(
             _scale_x=0,
             _scale_y=0,
-            # _opacity=0,
             duration=self.hide_duration,
             transition=self.hide_transition,
         )
-        anim.bind(on_complete=lambda *args: Window.remove_widget(self))
+        anim.bind(on_complete=remove_menu)
         anim.start(self)
 
     def on_open(self, *args):
+        """Fired when a menu opened."""
+
+        if self._scrim:
+            self._scrim.alpha = 0  # Сбрасываем в 0 перед анимацией
+            target_alpha = (
+                self.scrim_color[3]
+                if hasattr(self, "scrim_color") and len(self.scrim_color) > 3
+                else 0.5
+            )
+            Animation(alpha=target_alpha, d=self.show_duration).start(
+                self._scrim
+            )
+
         anim = Animation(
             _scale_y=1,
-            # _opacity=1,
             duration=self.show_duration,
             transition=self.show_transition,
         )

--- a/kivymd/uix/menu/menu.kv
+++ b/kivymd/uix/menu/menu.kv
@@ -1,3 +1,12 @@
+<MenuScrim>
+    canvas:
+        Color:
+            rgba: self.color[:-1] + [self.alpha]
+        Rectangle:
+            pos: self.pos
+            size: self.size
+
+
 <MDMenu>
     bar_width: 0
     key_viewclass: "viewclass"

--- a/kivymd/uix/menu/menu.py
+++ b/kivymd/uix/menu/menu.py
@@ -1065,6 +1065,7 @@ from kivy.properties import (
 )
 from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.recycleview import RecycleView
+from kivy.uix.widget import Widget
 
 from kivymd import uix_path
 from kivymd.uix.behaviors import RectangularRippleBehavior, StencilBehavior
@@ -1073,12 +1074,15 @@ from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.card import MDCard
 from kivymd.uix.label import MDLabel
 
-# from kivymd.uix.list import IRightBody
-
 with open(
     os.path.join(uix_path, "menu", "menu.kv"), encoding="utf-8"
 ) as kv_file:
     Builder.load_string(kv_file.read())
+
+
+class MenuScrim(Widget):
+    color = ColorProperty(None)
+    alpha = NumericProperty(0)
 
 
 class MDMenu(RecycleView):
@@ -1488,6 +1492,15 @@ class MDDropdownMenu(MotionDropDownMenuBehavior, StencilBehavior, MDCard):
     and defaults to `'[dp(7)]'`.
     """
 
+    scrim_color = ColorProperty([0, 0, 0, 0.5])
+    """
+    Color for scrim in (r, g, b, a) or string format.
+
+    :attr:`scrim_color` is a :class:`~kivy.properties.ColorProperty`
+    and defaults to `[0, 0, 0, 0.5]`.
+    """
+
+    _scrim = ObjectProperty()  # kivymd.uix.menu.menu.MenuScrim object
     _items = []
     _start_coords = []
     _tar_x = 0
@@ -1707,7 +1720,13 @@ class MDDropdownMenu(MotionDropDownMenuBehavior, StencilBehavior, MDCard):
         """Animate the opening of a menu window."""
 
         self.set_menu_properties()
+
+        if not self._scrim:
+            self._scrim = MenuScrim(color=self.scrim_color)
+
+        Window.add_widget(self._scrim)
         Window.add_widget(self)
+
         self.position = self.adjust_position()
 
         if self.width <= 100:


### PR DESCRIPTION
### Description of the problem

`MDDropdownMenu` lacked a scrim (overlay background) when opened, making it hard to visually isolate the menu from the background UI. Additionally, touching outside the menu did not consistently handle touch propagation or smooth dismissal with overlay transitions.

### Describe the algorithm of actions that leads to the problem

1. Open an application containing an `MDDropdownMenu`.
2. Open the menu by clicking the caller widget.
3. Observe that no dimmed overlay background appears behind the dropdown menu.

### Reproducing the problem

```python
from kivy.lang import Builder

from kivymd.app import MDApp
from kivymd.uix.menu import MDDropdownMenu

KV = """
MDScreen:

    MDButton:
        id: button
        pos_hint: {"center_x": .5, "center_y": .5}
        on_release: app.open_menu()

        MDButtonText:
            text: "Open Menu"
"""


class Example(MDApp):
    def build(self):
        return Builder.load_string(KV)

    def open_menu(self):
        menu_items = [
            {
                "text": f"Item {i}",
                "on_release": lambda x=f"Item {i}": self.menu_callback(x),
            }
            for i in range(5)
        ]
        self.menu = MDDropdownMenu(
            caller=self.root.ids.button,
            items=menu_items,
        )
        self.menu.open()

    def menu_callback(self, text_item):
        print(text_item)
        self.menu.dismiss()


Example().run()
```

### Description of Changes

- Implemented `MenuScrim` widget with full-window canvas rendering and scrim_color property support.
- Added smooth fade-in/fade-out animations for `MenuScrim` synchronized with `show_duration` and hide_duration in `MotionDropDownMenuBehavior`.
- Added touch absorption in `MenuScrim.on_touch_down` to properly dismiss the menu on outside clicks without passing touch events to underlying widgets.
- Updated `MDDropdownMenu.open()` and `on_dismiss()` to manage adding and removing _scrim to `Window`.

Closed #1898